### PR TITLE
Fix the node dependency on libhttp_parser

### DIFF
--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -63,6 +63,7 @@ RUN yum -y install centos-release-scl-rh && \
                    cronie                  \
                    logrotate               \
                    nmap-ncat               \
+                   http-parser             \
                    &&                      \
     yum clean all
 


### PR DESCRIPTION
Builds were failing with the following error:

`node: error while loading shared libraries: libhttp_parser.so.2: cannot open shared object file: No such file or directory`

This resolves that issue

/cc @simaishi @fbladilo 