### PR TITLE
Add svc dependency annotations

### DIFF
--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -14,6 +14,7 @@ objects:
   metadata:
     annotations:
       description: "Exposes and load balances ManageIQ pods"
+      service.alpha.openshift.io/dependencies: '[{"name":"${DATABASE_SERVICE_NAME}","namespace":"","kind":"Service"},{"name":"${MEMCACHED_SERVICE_NAME}","namespace":"","kind":"Service"}]'
     name: ${NAME}
   spec:
     ports:


### PR DESCRIPTION
- Add svc dependency annotations, allows automatic grouping of services and deps on web console
- Suggestion by Openshift team