### PR TITLE
Enhance health probes on MIQ pod (liveness/readiness)

### DIFF
--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -108,15 +108,15 @@ objects:
           imagePullPolicy: IfNotPresent
           name: manageiq
           livenessProbe:
-            httpGet:
-              path: /
-              port: 80
+            tcpSocket:
+              port: 443
             initialDelaySeconds: 480
             timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 443
+              scheme: HTTPS
             initialDelaySeconds: 200
             timeoutSeconds: 3
           ports:


### PR DESCRIPTION
- Switch liveness probe to tcpsocket to resolve miq pod restart issue in the event of DB outage
- Switch readiness probe to HTTPs instead HTTP