### PR TITLE
Relax PG pod deployment config probes initialdelay

### DIFF
--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -314,7 +314,7 @@ objects:
                 containerPort: 5432
             readinessProbe:
               timeoutSeconds: 1
-              initialDelaySeconds: 5
+              initialDelaySeconds: 15
               exec:
                 command:
                   - "/bin/sh"
@@ -323,7 +323,7 @@ objects:
                   - "psql -h 127.0.0.1 -U ${POSTGRESQL_USER} -q -d ${POSTGRESQL_DATABASE} -c 'SELECT 1'"
             livenessProbe:
               timeoutSeconds: 1
-              initialDelaySeconds: 30
+              initialDelaySeconds: 60
               tcpSocket:
                 port: 5432
             volumeMounts:


### PR DESCRIPTION
- The PG dc initialdelay is too aggressive for certain OCP cluster hardware configurations
- Set 15 seconds for initialdelay on readiness and 1 minute for liveness