### PR TITLE
Enhance write_deployment_info to handle upgrade

### DIFF
--- a/images/miq-app/docker-assets/appliance-initialize.sh
+++ b/images/miq-app/docker-assets/appliance-initialize.sh
@@ -30,6 +30,7 @@ case "${DEPLOYMENT_STATUS}" in
   setup_memcached
   migrate_db
   run_hook post-upgrade
+  write_deployment_info
   ;;
   new_deployment)
   echo "== Starting New Deployment =="


### PR DESCRIPTION
- write_deployment_info has been enhanced to handle PV deployment info file updates once an upgrade is successful
- write_deployment_info call added to deployment upgrade case procedure on appliance-initialize.sh

Sample simulated upgrade from darga to euwe

```
[root@manageiq-1-qw200 /]# /bin/appliance-initialize.sh
== Checking deployment status ==
== Found existing deployment configuration ==
== Restoring existing database configuration ==
== Starting Upgrade ==
== Initializing PV data backup ==
== Calling Deployment Hook ==
Hook script pre-upgrade not found, skipping
== Restoring PV data symlinks ==
/var/www/miq/vmdb/REGION symlink is already in place, skipping
/var/www/miq/vmdb/GUID symlink is already in place, skipping
/var/www/miq/vmdb/config/database.yml symlink is already in place, skipping
/var/www/miq/vmdb/certs/v2_key symlink is already in place, skipping
/var/www/miq/vmdb/log symlink is already in place, skipping
== Applying memcached config ==
== Migrating Database ==
== Calling Deployment Hook ==
Hook script post-upgrade not found, skipping

[root@manageiq-1-qw200 persistent]# cat /persistent/.deployment_info~
PV_APP_VERSION=darga
PV_SCHEMA_VERSION=20160922171248
PV_IMG_VERSION=master
PV_DEPLOYMENT_DATE=2016-10-13_15:40:34
[root@manageiq-1-qw200 persistent]# cat /persistent/.deployment_info
PV_APP_VERSION=euwe
PV_SCHEMA_VERSION=20160922171248
PV_IMG_VERSION=master
PV_DEPLOYMENT_DATE=2016-10-13_16:01:34
```