### PR TITLE
Systemd set correct STOPSIGNAL on podified MIQ image

### DIFF
--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -30,6 +30,9 @@ LABEL name="manageiq" \
       io.openshift.expose-services="443:https" \
       io.openshift.tags="ManageIQ,miq,manageiq"
 
+## To cleanly shutdown systemd, use SIGRTMIN+3
+STOPSIGNAL SIGRTMIN+3
+
 ## Install EPEL repo, yum necessary packages for the build without docs, clean all caches
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     yum -y install centos-release-scl-rh && \


### PR DESCRIPTION
- See https://github.com/ManageIQ/manageiq/pull/14605
- OpenShift honors STOPSIGNAL on termination/shutdown
- Allows container to shutdown gracefully and terminate all connections appropiately