### PR TITLE
Scale MIQ appliances using PetSets

### DIFF
--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -9,6 +9,7 @@ ENV TERM xterm
 ENV RUBY_GEMS_ROOT /opt/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0
 ENV APP_ROOT /var/www/miq/vmdb
 ENV APP_ROOT_PERSISTENT /persistent
+ENV APP_ROOT_PERSISTENT_REGION /persistent-region
 ENV APPLIANCE_ROOT /opt/manageiq/manageiq-appliance
 ENV SUI_ROOT /opt/manageiq/manageiq-ui-service
 ENV CONTAINER_SCRIPTS_ROOT /opt/manageiq/container-scripts
@@ -103,6 +104,7 @@ RUN ${APPLIANCE_ROOT}/setup && \
     echo "export PATH=\$PATH:/opt/rubies/ruby-2.3.1/bin" >> /etc/default/evm && \
     mkdir ${APP_ROOT}/log/apache && \
     mkdir ${APP_ROOT_PERSISTENT} && \
+    mkdir ${APP_ROOT_PERSISTENT_REGION} && \
     mkdir -p ${CONTAINER_SCRIPTS_ROOT} && \
     mv /etc/httpd/conf.d/ssl.conf{,.orig} && \
     echo "# This file intentionally left blank. ManageIQ maintains its own SSL configuration" > /etc/httpd/conf.d/ssl.conf && \

--- a/images/miq-app/docker-assets/appliance-initialize.sh
+++ b/images/miq-app/docker-assets/appliance-initialize.sh
@@ -17,6 +17,9 @@ check_db_status
 # Check deployment status
 check_deployment_status
 
+# Check for new replica case
+check_if_new_replica
+
 # Select path of action based on DEPLOYMENT_STATUS value
 case "${DEPLOYMENT_STATUS}" in
   redeployment)
@@ -34,6 +37,14 @@ case "${DEPLOYMENT_STATUS}" in
   migrate_db
   run_hook post-upgrade
   write_deployment_info
+  ;;
+  new_replica)
+  echo "== Starting New Replica =="
+  setup_logs
+  setup_memcached
+  replica_join_region
+  sync_pv_data
+  restore_pv_data
   ;;
   new_deployment)
   echo "== Starting New Deployment =="

--- a/images/miq-app/docker-assets/appliance-initialize.sh
+++ b/images/miq-app/docker-assets/appliance-initialize.sh
@@ -60,6 +60,9 @@ case "${DEPLOYMENT_STATUS}" in
   # Init persistent data from application rootdir on PV
   init_pv_data
 
+  # Make initial backup
+  backup_pv_data
+
   # Restore symlinks from PV to application rootdir
   restore_pv_data
 

--- a/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
+++ b/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
@@ -303,8 +303,6 @@ rsync -qavL --exclude 'v2_key' --exclude 'database.yml' --exclude 'REGION' --fil
 [ ! -f "${PV_REGION_VMDB}/certs/v2_key" ] && rsync -qavR "${APP_ROOT}/certs/v2_key" "${PV_CONTAINER_DATA_REGION_DIR}"
 [ ! -f "${PV_REGION_VMDB}/REGION" ] && rsync -qavR "${APP_ROOT}/REGION" "${PV_CONTAINER_DATA_REGION_DIR}"
 
-backup_pv_data
-
 ) 2>&1 | tee "${PV_DATA_INIT_LOG}"
 
 }
@@ -360,7 +358,7 @@ PV_BACKUP_TIMESTAMP="$(date +%Y_%m_%d_%H%M%S)"
 (
 echo "== Initializing PV data backup =="
 
-rsync -qav --exclude 'log' "${PV_CONTAINER_DATA_DIR}" "${PV_BACKUP_DIR}/backup_${PV_BACKUP_TIMESTAMP}"
+rsync -av --exclude 'log' "${PV_CONTAINER_DATA_DIR}" "${PV_CONTAINER_DATA_REGION_DIR}" "${PV_BACKUP_DIR}/backup_${PV_BACKUP_TIMESTAMP}"
 
 [ "$?" -ne "0" ] && echo "WARNING: Some files might not have been copied please check logs at ${PV_DATA_BACKUP_LOG}"
 

--- a/miq-pv-db-example.yaml
+++ b/miq-pv-db-example.yaml
@@ -10,4 +10,4 @@ spec:
   nfs: 
     path: /exports/miq-pv01
     server: <your-nfs-host-here>
-  persistentVolumeReclaimPolicy: Recycle
+  persistentVolumeReclaimPolicy: Retain

--- a/miq-pv-region-example.yaml
+++ b/miq-pv-region-example.yaml
@@ -10,4 +10,4 @@ spec:
   nfs: 
     path: /exports/miq-pv02
     server: <your-nfs-host-here>
-  persistentVolumeReclaimPolicy: Recycle
+  persistentVolumeReclaimPolicy: Retain

--- a/miq-pv-server-example.yaml
+++ b/miq-pv-server-example.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: miq-pv03
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  nfs: 
+    path: /exports/miq-pv03
+    server: <your-nfs-host-here>
+  persistentVolumeReclaimPolicy: Retain

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -17,6 +17,7 @@ objects:
       service.alpha.openshift.io/dependencies: '[{"name":"${DATABASE_SERVICE_NAME}","namespace":"","kind":"Service"},{"name":"${MEMCACHED_SERVICE_NAME}","namespace":"","kind":"Service"}]'
     name: ${NAME}
   spec:
+    clusterIP: None
     ports:
     - name: http
       port: 80
@@ -68,7 +69,7 @@ objects:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    name: ${DATABASE_SERVICE_NAME}
+    name: "${NAME}-${DATABASE_SERVICE_NAME}"
   spec:
     accessModes:
       - ReadWriteOnce
@@ -78,35 +79,34 @@ objects:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    name: ${NAME}
+    name: "${NAME}-region"
   spec:
     accessModes:
       - ReadWriteOnce
     resources:
       requests:
-        storage: ${APPLICATION_VOLUME_CAPACITY}
-- apiVersion: v1
-  kind: "DeploymentConfig"
+        storage: ${APPLICATION_REGION_VOLUME_CAPACITY}
+- apiVersion: apps/v1alpha1
+  kind: "PetSet"
   metadata:
     name: ${NAME}
     annotations:
       description: "Defines how to deploy the ManageIQ appliance"
   spec:
+    serviceName: "${NAME}"
+    replicas: 1
     template:
       metadata:
         labels:
           name: ${NAME}
         name: ${NAME}
+        annotations:
+          # 'false' pauses a petset after creation of each pet, to avoid it we set it to 'true'
+          pod.alpha.kubernetes.io/initialized: "true"
       spec:
-        volumes:
-          -
-            name: "miq-app-volume"
-            persistentVolumeClaim:
-              claimName: ${NAME}
         containers:
-        - image: "${APPLICATION_IMG_NAME}:${APPLICATION_IMG_TAG}"
-          imagePullPolicy: IfNotPresent
-          name: manageiq
+        - name: manageiq
+          image: "${APPLICATION_IMG_NAME}:${APPLICATION_IMG_TAG}"
           livenessProbe:
             tcpSocket:
               port: 443
@@ -128,8 +128,11 @@ objects:
             privileged: true
           volumeMounts:
               -
-                name: "miq-app-volume"
+                name: "${NAME}-server"
                 mountPath: "/persistent"
+              -
+                name: "${NAME}-region"
+                mountPath: "/persistent-region"
           env:
             -
               name: "APPLICATION_INIT_DELAY"
@@ -169,23 +172,23 @@ objects:
               exec:
                 command:
                   - /opt/manageiq/container-scripts/sync-pv-data
-    replicas: 1
-    selector:
-      name: ${NAME}
-    triggers:
-      - type: "ConfigChange"
-      - type: "ImageChange"
-        imageChangeParams:
-          automatic: true
-          containerNames:
-            - "manageiq"
-          from:
-            kind: "ImageStreamTag"
-            name: "miq-app:${APPLICATION_IMG_TAG}"
-    strategy:
-      type: "Recreate"
-      recreateParams:
-        timeoutSeconds: 1200
+        volumes:
+         -
+           name: "${NAME}-region"
+           persistentVolumeClaim:
+             claimName: ${NAME}-region
+    volumeClaimTemplates:
+      - metadata:
+          name: "${NAME}-server"
+          annotations:
+            # Uncomment this if using dynamic volume provisioning.
+            # https://docs.openshift.org/latest/install_config/persistent_storage/dynamically_provisioning_pvs.html
+            # volume.alpha.kubernetes.io/storage-class: anything
+        spec:
+          accessModes: [ ReadWriteOnce ]
+          resources:
+            requests:
+              storage: "${APPLICATION_VOLUME_CAPACITY}"
 - apiVersion: v1
   kind: "Service"
   metadata:
@@ -313,7 +316,7 @@ objects:
           -
             name: "miq-pgdb-volume"
             persistentVolumeClaim:
-              claimName: ${DATABASE_SERVICE_NAME}
+              claimName: "${NAME}-${DATABASE_SERVICE_NAME}"
         containers:
           -
             name: "postgresql"
@@ -530,6 +533,12 @@ parameters:
     displayName: "Application Volume Capacity"
     required: true
     description: "Volume space available for application data."
+    value: "5Gi"
+  -
+    name: "APPLICATION_REGION_VOLUME_CAPACITY"
+    displayName: "Application Region Volume Capacity"
+    required: true
+    description: "Volume space available for region application data."
     value: "5Gi"
   -
     name: "DATABASE_VOLUME_CAPACITY"


### PR DESCRIPTION
- Replaced MIQ template Deployments in favor of Petsets
- miq-app image Dockerfile updated to reflect a 2-volume deployment (region/server)
- Applied necessary changes to container-deploy-common.sh to handle the 2-volume configuration
- Created function to detect a new_replica deployment on container-deploy-common.sh
- Created function to handle REGION join for new replicas on container-deploy-common.sh
- Added logic on appliance-initialize.sh to call a new_replica case
- Updated NFS PV templates to reflect new storage configuration
- Updated all documentation to reflect new procedures and added "Scale" section