### PR TITLE
Update the repo location for MIQ pglogical and repmgr packages

### DIFF
--- a/images/miq-postgresql/9.5/Dockerfile
+++ b/images/miq-postgresql/9.5/Dockerfile
@@ -7,14 +7,11 @@ MAINTAINER ManageIQ https://github.com/ManageIQ/manageiq-appliance-build
 # Switch USER to root to add required repo and packages
 USER root
 
-# Fetch pglogical and repmgr repos for MIQ use
-RUN  curl -sSLko /etc/yum.repos.d/ncarboni-pglogical-SCL-epel-7.repo \
-     https://copr.fedorainfracloud.org/coprs/ncarboni/pglogical-SCL/repo/epel-7/ncarboni-pglogical-SCL-epel-7.repo
-RUN  curl -sSLko /etc/yum.repos.d/manageiq-ManageIQ-epel-7.repo \
-     https://copr.fedorainfracloud.org/coprs/manageiq/ManageIQ/repo/epel-7/manageiq-ManageIQ-epel-7.repo
-
-RUN yum -y --setopt=tsflags=nodocs install rh-postgresql95-postgresql-pglogical-output \
-                                           rh-postgresql95-postgresql-pglogical \
+# Fetch MIQ repo for pglogical and repmgr packages
+RUN curl -sSLko /etc/yum.repos.d/manageiq-ManageIQ-Fine-epel-7.repo \
+      https://copr.fedorainfracloud.org/coprs/manageiq/ManageIQ-Fine/repo/epel-7/manageiq-ManageIQ-Fine-epel-7.repo
+ 
+RUN yum -y --setopt=tsflags=nodocs install rh-postgresql95-postgresql-pglogical \
                                            rh-postgresql95-repmgr && \
     yum clean all
 


### PR DESCRIPTION
This repo is now versioned so that we can maintain different package versions for different MIQ versions.

This also upgrades the pglogical package to version 1.2.1

Related PRs:
https://github.com/ManageIQ/manageiq-appliance-build/pull/186
https://github.com/ManageIQ/manageiq/pull/13070

@simaishi @fbladilo please review