### PR TITLE
Add a httpd front end

### DIFF
--- a/images/miq-app/docker-assets/appliance-initialize.sh
+++ b/images/miq-app/docker-assets/appliance-initialize.sh
@@ -24,13 +24,13 @@ restore_pv_data
 cd ${APP_ROOT}
 bin/rake evm:deployment_status
 
+# Generate httpd certificate
+/usr/bin/generate_miq_server_cert.sh
+
 # Select path of action based on DEPLOYMENT_STATUS value
 case $? in
   3) # new_deployment
     echo "== Starting New Deployment =="
-    # Generate the certs
-    /usr/bin/generate_miq_server_cert.sh
-
     # Setup logs on PV before init
     setup_logs
 
@@ -48,7 +48,6 @@ case $? in
   ;;
   4) # new_replica
     echo "== Starting New Replica =="
-    /usr/bin/generate_miq_server_cert.sh
     setup_logs
     replica_join_region
     sync_pv_data

--- a/images/miq-app/docker-assets/container.data.persist
+++ b/images/miq-app/docker-assets/container.data.persist
@@ -1,5 +1,3 @@
 # Please list ABSOLUTE path to files or directories to persist across deployments (upgrade/redeployment)
 /var/www/miq/vmdb/GUID
 /var/www/miq/vmdb/log
-/var/www/miq/vmdb/certs/server.cer
-/var/www/miq/vmdb/certs/server.cer.key

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -56,7 +56,7 @@ objects:
 - apiVersion: v1
   kind: Route
   metadata:
-    name: ${NAME}
+    name: "${HTTPD_SERVICE_NAME}"
   spec:
     host: ${APPLICATION_DOMAIN}
     port:
@@ -65,7 +65,7 @@ objects:
       termination: passthrough
     to:
       kind: Service
-      name: ${NAME}
+      name: "${HTTPD_SERVICE_NAME}"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -400,6 +400,87 @@ objects:
               memory: "${ANSIBLE_MEM_LIMIT}"
         serviceAccount: miq-privileged
         serviceAccountName: miq-privileged
+
+
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: httpd
+    annotations:
+      description: "Keeps track of the httpd image changes"
+  spec:
+    dockerImageRepository: "${HTTPD_IMG_NAME}"
+- apiVersion: v1
+  kind: "Service"
+  metadata:
+    name: "${HTTPD_SERVICE_NAME}"
+    annotations:
+      description: "Exposes the httpd server"
+      service.alpha.openshift.io/dependencies: '[{"name":"${NAME}","namespace":"","kind":"Service"}]'
+  spec:
+    ports:
+      - name: "http"
+        port: 80
+        targetPort: 80
+      - name: "https"
+        port: 443
+        targetPort: 443
+    selector:
+      name: "httpd"
+- apiVersion: v1
+  kind: "DeploymentConfig"
+  metadata:
+    name: "${HTTPD_SERVICE_NAME}"
+    annotations:
+      description: "Defines how to deploy httpd"
+  spec:
+    strategy:
+      type: "Recreate"
+    triggers:
+      - type: "ImageChange"
+        imageChangeParams:
+          automatic: true
+          containerNames:
+            - "httpd"
+          from:
+            kind: "ImageStreamTag"
+            name: "httpd:${HTTPD_IMG_TAG}"
+      - type: "ConfigChange"
+    replicas: 1
+    selector:
+      name: "${HTTPD_SERVICE_NAME}"
+    template:
+      metadata:
+        name: "${HTTPD_SERVICE_NAME}"
+        labels:
+          name: "${HTTPD_SERVICE_NAME}"
+      spec:
+        volumes: []
+        containers:
+          - name: "httpd"
+            image: "${HTTPD_IMG_NAME}:${HTTPD_IMG_TAG}"
+            ports:
+              - containerPort: 80
+              - containerPort: 443
+            livenessProbe:
+              tcpSocket:
+                port: 443
+              initialDelaySeconds: 15
+              timeoutSeconds: 3
+            readinessProbe:
+              httpGet:
+                path: /
+                port: 443
+                scheme: HTTPS
+              initialDelaySeconds: 10
+              timeoutSeconds: 3
+            volumeMounts: []
+            env:
+            resources:
+              requests:
+              limits:
+
+
 parameters:
   -
     name: "NAME"
@@ -622,3 +703,17 @@ parameters:
     required: true
     description: "Volume space available for application data."
     value: "5Gi"
+
+  - name: "HTTPD_SERVICE_NAME"
+    required: true
+    displayName: "Apache httpd Service Name"
+    description: "The name of the OpenShift Service exposed for the httpd container."
+    value: "httpd"
+  - name: "HTTPD_IMG_NAME"
+    displayName: "Apache httpd Image Name"
+    description: "This is the httpd image name requested to deploy."
+    value: "docker.io/manageiq/httpd"
+  - name: "HTTPD_IMG_TAG"
+    displayName: "Apache httpd Image Tag"
+    description: "This is the httpd image tag/version requested to deploy."
+    value: "latest"

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -478,7 +478,10 @@ objects:
             env:
             resources:
               requests:
+                memory: "${HTTPD_MEM_REQ}"
+                cpu: "${HTTPD_CPU_REQ}"
               limits:
+                memory: "${HTTPD_MEM_LIMIT}"
 
 
 parameters:
@@ -717,3 +720,18 @@ parameters:
     displayName: "Apache httpd Image Tag"
     description: "This is the httpd image tag/version requested to deploy."
     value: "latest"
+  - name: "HTTPD_CPU_REQ"
+    displayName: "Apache httpd Min CPU Requested"
+    required: true
+    description: "Minimum amount of CPU time the httpd container will need (expressed in millicores)."
+    value: "500m"
+  - name: "HTTPD_MEM_REQ"
+    displayName: "Apache httpd Min RAM Requested"
+    required: true
+    description: "Minimum amount of memory the httpd container will need."
+    value: "512Mi"
+  - name: "HTTPD_MEM_LIMIT"
+    displayName: "Apache httpd Max RAM Limit"
+    required: true
+    description: "Maximum amount of memory the httpd container can consume."
+    value: "8192Mi"

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -56,7 +56,7 @@ objects:
 - apiVersion: v1
   kind: Route
   metadata:
-    name: ${NAME}
+    name: "${HTTPD_SERVICE_NAME}"
   spec:
     host: ${APPLICATION_DOMAIN}
     port:
@@ -65,7 +65,7 @@ objects:
       termination: passthrough
     to:
       kind: Service
-      name: ${NAME}
+      name: "${HTTPD_SERVICE_NAME}"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -492,6 +492,86 @@ objects:
         serviceAccount: miq-privileged
         serviceAccountName: miq-privileged
 
+
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: httpd
+    annotations:
+      description: "Keeps track of the httpd image changes"
+  spec:
+    dockerImageRepository: "${HTTPD_IMG_NAME}"
+- apiVersion: v1
+  kind: "Service"
+  metadata:
+    name: "${HTTPD_SERVICE_NAME}"
+    annotations:
+      description: "Exposes the httpd server"
+      service.alpha.openshift.io/dependencies: '[{"name":"${NAME}","namespace":"","kind":"Service"}]'
+  spec:
+    ports:
+      - name: "http"
+        port: 80
+        targetPort: 80
+      - name: "https"
+        port: 443
+        targetPort: 443
+    selector:
+      name: "httpd"
+- apiVersion: v1
+  kind: "DeploymentConfig"
+  metadata:
+    name: "${HTTPD_SERVICE_NAME}"
+    annotations:
+      description: "Defines how to deploy httpd"
+  spec:
+    strategy:
+      type: "Recreate"
+    triggers:
+      - type: "ImageChange"
+        imageChangeParams:
+          automatic: true
+          containerNames:
+            - "httpd"
+          from:
+            kind: "ImageStreamTag"
+            name: "httpd:${HTTPD_IMG_TAG}"
+      - type: "ConfigChange"
+    replicas: 1
+    selector:
+      name: "${HTTPD_SERVICE_NAME}"
+    template:
+      metadata:
+        name: "${HTTPD_SERVICE_NAME}"
+        labels:
+          name: "${HTTPD_SERVICE_NAME}"
+      spec:
+        volumes: []
+        containers:
+          - name: "httpd"
+            image: "${HTTPD_IMG_NAME}:${HTTPD_IMG_TAG}"
+            ports:
+              - containerPort: 80
+              - containerPort: 443
+            livenessProbe:
+              tcpSocket:
+                port: 443
+              initialDelaySeconds: 15
+              timeoutSeconds: 3
+            readinessProbe:
+              httpGet:
+                path: /
+                port: 443
+                scheme: HTTPS
+              initialDelaySeconds: 10
+              timeoutSeconds: 3
+            volumeMounts: []
+            env:
+            resources:
+              requests:
+              limits:
+
+
 parameters:
   -
     name: "NAME"
@@ -746,3 +826,17 @@ parameters:
     required: true
     description: "Volume space available for database."
     value: "15Gi"
+
+  - name: "HTTPD_SERVICE_NAME"
+    required: true
+    displayName: "Apache httpd Service Name"
+    description: "The name of the OpenShift Service exposed for the httpd container."
+    value: "httpd"
+  - name: "HTTPD_IMG_NAME"
+    displayName: "Apache httpd Image Name"
+    description: "This is the httpd image name requested to deploy."
+    value: "docker.io/manageiq/httpd"
+  - name: "HTTPD_IMG_TAG"
+    displayName: "Apache httpd Image Tag"
+    description: "This is the httpd image tag/version requested to deploy."
+    value: "latest"

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -569,7 +569,10 @@ objects:
             env:
             resources:
               requests:
+                memory: "${HTTPD_MEM_REQ}"
+                cpu: "${HTTPD_CPU_REQ}"
               limits:
+                memory: "${HTTPD_MEM_LIMIT}"
 
 
 parameters:
@@ -840,3 +843,18 @@ parameters:
     displayName: "Apache httpd Image Tag"
     description: "This is the httpd image tag/version requested to deploy."
     value: "latest"
+  - name: "HTTPD_CPU_REQ"
+    displayName: "Apache httpd Min CPU Requested"
+    required: true
+    description: "Minimum amount of CPU time the httpd container will need (expressed in millicores)."
+    value: "500m"
+  - name: "HTTPD_MEM_REQ"
+    displayName: "Apache httpd Min RAM Requested"
+    required: true
+    description: "Minimum amount of memory the httpd container will need."
+    value: "512Mi"
+  - name: "HTTPD_MEM_LIMIT"
+    displayName: "Apache httpd Max RAM Limit"
+    required: true
+    description: "Maximum amount of memory the httpd container can consume."
+    value: "8192Mi"


### PR DESCRIPTION
This httpd image will be the front-end for all incoming requests.
- It will handle SSL for now (until it is moved into the route)
- It will proxy to the correct services.
- In the future it will handle all of the auth as well.