### PR TITLE
Deploy MIQ using external PG database

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,22 @@ Deploy MIQ from template using customized settings
 
 `$ oc new-app --template=manageiq -p DATABASE_VOLUME_CAPACITY=2Gi,MEMORY_POSTGRESQL_LIMIT=4Gi`
 
+## Deploy MIQ using an external database
+
+Before you attempt an external DB deployment please ensure the following conditions are satisfied :
+
+* Your OpenShift cluster can access the remote PostgreSQL server on port 5432
+* MIQ user, password and role have been created on the remote PostgreSQL server
+* The intended MIQ database is created and ownership has been assigned to the MIQ user
+
+Import the MIQ external db template
+
+`$ oc create -f templates/miq-template-ext-db.yaml`
+
+Launch deployment, database server IP is required, rest of settings must match your remote PG server side.
+
+`$ oc new-app --template=manageiq-ext-db -p DATABASE_REMOTE_IP=<server_ip> -p DATABASE_USER=<user> -p DATABASE_PASSWORD=<password> -p DATABASE_NAME=<database_name>`
+
 ## Verifying the setup was successful
 
 _**Note:**_ The first deployment could take several minutes as OpenShift is downloading the necessary images.

--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ Deploy MIQ from template using customized settings
 
 Before you attempt an external DB deployment please ensure the following conditions are satisfied :
 
-* Your OpenShift cluster can access the remote PostgreSQL server on port 5432
-* MIQ user, password and role have been created on the remote PostgreSQL server
+* Your OpenShift cluster can access the external PostgreSQL server
+* MIQ user, password and role have been created on the external PostgreSQL server
 * The intended MIQ database is created and ownership has been assigned to the MIQ user
 
 Import the MIQ external db template
@@ -160,7 +160,7 @@ Import the MIQ external db template
 
 Launch deployment, database server IP is required, rest of settings must match your remote PG server side.
 
-`$ oc new-app --template=manageiq-ext-db -p DATABASE_REMOTE_IP=<server_ip> -p DATABASE_USER=<user> -p DATABASE_PASSWORD=<password> -p DATABASE_NAME=<database_name>`
+`$ oc new-app --template=manageiq-ext-db -p DATABASE_IP=<server_ip> -p DATABASE_USER=<user> -p DATABASE_PASSWORD=<password> -p DATABASE_NAME=<database_name>`
 
 ## Verifying the setup was successful
 

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -74,8 +74,8 @@ objects:
     resources:
       requests:
         storage: ${APPLICATION_REGION_VOLUME_CAPACITY}
-- apiVersion: apps/v1alpha1
-  kind: "PetSet"
+- apiVersion: apps/v1beta1
+  kind: "StatefulSet"
   metadata:
     name: ${NAME}
     annotations:
@@ -88,9 +88,6 @@ objects:
         labels:
           name: ${NAME}
         name: ${NAME}
-        annotations:
-          # 'false' pauses a petset after creation of each pet, to avoid it we set it to 'true'
-          pod.alpha.kubernetes.io/initialized: "true"
       spec:
         containers:
         - name: manageiq

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -1,0 +1,430 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: manageiq-ext-db
+metadata:
+  name: manageiq-ext-db
+  annotations:
+    description: "ManageIQ appliance with persistent storage using a external DB host"
+    tags: "instant-app,manageiq,miq"
+    iconClass: "icon-rails"
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: "${NAME}-secrets"
+  stringData:
+    pg-password: "${DATABASE_PASSWORD}"
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: "Exposes and load balances ManageIQ pods"
+      service.alpha.openshift.io/dependencies: '[{"name":"${DATABASE_SERVICE_NAME}","namespace":"","kind":"Service"},{"name":"${MEMCACHED_SERVICE_NAME}","namespace":"","kind":"Service"}]'
+    name: ${NAME}
+  spec:
+    clusterIP: None
+    ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 80
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 443
+    selector:
+      name: ${NAME}
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: ${NAME}
+  spec:
+    host: ${APPLICATION_DOMAIN}
+    port:
+      targetPort: https
+    tls:
+      termination: passthrough
+    to:
+      kind: Service
+      name: ${NAME}
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: miq-app
+    annotations:
+      description: "Keeps track of the ManageIQ image changes"
+  spec:
+    dockerImageRepository: "${APPLICATION_IMG_NAME}"
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: miq-memcached
+    annotations:
+      description: "Keeps track of the Memcached image changes"
+  spec:
+    dockerImageRepository: "${MEMCACHED_IMG_NAME}"
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: "${NAME}-region"
+  spec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: ${APPLICATION_REGION_VOLUME_CAPACITY}
+- apiVersion: apps/v1alpha1
+  kind: "PetSet"
+  metadata:
+    name: ${NAME}
+    annotations:
+      description: "Defines how to deploy the ManageIQ appliance"
+  spec:
+    serviceName: "${NAME}"
+    replicas: "${APPLICATION_REPLICA_COUNT}"
+    template:
+      metadata:
+        labels:
+          name: ${NAME}
+        name: ${NAME}
+        annotations:
+          # 'false' pauses a petset after creation of each pet, to avoid it we set it to 'true'
+          pod.alpha.kubernetes.io/initialized: "true"
+      spec:
+        containers:
+        - name: manageiq
+          image: "${APPLICATION_IMG_NAME}:${APPLICATION_IMG_TAG}"
+          livenessProbe:
+            tcpSocket:
+              port: 443
+            initialDelaySeconds: 480
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 443
+              scheme: HTTPS
+            initialDelaySeconds: 200
+            timeoutSeconds: 3
+          ports:
+          - containerPort: 80
+            protocol: TCP
+          - containerPort: 443
+            protocol: TCP
+          securityContext:
+            privileged: true
+          volumeMounts:
+              -
+                name: "${NAME}-server"
+                mountPath: "/persistent"
+              -
+                name: "${NAME}-region"
+                mountPath: "/persistent-region"
+          env:
+            -
+              name: "APPLICATION_INIT_DELAY"
+              value: "${APPLICATION_INIT_DELAY}"
+            -
+              name: "DATABASE_SERVICE_NAME"
+              value: "${DATABASE_SERVICE_NAME}"
+            -
+              name: "DATABASE_REGION"
+              value: "${DATABASE_REGION}"
+            -
+              name: "MEMCACHED_SERVICE_NAME"
+              value: "${MEMCACHED_SERVICE_NAME}"
+            -
+              name: "POSTGRESQL_USER"
+              value: "${DATABASE_USER}"
+            -
+              name: "POSTGRESQL_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "${NAME}-secrets"
+                  key: "pg-password"
+            -
+              name: "POSTGRESQL_DATABASE"
+              value: "${DATABASE_NAME}"
+          resources:
+            requests:
+              memory: "${APPLICATION_MEM_REQ}"
+              cpu: "${APPLICATION_CPU_REQ}"
+            limits:
+              memory: "${APPLICATION_MEM_LIMIT}"
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /opt/manageiq/container-scripts/sync-pv-data
+        volumes:
+         -
+           name: "${NAME}-region"
+           persistentVolumeClaim:
+             claimName: ${NAME}-region
+    volumeClaimTemplates:
+      - metadata:
+          name: "${NAME}-server"
+          annotations:
+            # Uncomment this if using dynamic volume provisioning.
+            # https://docs.openshift.org/latest/install_config/persistent_storage/dynamically_provisioning_pvs.html
+            # volume.alpha.kubernetes.io/storage-class: anything
+        spec:
+          accessModes: [ ReadWriteOnce ]
+          resources:
+            requests:
+              storage: "${APPLICATION_VOLUME_CAPACITY}"
+- apiVersion: v1
+  kind: "Service"
+  metadata:
+    name: "${MEMCACHED_SERVICE_NAME}"
+    annotations:
+      description: "Exposes the memcached server"
+  spec:
+    ports:
+      -
+        name: "memcached"
+        port: 11211
+        targetPort: 11211
+    selector:
+      name: "${MEMCACHED_SERVICE_NAME}"
+- apiVersion: v1
+  kind: "DeploymentConfig"
+  metadata:
+    name: "${MEMCACHED_SERVICE_NAME}"
+    annotations:
+      description: "Defines how to deploy memcached"
+  spec:
+    strategy:
+      type: "Recreate"
+    triggers:
+      -
+        type: "ImageChange"
+        imageChangeParams:
+          automatic: true
+          containerNames:
+            - "memcached"
+          from:
+            kind: "ImageStreamTag"
+            name: "miq-memcached:${MEMCACHED_IMG_TAG}"
+      -
+        type: "ConfigChange"
+    replicas: 1
+    selector:
+      name: "${MEMCACHED_SERVICE_NAME}"
+    template:
+      metadata:
+        name: "${MEMCACHED_SERVICE_NAME}"
+        labels:
+          name: "${MEMCACHED_SERVICE_NAME}"
+      spec:
+        volumes: []
+        containers:
+          -
+            name: "memcached"
+            image: "${MEMCACHED_IMG_NAME}:${MEMCACHED_IMG_TAG}"
+            ports:
+              -
+                containerPort: 11211
+            readinessProbe:
+              timeoutSeconds: 1
+              initialDelaySeconds: 5
+              tcpSocket:
+                port: 11211
+            livenessProbe:
+              timeoutSeconds: 1
+              initialDelaySeconds: 30
+              tcpSocket:
+                port: 11211
+            volumeMounts: []
+            env:
+              -
+                name: "MEMCACHED_MAX_MEMORY"
+                value: "${MEMCACHED_MAX_MEMORY}"
+              -
+                name: "MEMCACHED_MAX_CONNECTIONS"
+                value: "${MEMCACHED_MAX_CONNECTIONS}"
+              -
+                name: "MEMCACHED_SLAB_PAGE_SIZE"
+                value: "${MEMCACHED_SLAB_PAGE_SIZE}"
+            resources:
+              requests:
+                memory: "${MEMCACHED_MEM_REQ}"
+                cpu: "${MEMCACHED_CPU_REQ}"
+              limits:
+                memory: "${MEMCACHED_MEM_LIMIT}"
+- apiVersion: v1
+  kind: "Service"
+  metadata:
+    name: "${DATABASE_SERVICE_NAME}"
+    annotations:
+      description: "Remote database service"
+  spec:
+    ports:
+      -
+        name: "postgresql"
+        port: 5432
+        targetPort: 5432
+    selector: {}
+- apiVersion: v1
+  kind: "Endpoints"
+  metadata:
+    name: "${DATABASE_SERVICE_NAME}"
+  subsets:
+    -
+      addresses:
+        -
+          ip: "${DATABASE_REMOTE_IP}"
+      ports:
+        -
+          port: 5432
+          name: "postgresql"
+parameters:
+  -
+    name: "NAME"
+    displayName: Name
+    required: true
+    description: "The name assigned to all of the frontend objects defined in this template."
+    value: manageiq
+  -
+    name: "DATABASE_SERVICE_NAME"
+    displayName: "PostgreSQL Service Name"
+    required: true
+    description: "The name of the OpenShift Service exposed for the PostgreSQL container."
+    value: "postgresql"
+  -
+    name: "DATABASE_USER"
+    displayName: "PostgreSQL User"
+    required: true
+    description: "PostgreSQL user that will access the database."
+    value: "root"
+  -
+    name: "DATABASE_PASSWORD"
+    displayName: "PostgreSQL Password"
+    required: true
+    description: "Password for the PostgreSQL user."
+    from: "[a-zA-Z0-9]{8}"
+    generate: expression
+  -
+    name: "DATABASE_REMOTE_IP"
+    displayName: "PostgreSQL Server IP"
+    required: true
+    description: "PostgreSQL remote server IP used to configure service end-points."
+    value: ""
+  -
+    name: "DATABASE_NAME"
+    required: true
+    displayName: "PostgreSQL Database Name"
+    description: "Name of the PostgreSQL database accessed."
+    value: "vmdb_production"
+  -
+    name: "DATABASE_REGION"
+    required: true
+    displayName: "Application Database Region"
+    description: "Database region that will be used for application."
+    value: "0"
+  -
+    name: "MEMCACHED_SERVICE_NAME"
+    required: true
+    displayName: "Memcached Service Name"
+    description: "The name of the OpenShift Service exposed for the Memcached container."
+    value: "memcached"
+  -
+    name: "MEMCACHED_MAX_MEMORY"
+    displayName: "Memcached Max Memory"
+    description: "Memcached maximum memory for memcached object storage in MB."
+    value: "64"
+  -
+    name: "MEMCACHED_MAX_CONNECTIONS"
+    displayName: "Memcached Max Connections"
+    description: "Memcached maximum number of connections allowed."
+    value: "1024"
+  -
+    name: "MEMCACHED_SLAB_PAGE_SIZE"
+    displayName: "Memcached Slab Page Size"
+    description: "Memcached size of each slab page."
+    value: "1m"
+  -
+    name: "APPLICATION_CPU_REQ"
+    displayName: "Application Min CPU Requested"
+    required: true
+    description: "Minimum amount of CPU time the Application container will need (expressed in millicores)."
+    value: "1000m"
+  -
+    name: "MEMCACHED_CPU_REQ"
+    displayName: "Memcached Min CPU Requested"
+    required: true
+    description: "Minimum amount of CPU time the Memcached container will need (expressed in millicores)."
+    value: "200m"
+  -
+    name: "APPLICATION_MEM_REQ"
+    displayName: "Application Min RAM Requested"
+    required: true
+    description: "Minimum amount of memory the Application container will need."
+    value: "6144Mi"
+  -
+    name: "MEMCACHED_MEM_REQ"
+    displayName: "Memcached Min RAM Requested"
+    required: true
+    description: "Minimum amount of memory the Memcached container will need."
+    value: "64Mi"
+  -
+    name: "APPLICATION_MEM_LIMIT"
+    displayName: "Application Max RAM Limit"
+    required: true
+    description: "Maximum amount of memory the Application container can consume."
+    value: "16384Mi"
+  -
+    name: "MEMCACHED_MEM_LIMIT"
+    displayName: "Memcached Max RAM Limit"
+    required: true
+    description: "Maximum amount of memory the Memcached container can consume."
+    value: "256Mi"
+  -
+    name: "MEMCACHED_IMG_NAME"
+    displayName: "Memcached Image Name"
+    description: "This is the Memcached image name requested to deploy."
+    value: "docker.io/manageiq/manageiq-pods"
+  -
+    name: "MEMCACHED_IMG_TAG"
+    displayName: "Memcached Image Tag"
+    description: "This is the Memcached image tag/version requested to deploy."
+    value: "memcached-latest"
+  -
+    name: "APPLICATION_IMG_NAME"
+    displayName: "Application Image Name"
+    description: "This is the Application image name requested to deploy."
+    value: "docker.io/manageiq/manageiq-pods"
+  -
+    name: "APPLICATION_IMG_TAG"
+    displayName: "Application Image Tag"
+    description: "This is the Application image tag/version requested to deploy."
+    value: "app-latest"
+  -
+    name: "APPLICATION_DOMAIN"
+    displayName: "Application Hostname"
+    description: "The exposed hostname that will route to the application service, if left blank a value will be defaulted."
+    value: ""
+  -
+    name: "APPLICATION_REPLICA_COUNT"
+    displayName: "Application Replica Count"
+    description: "This is the number of Application replicas requested to deploy."
+    value: "1"
+  -
+    name: "APPLICATION_INIT_DELAY"
+    displayName: "Application Init Delay"
+    required: true
+    description: "Delay in seconds before we attempt to initialize the application."
+    value: "15"
+  -
+    name: "APPLICATION_VOLUME_CAPACITY"
+    displayName: "Application Volume Capacity"
+    required: true
+    description: "Volume space available for application data."
+    value: "5Gi"
+  -
+    name: "APPLICATION_REGION_VOLUME_CAPACITY"
+    displayName: "Application Region Volume Capacity"
+    required: true
+    description: "Volume space available for region application data."
+    value: "5Gi"

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -132,6 +132,9 @@ objects:
               name: "DATABASE_REGION"
               value: "${DATABASE_REGION}"
             -
+              name: "DATABASE_PORT"
+              value: "${DATABASE_PORT}"
+            -
               name: "MEMCACHED_SERVICE_NAME"
               value: "${MEMCACHED_SERVICE_NAME}"
             -
@@ -264,7 +267,7 @@ objects:
       -
         name: "postgresql"
         port: 5432
-        targetPort: 5432
+        targetPort: ${{DATABASE_PORT}}
     selector: {}
 - apiVersion: v1
   kind: "Endpoints"
@@ -274,10 +277,10 @@ objects:
     -
       addresses:
         -
-          ip: "${DATABASE_REMOTE_IP}"
+          ip: "${DATABASE_IP}"
       ports:
         -
-          port: 5432
+          port: ${{DATABASE_PORT}}
           name: "postgresql"
 parameters:
   -
@@ -306,16 +309,16 @@ parameters:
     from: "[a-zA-Z0-9]{8}"
     generate: expression
   -
-    name: "DATABASE_REMOTE_IP"
+    name: "DATABASE_IP"
     displayName: "PostgreSQL Server IP"
     required: true
-    description: "PostgreSQL remote server IP used to configure service end-points."
+    description: "PostgreSQL external server IP used to configure service."
     value: ""
   -
-    name: "DATABASE_PORT_
+    name: "DATABASE_PORT"
     displayName: "PostgreSQL Server Port"
     required: true
-    description: "PostgreSQL remote server port used to configure service end-points."
+    description: "PostgreSQL external server port used to configure service."
     value: "5432"
   -
     name: "DATABASE_NAME"

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -312,6 +312,12 @@ parameters:
     description: "PostgreSQL remote server IP used to configure service end-points."
     value: ""
   -
+    name: "DATABASE_PORT_
+    displayName: "PostgreSQL Server Port"
+    required: true
+    description: "PostgreSQL remote server port used to configure service end-points."
+    value: "5432"
+  -
     name: "DATABASE_NAME"
     required: true
     displayName: "PostgreSQL Database Name"


### PR DESCRIPTION
- Created new template excluding unncessary PG pod objects
- Added endpoints object and re-configured PG svc
- Remote endpoints parametized via DATABASE_SERVER_IP
- Updated documentation to reflect new deployment option
- PG server must be prepared for MIQ before attempting to use this template