### PR TITLE
Parametize APPLICATION_REPLICA_COUNT for petset controller

### DIFF
--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -94,7 +94,7 @@ objects:
       description: "Defines how to deploy the ManageIQ appliance"
   spec:
     serviceName: "${NAME}"
-    replicas: 1
+    replicas: "${APPLICATION_REPLICA_COUNT}"
     template:
       metadata:
         labels:
@@ -522,6 +522,11 @@ parameters:
     displayName: "Application Hostname"
     description: "The exposed hostname that will route to the application service, if left blank a value will be defaulted."
     value: ""
+  -
+    name: "APPLICATION_REPLICA_COUNT"
+    displayName: "Application Replica Count"
+    description: "This is the number of Application replicas requested to deploy."
+    value: "1"
   -
     name: "APPLICATION_INIT_DELAY"
     displayName: "Application Init Delay"


### PR DESCRIPTION
- Allow user to deploy desired number of MIQ replicas using parameters