### PR TITLE
Randomize DB password by default and store on secret

### DIFF
--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -10,6 +10,12 @@ metadata:
     iconClass: "icon-rails"
 objects:
 - apiVersion: v1
+  kind: Secret
+  metadata:
+    name: "${NAME}-secrets"
+  stringData:
+    pg-password: "${DATABASE_PASSWORD}"
+- apiVersion: v1
   kind: Service
   metadata:
     annotations:
@@ -151,7 +157,10 @@ objects:
               value: "${DATABASE_USER}"
             -
               name: "POSTGRESQL_PASSWORD"
-              value: "${DATABASE_PASSWORD}"
+              valueFrom:
+                secretKeyRef:
+                  name: "${NAME}-secrets"
+                  key: "pg-password"
             -
               name: "POSTGRESQL_DATABASE"
               value: "${DATABASE_NAME}"
@@ -348,7 +357,10 @@ objects:
                 value: "${DATABASE_USER}"
               -
                 name: "POSTGRESQL_PASSWORD"
-                value: "${DATABASE_PASSWORD}"
+                valueFrom:
+                  secretKeyRef:
+                    name: "${NAME}-secrets"
+                    key: "pg-password"
               -
                 name: "POSTGRESQL_DATABASE"
                 value: "${DATABASE_NAME}"
@@ -389,7 +401,8 @@ parameters:
     displayName: "PostgreSQL Password"
     required: true
     description: "Password for the PostgreSQL user."
-    value: "smartvm"
+    from: "[a-zA-Z0-9]{8}"
+    generate: expression
   -
     name: "DATABASE_NAME"
     required: true


### PR DESCRIPTION
- Create secret template object along with necessary keys
- Randomize DB password template parameter
- Expose DB password secret as a ENV variable for deployment use
- Fixes #105