### PR TITLE
Update monolithic template to use upstream MIQ image and other fixes

### DIFF
--- a/templates/miq-template-monolithic.yaml
+++ b/templates/miq-template-monolithic.yaml
@@ -4,10 +4,10 @@ labels:
   template: manageiq-monolithic
 metadata:
   name: manageiq-monolithic
-  annotations: 
-    description: "ManageIQ monolithic appliance template"
-    tags: "manageiq,quickstart,miq"
-    iconClass: "icon-app-code"
+  annotations:
+    description: "ManageIQ monolithic appliance with persistent storage"
+    tags: "instant-app,manageiq,miq"
+    iconClass: "icon-rails"
 objects:
 - apiVersion: v1
   kind: Service
@@ -32,6 +32,7 @@ objects:
   metadata:
     name: ${NAME}
   spec:
+    host: ${APPLICATION_DOMAIN}
     port:
       targetPort: https
     tls:
@@ -46,7 +47,7 @@ objects:
     annotations:
       description: "Keeps track of changes in the ManageIQ image"
   spec:
-    dockerImageRepository: docker.io/fbladilo/miq-app
+    dockerImageRepository: docker.io/manageiq/manageiq
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
@@ -56,7 +57,7 @@ objects:
       - ReadWriteOnce
     resources:
       requests:
-         storage: 2Gi
+         storage: ${DATABASE_VOLUME_CAPACITY}
 - apiVersion: v1
   kind: "DeploymentConfig"
   metadata:
@@ -75,14 +76,14 @@ objects:
           persistentVolumeClaim:
             claimName: miq-pgdb-claim
         containers:
-        - image: fbladilo/miq-app:monolithic
+        - image: manageiq/manageiq:latest
           imagePullPolicy: IfNotPresent
           name: manageiq
           livenessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 300
+            initialDelaySeconds: 480
             timeoutSeconds: 3
           ports:
           - containerPort: 80
@@ -100,7 +101,6 @@ objects:
               port: 80
             initialDelaySeconds: 200
             timeoutSeconds: 3
-            failureThreshold: 5
     replicas: 1
     selector:
       name: ${NAME}
@@ -108,19 +108,31 @@ objects:
       - type: "ConfigChange"
       - type: "ImageChange"
         imageChangeParams:
-          automatic: true
+          automatic: false
           containerNames:
             - "manageiq"
           from:
             kind: "ImageStreamTag"
-            name: "manageiq:monolithic"
+            name: "manageiq:latest"
     strategy:
-      type: Rolling
-      rollingParams:
-         timeoutSeconds: 960
+      type: "Recreate"
+      recreateParams:
+         timeoutSeconds: 1200
 parameters:
-- description: The name assigned to all of the frontend objects defined in this template.
-  displayName: Name
-  name: NAME
-  required: true
-  value: manageiq
+  -
+    name: "NAME"
+    displayName: "Name"
+    required: true
+    description: "The name assigned to all of the frontend objects defined in this template."
+    value: manageiq
+  -
+    name: "APPLICATION_DOMAIN"
+    displayName: "Application Hostname"
+    description: "The exposed hostname that will route to the application service, if left blank a value will be defaulted."
+    value: ""
+  -
+    name: "DATABASE_VOLUME_CAPACITY"
+    displayName: "Database Volume Capacity"
+    required: true
+    description: "Volume space available for database."
+    value: "1Gi"


### PR DESCRIPTION
- Updated template metadata and tags
- Modified image stream source to track upstream MIQ image
- Added DATABASE_VOLUME_CAPACITY parameter to template
- Relaxed strategy and liveness checks timeouts
- Switched to Recreate strategy
- Added APPLICATION_DOMAIN parameter to template