### PR TITLE
Add minimum memory request to miq-app pod

### DIFF
--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -142,6 +142,9 @@ objects:
             -
               name: "POSTGRESQL_SHARED_BUFFERS"
               value: "${POSTGRESQL_SHARED_BUFFERS}"
+          resources:
+            requests:
+              memory: "${MEMORY_APPLICATION_MIN}"
           lifecycle:
             preStop:
               exec:
@@ -418,6 +421,12 @@ parameters:
     displayName: "PostgreSQL Shared Buffer Amount"
     description: "Amount of memory dedicated for PostgreSQL shared memory buffers."
     value: "64MB"
+  -
+    name: "MEMORY_APPLICATION_MIN"
+    displayName: "Application Memory Minimum"
+    required: true
+    description: "Minimum amount of memory the Application container will need."
+    value: "4096Mi"
   -
     name: "MEMORY_POSTGRESQL_LIMIT"
     displayName: "PostgreSQL Memory Limit"


### PR DESCRIPTION
- Hint OpenShift via resource request about our minimum memory needed to run the miq-app container
- 4Gi is the default requested mem, it should be good enough for an initial deployment
- Min memory is customizable via the MEMORY_APPLICATION_MIN parameter