### PR TITLE
Ensure DB v2_key is always restored on upgrade/redeploy

### DIFF
--- a/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
+++ b/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
@@ -41,6 +41,7 @@ if [[ -f ${APP_ROOT_PERSISTENT_VMDB}/config/database.yml && -f ${PV_DEPLOY_INFO_
   echo "== Found existing deployment configuration =="
   echo "== Restoring existing database configuration =="
   ln --backup -sn ${APP_ROOT_PERSISTENT_VMDB}/config/database.yml ${APP_ROOT}/config/database.yml
+  [[ ! -f ${APP_ROOT_PERSISTENT_VMDB}/certs/v2_key ]] && echo "ERROR: Could not find ${APP_ROOT_PERSISTENT_VMDB}/certs/v2_key on upgrade/redeploy case, aborting.." && exit 1
   ln --backup -sn ${APP_ROOT_PERSISTENT_VMDB}/certs/v2_key ${APP_ROOT}/certs/v2_key
   # Source original deployment info variables from PV
   source ${PV_DEPLOY_INFO_FILE}

--- a/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
+++ b/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
@@ -41,6 +41,7 @@ if [[ -f ${APP_ROOT_PERSISTENT_VMDB}/config/database.yml && -f ${PV_DEPLOY_INFO_
   echo "== Found existing deployment configuration =="
   echo "== Restoring existing database configuration =="
   ln --backup -sn ${APP_ROOT_PERSISTENT_VMDB}/config/database.yml ${APP_ROOT}/config/database.yml
+  ln --backup -sn ${APP_ROOT_PERSISTENT_VMDB}/certs/v2_key ${APP_ROOT}/certs/v2_key
   # Source original deployment info variables from PV
   source ${PV_DEPLOY_INFO_FILE}
   # Obtain current running environment


### PR DESCRIPTION
- Do not rely on v2_key present on image, always restore v2_key from persistent volume on redeploy/upgrade.