### PR TITLE
Add check_db_status function to container-deploy-common

### DIFF
--- a/images/miq-app/docker-assets/appliance-initialize.sh
+++ b/images/miq-app/docker-assets/appliance-initialize.sh
@@ -11,6 +11,9 @@ sleep "${APPLICATION_INIT_DELAY}"
 # Prepare initialization environment
 prepare_init_env
 
+# Check DB readiness
+check_db_status
+
 # Check deployment status
 check_deployment_status
 

--- a/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
+++ b/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
@@ -70,6 +70,22 @@ fi
 
 }
 
+function check_db_status() {
+# Check if database pod is accepting connections
+
+echo "== Checking DB status =="
+
+PG_ISREADY="$(which pg_isready)"
+
+[[ ! -x ${PG_ISREADY} ]] && echo "ERROR: Could not find pg_isready executable, aborting.." && exit 1
+
+while true; do
+  ${PG_ISREADY} -h ${DATABASE_SERVICE_NAME} && break
+  sleep 5
+done
+
+}
+
 function check_version_gt() { 
 # Check if upgrade version is actually greater than stored PV version
 # -V sorts alphanumeric versions within text, will always return oldest version first


### PR DESCRIPTION
- Added check_db_status to ensure readiness of postgresql POD before trying to initialize
- Function uses PG provided pg_isready to perform connectivity tests
- Database hostname is supplied by OpenShift template parameters