### PR TITLE
Add the db service back to the app pod in the external db template

### DIFF
--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -114,6 +114,9 @@ objects:
               name: "APPLICATION_INIT_DELAY"
               value: "${APPLICATION_INIT_DELAY}"
             -
+              name: "DATABASE_SERVICE_NAME"
+              value: "${DATABASE_SERVICE_NAME}"
+            -
               name: "DATABASE_REGION"
               value: "${DATABASE_REGION}"
             -


### PR DESCRIPTION
This was removed in e496ce5ba305a74f3c2233414352b737e7453fc5 but is still needed