### PR TITLE
Migrate petset to statefulsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This example gives a base template to deploy a multi-pod ManageIQ appliance with
 
 ### Prerequisites:
 
-* OpenShift Origin 1.3 or higher
+* OpenShift Origin 1.5 or higher
 * NFS or other compatible volume provider
 * A cluster-admin user
 
@@ -225,13 +225,13 @@ Please note the config change trigger is kept enabled, if you desire to have ful
 
 ## Scale MIQ 
 
-We use PetSets (AKA StatefulSets) to allow scaling of MIQ appliances, before you attempt scaling please ensure you have enough PVs available to scale. Each new replica will consume a PV.
+We use StatefulSets to allow scaling of MIQ appliances, before you attempt scaling please ensure you have enough PVs available to scale. Each new replica will consume a PV.
 
 Example scaling to 2 replicas/servers
 
 ```bash 
-$ oc patch petset manageiq -p '{"spec":{"replicas":2}}'
-"manageiq" patched
+$ oc scale statefulset manageiq --replicas=2
+statefulset "manageiq" scaled
 $ oc get pods
 NAME                 READY     STATUS    RESTARTS   AGE
 manageiq-0           1/1       Running   0          34m
@@ -240,9 +240,9 @@ memcached-1-mzeer    1/1       Running   0          1h
 postgresql-1-dufgp   1/1       Running   0          1h
 ```
 
-The newly created replicas will join the existing MIQ region. For a PetSet with N replicas, when Pods are being deployed, they are created sequentially, in order from {0..N-1}.
+The newly created replicas will join the existing MIQ region. For a StatefulSet with N replicas, when Pods are being deployed, they are created sequentially, in order from {0..N-1}.
 
-_**Note:**_ As of Origin 1.4 PetSets are an alpha feature, be aware functionality might be limited.
+_**Note:**_ As of Origin 1.5 StatefulSets are a beta feature, be aware functionality might be limited.
 
 ## POD access and routes
 

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -92,8 +92,8 @@ objects:
     resources:
       requests:
         storage: ${APPLICATION_REGION_VOLUME_CAPACITY}
-- apiVersion: apps/v1alpha1
-  kind: "PetSet"
+- apiVersion: apps/v1beta1
+  kind: "StatefulSet"
   metadata:
     name: ${NAME}
     annotations:
@@ -106,9 +106,6 @@ objects:
         labels:
           name: ${NAME}
         name: ${NAME}
-        annotations:
-          # 'false' pauses a petset after creation of each pet, to avoid it we set it to 'true'
-          pod.alpha.kubernetes.io/initialized: "true"
       spec:
         containers:
         - name: manageiq


### PR DESCRIPTION
@bazulay @carbonin @simaishi Please review, controller name change and documentation update, tested on latest OCP 3.5. We now have `oc scale` support. See sample below : 

```
oc version
oc v3.5.5.5
kubernetes v1.5.2+43a9be4
features: Basic-Auth GSSAPI Kerberos SPNEGO

Server https://franco-ocp-master.e2e.bos.redhat.com:8443
openshift v3.5.5.5
kubernetes v1.5.2+43a9be4

[root@franco-ocp-master franco]# oc get pods
NAME                 READY     STATUS    RESTARTS   AGE
manageiq-0           1/1       Running   0          11m
memcached-1-p80t3    1/1       Running   0          10m
postgresql-1-c8rs2   1/1       Running   0          10m

[root@franco-ocp-master franco]# oc scale statefulset manageiq --replicas=2
statefulset "manageiq" scaled

[root@franco-ocp-master franco]# oc get statefulset 
NAME       DESIRED   CURRENT   AGE
manageiq   2         2         12m

[root@franco-ocp-master franco]# oc get pods
NAME                 READY     STATUS    RESTARTS   AGE
manageiq-0           1/1       Running   0          24m
manageiq-1           1/1       Running   0          12m
memcached-1-p80t3    1/1       Running   0          23m
postgresql-1-c8rs2   1/1       Running   0          23m
```
Resolves #115 