### PR TITLE
MIQ POD cleanup yarn cache

### DIFF
--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -157,7 +157,8 @@ RUN source /etc/default/evm && \
 RUN source /etc/default/evm && \
     cd ${SUI_ROOT} && \
     yarn install --production && \
-    yarn run build
+    yarn run build && \
+    yarn cache clean
 
 ## Expose required container ports
 EXPOSE 80 443


### PR DESCRIPTION
- Issue a yarn cache clean after SUI build
- Reduces image size by 300MB