### PR TITLE
Increase miq-app deployment strategy timeout

### DIFF
--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -94,7 +94,7 @@ objects:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 300
+            initialDelaySeconds: 480
             timeoutSeconds: 3
           readinessProbe:
             httpGet:
@@ -156,6 +156,8 @@ objects:
             name: "miq-app:latest"
     strategy:
       type: "Recreate"
+      recreateParams:
+        timeoutSeconds: 1200
 - apiVersion: v1
   kind: "Service"
   metadata:


### PR DESCRIPTION
- Increased timeout to 1200 seconds on miq-app deployment strategy
- Increase liveness check timeout to 480 seconds (8mins)

This prevents issues on first time deployment where the miq-app image
is being downloaded and the default recreate strategy timeout of 600 seconds
is not long enough for a complete a successful deployment.

Tested on OCP 3.3