### PR TITLE
Scale Infra: Split server and region data in 2 PVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,27 +55,37 @@ $ oc describe scc privileged | grep Users
 Users:					system:serviceaccount:openshift-infra:build-controller,system:serviceaccount:management-infra:management-admin,system:serviceaccount:management-infra:inspector-admin,system:serviceaccount:default:router,system:serviceaccount:default:registry,system:serviceaccount:<your-namespace>:default
 ```
 
-###Make persistent volumes to host the MIQ database and application data
+###Create persistent volumes (PVs) to host the MIQ database and application data
 
-An example NFS backed volume is provided by miq-pv-example.yaml (edit to match your settings), **please skip this step you have already configured persistent storage.**
+We need at least 3 persistent volumes to store MIQ data:
 
-For NFS backed volumes, please ensure your firewall is configured to allow traffic to the appropiate NFS shares.
+* Server   (Server specific appliance data)
+* Region   (Shared region appliance data)
+* Database (PostgreSQL)
 
-_**Note:**_ Recommended permissions for the pv-app (privileged pod volume) are 775, uid/gid 0 (root)
+Example NFS volume templates are provided (edit to match your site settings), **please skip this step you have already configured persistent storage.**
+
+For NFS backed volumes, please ensure your NFS server firewall is configured to allow traffic on port 2049 (TCP) from the OpenShift cluster.
+
+_**Note:**_ Recommended permissions for the PV volumes are 775, root uid/gid owned.
 
 _**As admin:**_
 
 ```bash
-$ oc create -f miq-pv-example.yaml
-$ oc create -f miq-pv-app-example.yaml
+$ oc create -f miq-pv-db-example.yaml
+$ oc create -f miq-pv-region-example.yaml
+$ oc create -f miq-pv-server-example.yaml
 ```
-Verify pv creation
+Verify PV creation
 ```bash
 $ oc get pv
-NAME       CAPACITY   ACCESSMODES   STATUS      CLAIM     REASON    AGE
-manageiq   2Gi        RWO           Available                       24d
-postgresql 2Gi        RWO           Available                       24d
+NAME       CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS      CLAIM  REASON   AGE
+miq-pv01   2Gi        RWO           Recycle         Available                   30s
+miq-pv02   2Gi        RWO           Recycle         Available                   19s
+miq-pv03   2Gi        RWO           Recycle         Available                   14s
 ```
+
+It is strongly suggested that you validate NFS share connectivity from an OpenShift node prior attemping a deployment.
 
 ###Increase maximum number of imported images on ImageStream
 
@@ -152,15 +162,17 @@ metadata:
 
 ```bash
 $ oc volume pods --all
-pods/postgresql-1-437jg
-  pvc/miq-pgdb-claim (allocated 2GiB) as miq-pgdb-volume
-    mounted at /var/lib/pgsql/data
-  secret/default-token-2se06 as default-token-2se06
-    mounted at /var/run/secrets/kubernetes.io/serviceaccount
-pods/manageiq-1-s3bnp
-  pvc/manageiq (allocated 2GiB) as miq-app-volume
+pods/manageiq-1-of9nl
+  pvc/manageiq-server (allocated 2GiB) as miq-app-volume-server
     mounted at /persistent
-  secret/default-token-9q4ge as default-token-9q4ge
+  pvc/manageiq-region (allocated 2GiB) as miq-app-volume-region
+    mounted at /persistent-region
+  secret/default-token-nw0qi as default-token-nw0qi
+    mounted at /var/run/secrets/kubernetes.io/serviceaccount
+pods/postgresql-1-3fltn
+  pvc/manageiq-postgresql (allocated 2GiB) as miq-pgdb-volume
+    mounted at /var/lib/pgsql/data
+  secret/default-token-nw0qi as default-token-nw0qi
     mounted at /var/run/secrets/kubernetes.io/serviceaccount
 ```
 

--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -9,6 +9,7 @@ ENV TERM xterm
 ENV RUBY_GEMS_ROOT /opt/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0
 ENV APP_ROOT /var/www/miq/vmdb
 ENV APP_ROOT_PERSISTENT /persistent
+ENV APP_ROOT_PERSISTENT_REGION /persistent-region
 ENV APPLIANCE_ROOT /opt/manageiq/manageiq-appliance
 ENV SUI_ROOT /opt/manageiq/manageiq-ui-service
 ENV CONTAINER_SCRIPTS_ROOT /opt/manageiq/container-scripts
@@ -101,6 +102,7 @@ RUN ${APPLIANCE_ROOT}/setup && \
     echo "export PATH=\$PATH:/opt/rubies/ruby-2.3.1/bin" >> /etc/default/evm && \
     mkdir ${APP_ROOT}/log/apache && \
     mkdir ${APP_ROOT_PERSISTENT} && \
+    mkdir ${APP_ROOT_PERSISTENT_REGION} && \
     mkdir -p ${CONTAINER_SCRIPTS_ROOT} && \
     mv /etc/httpd/conf.d/ssl.conf{,.orig} && \
     echo "# This file intentionally left blank. ManageIQ maintains its own SSL configuration" > /etc/httpd/conf.d/ssl.conf && \

--- a/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
+++ b/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
@@ -5,17 +5,20 @@
 # This file is created by the write_deployment_info during initial deployment
 PV_DEPLOY_INFO_FILE="${APP_ROOT_PERSISTENT}/.deployment_info"
 
-# This directory is used to store application data to be persisted
+# This directory is used to store server specific data to be persisted
 PV_CONTAINER_DATA_DIR="${APP_ROOT_PERSISTENT}/container-data"
 
-# This directory is used to store container deployment data (logs,backups,etc)
+# This directory is used to store server specific container deployment data (logs,backups,etc)
 PV_CONTAINER_DEPLOY_DIR="${APP_ROOT_PERSISTENT}/container-deploy"
 
-# This directory is used to store initialization logfiles on PV
+# This directory is used to store server specific initialization logfiles on PV
 PV_LOG_DIR="${PV_CONTAINER_DEPLOY_DIR}/log"
 
-# Directory used to backup PV data before performing an upgrade
+# Directory used to backup server specific PV data before performing an upgrade
 PV_BACKUP_DIR="${PV_CONTAINER_DEPLOY_DIR}/backup"
+
+# This directory is used to store shared region application data to be persisted (database.yml, keys, etc)
+PV_CONTAINER_DATA_REGION_DIR="${APP_ROOT_PERSISTENT_REGION}/container-data"
 
 # This file is supplied by the app docker image with default files/dirs to persist on PV
 CONTAINER_DATA_PERSIST_FILE="/container.data.persist"
@@ -26,8 +29,8 @@ PV_DATA_PERSIST_FILE="${APP_ROOT_PERSISTENT}/container.data.persist"
 # Set log timestamp for running instance
 PV_LOG_TIMESTAMP="$(date +%s)"
 
-# VMDB app_root directory inside persistent volume mount
-APP_ROOT_PERSISTENT_VMDB="${PV_CONTAINER_DATA_DIR}/var/www/miq/vmdb"
+# VMDB shared REGION app_root directory on PV
+PV_REGION_VMDB="${PV_CONTAINER_DATA_REGION_DIR}/var/www/miq/vmdb"
 
 function check_deployment_status() {
 # Description
@@ -37,12 +40,12 @@ function check_deployment_status() {
 
 echo "== Checking deployment status =="
 
-if [[ -f ${APP_ROOT_PERSISTENT_VMDB}/config/database.yml && -f ${PV_DEPLOY_INFO_FILE} ]]; then
+if [[ -f ${PV_REGION_VMDB}/config/database.yml && -f ${PV_DEPLOY_INFO_FILE} ]]; then
   echo "== Found existing deployment configuration =="
   echo "== Restoring existing database configuration =="
-  ln --backup -sn ${APP_ROOT_PERSISTENT_VMDB}/config/database.yml ${APP_ROOT}/config/database.yml
-  [[ ! -f ${APP_ROOT_PERSISTENT_VMDB}/certs/v2_key ]] && echo "ERROR: Could not find ${APP_ROOT_PERSISTENT_VMDB}/certs/v2_key on upgrade/redeploy case, aborting.." && exit 1
-  ln --backup -sn ${APP_ROOT_PERSISTENT_VMDB}/certs/v2_key ${APP_ROOT}/certs/v2_key
+  ln --backup -sn ${PV_REGION_VMDB}/config/database.yml ${APP_ROOT}/config/database.yml
+  [[ ! -f ${PV_REGION_VMDB}/certs/v2_key ]] && echo "ERROR: Could not find ${PV_REGION_VMDB}/certs/v2_key on upgrade/redeploy case, aborting.." && exit 1
+  ln --backup -sn ${PV_REGION_VMDB}/certs/v2_key ${APP_ROOT}/certs/v2_key
   # Source original deployment info variables from PV
   source ${PV_DEPLOY_INFO_FILE}
   # Obtain current running environment
@@ -260,6 +263,14 @@ rsync -qavL --files-from="${PV_DATA_PERSIST_FILE}" / "${PV_CONTAINER_DATA_DIR}"
 # Catch non-zero return value and print warning
 
 [ "$?" -ne "0" ] && echo "WARNING: Some files might not have been copied please check logs at ${PV_DATA_SYNC_LOG}"
+
+# Make database.yml, DB keys and region file are available on shared PV, rsync will create directory structure
+
+[ ! -f "${PV_REGION_VMDB}/config/database.yml" ] && rsync -qavR "${APP_ROOT}/config/database.yml" "${PV_CONTAINER_DATA_REGION_DIR}"
+[ ! -f "${PV_REGION_VMDB}/certs/v2_key" ] && rsync -qavR "${APP_ROOT}/certs/v2_key" "${PV_CONTAINER_DATA_REGION_DIR}"
+[ ! -f "${PV_REGION_VMDB}/REGION" ] && rsync -qavR "${APP_ROOT}/REGION" "${PV_CONTAINER_DATA_REGION_DIR}"
+
+
 ) 2>&1 | tee "${PV_DATA_SYNC_LOG}"
 
 }
@@ -277,6 +288,12 @@ echo "== Restoring PV data symlinks =="
 # Ensure PV_DATA_PERSIST_FILE is present, it should be if prepare_init_env_data was executed
 
 [ ! -f "${PV_DATA_PERSIST_FILE}" ] && echo "ERROR: Something seems wrong, ${PV_DATA_PERSIST_FILE} was not found" && exit 1
+
+# Ensure we always restore DB config and keys from region PV before processing PV_DATA_PERSIST_FILE, sync_pv_data populates these files
+
+ln --backup -sn "${PV_REGION_VMDB}/config/database.yml" "${APP_ROOT}/config/database.yml"
+ln --backup -sn "${PV_REGION_VMDB}/certs/v2_key" "${APP_ROOT}/certs/v2_key"
+ln --backup -sn "${PV_REGION_VMDB}/REGION" "${APP_ROOT}/REGION"
 
 while read -r FILE
 do

--- a/miq-pv-db-example.yaml
+++ b/miq-pv-db-example.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: manageiq
+  name: miq-pv01
 spec:
   capacity:
     storage: 2Gi
   accessModes:
     - ReadWriteOnce
   nfs: 
-    path: /opt/nfs/volumes-app
-    server: 10.19.0.216
+    path: /exports/miq-pv01
+    server: <your-nfs-host-here>
   persistentVolumeReclaimPolicy: Recycle

--- a/miq-pv-region-example.yaml
+++ b/miq-pv-region-example.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: nfs-pv01
+  name: miq-pv02
 spec:
   capacity:
     storage: 2Gi
   accessModes:
     - ReadWriteOnce
   nfs: 
-    path: /opt/nfs/volumes
-    server: 10.19.0.216
+    path: /exports/miq-pv02
+    server: <your-nfs-host-here>
   persistentVolumeReclaimPolicy: Recycle

--- a/miq-pv-server-example.yaml
+++ b/miq-pv-server-example.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: miq-pv03
+spec:
+  capacity:
+    storage: 2Gi
+  accessModes:
+    - ReadWriteOnce
+  nfs: 
+    path: /exports/miq-pv03
+    server: <your-nfs-host-here>
+  persistentVolumeReclaimPolicy: Recycle

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -52,7 +52,7 @@ objects:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    name: ${DATABASE_SERVICE_NAME}
+    name: ${NAME}-${DATABASE_SERVICE_NAME}
   spec:
     accessModes:
       - ReadWriteOnce
@@ -62,13 +62,23 @@ objects:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    name: ${NAME}
+    name: ${NAME}-server
   spec:
     accessModes:
       - ReadWriteOnce
     resources:
       requests:
         storage: ${APPLICATION_VOLUME_CAPACITY}
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: ${NAME}-region
+  spec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: ${APPLICATION_REGION_VOLUME_CAPACITY}
 - apiVersion: v1
   kind: "DeploymentConfig"
   metadata:
@@ -84,9 +94,13 @@ objects:
       spec:
         volumes:
           -
-            name: "miq-app-volume"
+            name: "miq-app-volume-server"
             persistentVolumeClaim:
-              claimName: ${NAME}
+              claimName: ${NAME}-server
+          -
+            name: "miq-app-volume-region"
+            persistentVolumeClaim:
+              claimName: ${NAME}-region
         containers:
         - image: manageiq/manageiq-pods:${APPLICATION_IMG_TAG}
           imagePullPolicy: IfNotPresent
@@ -112,8 +126,11 @@ objects:
             privileged: true
           volumeMounts:
               -
-                name: "miq-app-volume"
+                name: "miq-app-volume-server"
                 mountPath: "/persistent"
+              -
+                name: "miq-app-volume-region"
+                mountPath: "/persistent-region"
           env:
             -
               name: "APPLICATION_INIT_DELAY"
@@ -291,7 +308,7 @@ objects:
           -
             name: "miq-pgdb-volume"
             persistentVolumeClaim:
-              claimName: ${DATABASE_SERVICE_NAME}
+              claimName: ${NAME}-${DATABASE_SERVICE_NAME}
         containers:
           -
             name: "postgresql"
@@ -453,7 +470,13 @@ parameters:
     name: "APPLICATION_VOLUME_CAPACITY"
     displayName: "Application Volume Capacity"
     required: true
-    description: "Volume space available for application data."
+    description: "Volume space available for server application data."
+    value: "1Gi"
+  -
+    name: "APPLICATION_REGION_VOLUME_CAPACITY"
+    displayName: "Application Region Volume Capacity"
+    required: true
+    description: "Volume space available for region application data."
     value: "1Gi"
   -
     name: "DATABASE_VOLUME_CAPACITY"


### PR DESCRIPTION
- Added extra PVC along with volume setup on template for region volume
- Renamed manageiq DC volumes in order to obtain consistent naming
- Created APPLICATION_REGION_VOLUME_CAPACITY parameter to allow size customization of new PVC
- Made necessary adjustments to container-deploy-common to now handle db config/keys/region from region vol
- Created new ENV var and mount point on miq-app Dockerfile to handle new volume
- Updated documentation on PV creation to reflect all changes