### PR TITLE
Remove database.yml, REGION and v2_key from container.data.persist file

### DIFF
--- a/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
+++ b/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
@@ -262,7 +262,7 @@ function init_pv_data() {
     echo "== Initializing PV data =="
 
     # Exclude region files on server PV
-    rsync -qavL --exclude 'v2_key' --exclude 'database.yml' --exclude 'REGION' --files-from="${PV_DATA_PERSIST_FILE}" / "${PV_CONTAINER_DATA_DIR}"
+    rsync -qavL --files-from="${PV_DATA_PERSIST_FILE}" / "${PV_CONTAINER_DATA_DIR}"
 
     # Catch non-zero return value and print warning
     [ "$?" -ne "0" ] && echo "WARNING: Some files might not have been copied please check logs at ${PV_DATA_INIT_LOG}"
@@ -335,7 +335,7 @@ function sync_pv_data() {
   (
     echo "== Syncing PV data =="
 
-    rsync -avL --exclude 'v2_key' --exclude 'database.yml' --exclude 'REGION' --files-from="${PV_DATA_PERSIST_FILE}" / "${PV_CONTAINER_DATA_DIR}"
+    rsync -avL --files-from="${PV_DATA_PERSIST_FILE}" / "${PV_CONTAINER_DATA_DIR}"
 
     [ "$?" -ne "0" ] && echo "WARNING: Some files might not have been copied please check logs at ${PV_DATA_SYNC_LOG}"
   ) 2>&1 | tee "${PV_DATA_SYNC_LOG}"

--- a/images/miq-app/docker-assets/container.data.persist
+++ b/images/miq-app/docker-assets/container.data.persist
@@ -1,6 +1,3 @@
 # Please list ABSOLUTE path to files or directories to persist across deployments (upgrade/redeployment)
-/var/www/miq/vmdb/REGION
 /var/www/miq/vmdb/GUID
-/var/www/miq/vmdb/config/database.yml
-/var/www/miq/vmdb/certs/v2_key
 /var/www/miq/vmdb/log


### PR DESCRIPTION
container.data.persist now only contains files for the server.
All region data is already handled by other symlinks / rsyncs.