### PR TITLE
Update template default capacities for DB and Application PVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In order to avoid random deployment failures due to resource starvation, we reco
 
 * 1 x Master node with at least 8 VCPUs and 12GB of RAM
 * 2 x Nodes with at least 4 VCPUs and 8GB of RAM
-* 1 x NFS server with at least 10GB of space for PV use
+* At least 20GB of storage for MIQ PV use
 
 Other sizing considerations: 
 
@@ -88,8 +88,8 @@ Verify pv creation
 ```bash
 $ oc get pv
 NAME       CAPACITY   ACCESSMODES   STATUS      CLAIM     REASON    AGE
-manageiq   2Gi        RWO           Available                       24d
-postgresql 2Gi        RWO           Available                       24d
+miq-pv01   15Gi        RWO           Available                       24d
+miq-pv02   5Gi         RWO           Available                       24d
 ```
 
 ###Increase maximum number of imported images on ImageStream

--- a/miq-pv-app-example.yaml
+++ b/miq-pv-app-example.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: manageiq
+  name: miq-pv02
 spec:
   capacity:
-    storage: 2Gi
+    storage: 5Gi
   accessModes:
     - ReadWriteOnce
   nfs: 
-    path: /opt/nfs/volumes-app
-    server: 10.19.0.216
+    path: /exports/miq-pv02
+    server: <your-nfs-host-here>
   persistentVolumeReclaimPolicy: Recycle

--- a/miq-pv-example.yaml
+++ b/miq-pv-example.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: nfs-pv01
+  name: miq-pv01
 spec:
   capacity:
-    storage: 2Gi
+    storage: 15Gi
   accessModes:
     - ReadWriteOnce
   nfs: 
-    path: /opt/nfs/volumes
-    server: 10.19.0.216
+    path: /exports/miq-pv01
+    server: <your-nfs-host-here>
   persistentVolumeReclaimPolicy: Recycle

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -485,10 +485,10 @@ parameters:
     displayName: "Application Volume Capacity"
     required: true
     description: "Volume space available for application data."
-    value: "1Gi"
+    value: "5Gi"
   -
     name: "DATABASE_VOLUME_CAPACITY"
     displayName: "Database Volume Capacity"
     required: true
     description: "Volume space available for database."
-    value: "1Gi"
+    value: "15Gi"


### PR DESCRIPTION
- Increase default volume capacity to 5GB for App pod, 15GB DB pod, this is more realistic.
- Updated docs and sample templates.
- Fixes #106