### PR TITLE
Remove systemd in favor of dumb-init for process management

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ The default service account for your namespace (project) must be added to the pr
 _**As admin**_
 
 ```bash
-$ oadm policy add-scc-to-user privileged system:serviceaccount:<your-namespace>:default
+$ oadm policy add-scc-to-user anyuid system:serviceaccount:<your-namespace>:default
 ```
 
 Verify that your default service account is now included in the privileged scc
 ```
-$ oc describe scc privileged | grep Users
-Users:					system:serviceaccount:openshift-infra:build-controller,system:serviceaccount:management-infra:management-admin,system:serviceaccount:management-infra:inspector-admin,system:serviceaccount:default:router,system:serviceaccount:default:registry,system:serviceaccount:<your-namespace>:default
+$ oc describe scc anyuid | grep Users
+Users:					system:serviceaccount:<your-namespace>:default
 ```
 
 ### Make persistent volumes to host the MIQ database and application data

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Example NFS PV templates are provided, **please skip this step you have already 
 
 For NFS backed volumes, please ensure your NFS server firewall is configured to allow traffic on port 2049 (TCP) from the OpenShift cluster.
 
-_**Note:**_ Recommended permissions for the PV volumes are 775, root uid/gid owned.
+_**Note:**_ Recommended permissions for the PV volumes are 777, root uid/gid owned.
 
 _**As admin:**_
 

--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -29,9 +29,6 @@ LABEL name="manageiq" \
       io.openshift.expose-services="443:https" \
       io.openshift.tags="ManageIQ,miq,manageiq"
 
-## To cleanly shutdown systemd, use SIGRTMIN+3
-STOPSIGNAL SIGRTMIN+3
-
 ## Install EPEL repo, yum necessary packages for the build without docs, clean all caches
 RUN yum -y install centos-release-scl-rh && \
     yum -y install --setopt=tsflags=nodocs \

--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -140,5 +140,5 @@ RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/
 RUN chmod +x /usr/local/bin/dumb-init
 
 ## Call systemd to bring up system
-ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--single-child", "--"]
 CMD ["entrypoint"]

--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -140,9 +140,9 @@ COPY docker-assets/container.data.persist /
 COPY docker-assets/appliance-initialize.sh /bin
 ADD  docker-assets/container-scripts ${CONTAINER_SCRIPTS_ROOT}
 
-## Enable services on systemd
-RUN systemctl enable evmserverd crond
+RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64
+RUN chmod +x /usr/local/bin/dumb-init
 
 ## Call systemd to bring up system
-ENTRYPOINT ["entrypoint"]
-CMD [ "/usr/sbin/init" ]
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+CMD ["entrypoint"]

--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -7,6 +7,7 @@ ARG REF=master
 ## Set ENV, LANG only needed if building with docker-1.8
 ENV container=docker \
     TERM=xterm \
+    CONTAINER=true \
     APP_ROOT=/var/www/miq/vmdb \
     APP_ROOT_PERSISTENT=/persistent \
     APP_ROOT_PERSISTENT_REGION=/persistent-region \
@@ -92,15 +93,13 @@ RUN curl -L https://github.com/ManageIQ/manageiq/tarball/${REF} | tar vxz -C ${A
 
 ## Setup environment
 RUN ${APPLIANCE_ROOT}/setup && \
-    echo "export PATH=\$PATH:/opt/rubies/ruby-2.3.1/bin" >> /etc/default/evm && \
     mkdir ${APP_ROOT}/log/apache && \
     mkdir ${APP_ROOT_PERSISTENT} && \
     mkdir ${APP_ROOT_PERSISTENT_REGION} && \
     mkdir -p ${CONTAINER_SCRIPTS_ROOT} && \
     mv /etc/httpd/conf.d/ssl.conf{,.orig} && \
     echo "# This file intentionally left blank. ManageIQ maintains its own SSL configuration" > /etc/httpd/conf.d/ssl.conf && \
-    cp ${APP_ROOT}/config/cable.yml.sample ${APP_ROOT}/config/cable.yml && \
-    echo "export CONTAINER=true" >> /etc/default/evm
+    cp ${APP_ROOT}/config/cable.yml.sample ${APP_ROOT}/config/cable.yml
 
 ## Change workdir to application root, build/install gems
 WORKDIR ${APP_ROOT}

--- a/images/miq-app/docker-assets/appliance-initialize.sh
+++ b/images/miq-app/docker-assets/appliance-initialize.sh
@@ -11,6 +11,9 @@ sleep "${APPLICATION_INIT_DELAY}"
 # Prepare initialization environment
 prepare_init_env
 
+# Generate the certs if needed
+/usr/bin/generate_miq_server_cert.sh
+
 # Check Memcached readiness
 check_svc_status ${MEMCACHED_SERVICE_NAME} 11211
 

--- a/images/miq-app/docker-assets/container.data.persist
+++ b/images/miq-app/docker-assets/container.data.persist
@@ -1,3 +1,5 @@
 # Please list ABSOLUTE path to files or directories to persist across deployments (upgrade/redeployment)
 /var/www/miq/vmdb/GUID
 /var/www/miq/vmdb/log
+/var/www/miq/vmdb/certs/server.cer
+/var/www/miq/vmdb/certs/server.cer.key

--- a/images/miq-app/docker-assets/entrypoint
+++ b/images/miq-app/docker-assets/entrypoint
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+/usr/sbin/crond &
+
 appliance-initialize.sh
 
-exec "$@"
+[[ -s /etc/default/evm ]] && source /etc/default/evm
+
+exec ruby /var/www/miq/vmdb/lib/workers/bin/evm_server.rb

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -127,8 +127,6 @@ objects:
             protocol: TCP
           - containerPort: 443
             protocol: TCP
-          securityContext:
-            privileged: true
           volumeMounts:
               -
                 name: "${NAME}-server"

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -184,6 +184,7 @@ objects:
            name: "${NAME}-region"
            persistentVolumeClaim:
              claimName: ${NAME}-region
+        terminationGracePeriodSeconds: 90
     volumeClaimTemplates:
       - metadata:
           name: "${NAME}-server"


### PR DESCRIPTION
This allows us to move away from some of the unpleasantness that systemd enforces when running in a container.

In particular this allows us to carry our environment through to the server process.

This PR also handles some of the fallout from this change, namely:
  - Consolidation of ENVVARs
  - Creation of the server ssl certificate (previously done in [evmserver.sh](https://github.com/ManageIQ/manageiq-appliance/blob/master/LINK/usr/bin/evmserver.sh#L10))

For this to work properly I still need to start `httpd` manually on the command line. /cc @bdunne 