### PR TITLE
Do not copy dev v2_key during image build

### DIFF
--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -103,6 +103,7 @@ RUN ${APPLIANCE_ROOT}/setup && \
     mkdir -p ${CONTAINER_SCRIPTS_ROOT} && \
     mv /etc/httpd/conf.d/ssl.conf{,.orig} && \
     echo "# This file intentionally left blank. ManageIQ maintains its own SSL configuration" > /etc/httpd/conf.d/ssl.conf && \
+    cp ${APP_ROOT}/config/cable.yml.sample ${APP_ROOT}/config/cable.yml && \
     echo "export APP_ROOT=${APP_ROOT}" >> /etc/default/evm && \
     echo "export CONTAINER=true" >> /etc/default/evm
 
@@ -111,8 +112,10 @@ WORKDIR ${APP_ROOT}
 RUN source /etc/default/evm && \
     export RAILS_USE_MEMORY_STORE="true" && \
     npm install gulp bower yarn -g && \
-    gem install bundler -v ">=1.8.4" && \
-    bin/setup --no-db --no-tests && \
+    gem install bundler --conservative && \
+    bower install --allow-root -F --silent --config.analytics=false && \
+    bundle install && \
+    bin/rails log:clear tmp:clear && \
     rake evm:compile_assets && \
     rake evm:compile_sti_loader && \
     # Cleanup install artifacts

--- a/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
+++ b/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
@@ -182,7 +182,7 @@ function init_appliance() {
 # Execute appliance_console to initialize appliance
 
 echo "== Initializing Appliance =="
-appliance_console_cli --region ${DATABASE_REGION} --hostname ${DATABASE_SERVICE_NAME} --username ${POSTGRESQL_USER} --password ${POSTGRESQL_PASSWORD}
+appliance_console_cli --region ${DATABASE_REGION} --hostname ${DATABASE_SERVICE_NAME} --username ${POSTGRESQL_USER} --password ${POSTGRESQL_PASSWORD} --key
 
 [ "$?" -ne "0" ] && echo "ERROR: Failed to initialize appliance, please check journal or appliance_console logs at ${APP_ROOT}/log/appliance_console.log" && exit 1
 


### PR DESCRIPTION
- Removed bin/setup call on Dockerfile
- Modified appliance_console_cli to create a valid key during initialization