### PR TITLE
Remove npm updating itself

### DIFF
--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -108,7 +108,6 @@ RUN ${APPLIANCE_ROOT}/setup && \
 WORKDIR ${APP_ROOT}
 RUN source /etc/default/evm && \
     export RAILS_USE_MEMORY_STORE="true" && \
-    npm install npm -g && \
     npm install gulp bower -g && \
     gem install bundler -v ">=1.8.4" && \
     bin/setup --no-db --no-tests && \


### PR DESCRIPTION
With new npm (v3.10) in EPEL, updating itself is no longer needed
and 'npm install' no longer works after npm itself is updated

(https://github.com/ManageIQ/manageiq/pull/11849)