### PR TITLE
Include default name and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,11 @@ deploymentconfig "postgresql" updated
 
 Please note the config change trigger is kept enabled, if you desire to have full control of your deployments you can alternatively turn it off.
 
+### Loggin In
+
+Per the ManageIQ project [basic configuration](http://manageiq.org/docs/get-started/basic-configuration) documentation, you can now login to the MIQ web interface
+using the default name/password: `admin`/`smartvm`.
+
 ## Scale MIQ 
 
 We use StatefulSets to allow scaling of MIQ appliances, before you attempt scaling please ensure you have enough PVs available to scale. Each new replica will consume a PV.

--- a/README.md
+++ b/README.md
@@ -223,11 +223,6 @@ deploymentconfig "postgresql" updated
 
 Please note the config change trigger is kept enabled, if you desire to have full control of your deployments you can alternatively turn it off.
 
-### Loggin In
-
-Per the ManageIQ project [basic configuration](http://manageiq.org/docs/get-started/basic-configuration) documentation, you can now login to the MIQ web interface
-using the default name/password: `admin`/`smartvm`.
-
 ## Scale MIQ 
 
 We use StatefulSets to allow scaling of MIQ appliances, before you attempt scaling please ensure you have enough PVs available to scale. Each new replica will consume a PV.
@@ -264,6 +259,12 @@ NAME       HOST/PORT                       PATH      SERVICE            TERMINAT
 manageiq   miq.apps.e2e.bos.redhat.com             manageiq:443-tcp   passthrough   app=manageiq
 ```
 Examine output and point your web browser to the reported URL/HOST.
+
+### Logging In
+
+Per the ManageIQ project [basic configuration](http://manageiq.org/docs/get-started/basic-configuration) documentation, you can now login to the MIQ web interface
+using the default name/password: `admin`/`smartvm`.
+
 
 ## Troubleshooting
 Under normal circumstances the entire first time deployment process should take around ~10 minutes, indication of issues can be seen


### PR DESCRIPTION
Provide name and password in the 'verify setup successful' section so admins can browse the web interface without having to lookup other documentation.