### PR TITLE
Split front-end and back-end containers

### DIFF
--- a/images/miq-app-frontend/Dockerfile
+++ b/images/miq-app-frontend/Dockerfile
@@ -1,0 +1,69 @@
+FROM manageiq/manageiq-pods:backend-latest
+MAINTAINER ManageIQ https://github.com/ManageIQ/manageiq-appliance-build
+
+## Set build ARGs
+ARG REF=master
+
+## Set ENV, LANG only needed if building with docker-1.8
+ENV SUI_ROOT=/opt/manageiq/manageiq-ui-service
+
+## Atomic/OpenShift Labels
+LABEL name="manageiq" \
+      vendor="ManageIQ" \
+      version="Master" \
+      release=${REF} \
+      url="http://manageiq.org/" \
+      summary="ManageIQ appliance image" \
+      description="ManageIQ is a management and automation platform for virtual, private, and hybrid cloud infrastructures." \
+      io.k8s.display-name="ManageIQ" \
+      io.k8s.description="ManageIQ is a management and automation platform for virtual, private, and hybrid cloud infrastructures." \
+      io.openshift.expose-services="443:https" \
+      io.openshift.tags="ManageIQ,miq,manageiq"
+
+## Install EPEL repo, yum necessary packages for the build without docs, clean all caches
+RUN yum -y install centos-release-scl-rh && \
+    yum -y install --setopt=tsflags=nodocs \
+                   httpd                   \
+                   mod_auth_kerb           \
+                   mod_authnz_pam          \
+                   mod_intercept_form_submit \
+                   mod_lookup_identity     \
+                   mod_ssl                 \
+                   &&                      \
+    yum clean all
+
+## GIT clone manageiq-appliance and service UI repo (SUI)
+RUN mkdir -p ${SUI_ROOT} && \
+    curl -L https://github.com/ManageIQ/manageiq-ui-service/tarball/${REF} | tar vxz -C ${SUI_ROOT} --strip 1
+
+## Setup environment
+RUN mv /etc/httpd/conf.d/ssl.conf{,.orig} && \
+    echo "# This file intentionally left blank. ManageIQ maintains its own SSL configuration" > /etc/httpd/conf.d/ssl.conf
+
+## Change workdir to application root, build/install gems
+WORKDIR ${APP_ROOT}
+RUN source /etc/default/evm && \
+    export RAILS_USE_MEMORY_STORE="true" && \
+    rake update:bower && \
+    bin/rails log:clear tmp:clear && \
+    rake evm:compile_assets && \
+    # Cleanup install artifacts
+    npm cache clean && \
+    bower cache clean && \
+    rm -rvf ${APP_ROOT}/tmp/cache/assets && \
+    rm -vf ${APP_ROOT}/log/*.log
+
+## Build SUI
+RUN source /etc/default/evm && \
+    cd ${SUI_ROOT} && \
+    yarn install --production && \
+    yarn run build && \
+    yarn cache clean
+
+## Expose required container ports
+EXPOSE 80 443
+
+COPY docker-assets/check-dependent-services.sh /bin
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--single-child", "--"]
+CMD ["entrypoint"]

--- a/images/miq-app-frontend/docker-assets/check-dependent-services.sh
+++ b/images/miq-app-frontend/docker-assets/check-dependent-services.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Source OpenShift scripting env
+[[ -s ${CONTAINER_SCRIPTS_ROOT}/container-deploy-common.sh ]] && source "${CONTAINER_SCRIPTS_ROOT}/container-deploy-common.sh"
+
+# Check readiness of external services
+check_svc_status ${MEMCACHED_SERVICE_NAME} 11211
+check_svc_status ${DATABASE_SERVICE_NAME} 5432

--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -122,6 +122,7 @@ EXPOSE 80 443
 COPY docker-assets/entrypoint /usr/bin
 COPY docker-assets/container.data.persist /
 COPY docker-assets/appliance-initialize.sh /bin
+COPY docker-assets/check-dependent-services.sh /bin
 ADD  docker-assets/container-scripts ${CONTAINER_SCRIPTS_ROOT}
 
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64

--- a/images/miq-app/docker-assets/appliance-initialize.sh
+++ b/images/miq-app/docker-assets/appliance-initialize.sh
@@ -11,12 +11,6 @@ sleep "${APPLICATION_INIT_DELAY}"
 # Prepare initialization environment
 prepare_init_env
 
-# Check Memcached readiness
-check_svc_status ${MEMCACHED_SERVICE_NAME} 11211
-
-# Check DB readiness
-check_svc_status ${DATABASE_SERVICE_NAME} 5432
-
 write_v2_key
 
 restore_pv_data

--- a/images/miq-app/docker-assets/check-dependent-services.sh
+++ b/images/miq-app/docker-assets/check-dependent-services.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Source OpenShift scripting env
+[[ -s ${CONTAINER_SCRIPTS_ROOT}/container-deploy-common.sh ]] && source "${CONTAINER_SCRIPTS_ROOT}/container-deploy-common.sh"
+
+# Check readiness of external services
+check_svc_status ${FRONTEND_SERVICE_NAME} 80

--- a/images/miq-app/docker-assets/entrypoint
+++ b/images/miq-app/docker-assets/entrypoint
@@ -2,6 +2,7 @@
 
 /usr/sbin/crond &
 
+check-dependent-services.sh
 appliance-initialize.sh
 
 [[ -s /etc/default/evm ]] && source /etc/default/evm

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -107,7 +107,7 @@ objects:
       spec:
         containers:
         - name: manageiq
-          image: "${APPLICATION_IMG_NAME}:${APPLICATION_IMG_TAG}"
+          image: "${APPLICATION_IMG_NAME}:${FRONTEND_APPLICATION_IMG_TAG}"
           livenessProbe:
             tcpSocket:
               port: 443
@@ -192,6 +192,97 @@ objects:
           resources:
             requests:
               storage: "${APPLICATION_VOLUME_CAPACITY}"
+
+
+- apiVersion: apps/v1beta1
+  kind: "StatefulSet"
+  metadata:
+    name: ${NAME}-backend
+    annotations:
+      description: "Defines how to deploy the ManageIQ appliance"
+  spec:
+    replicas: 0
+    template:
+      metadata:
+        labels:
+          name: ${NAME}-backend
+        name: ${NAME}-backend
+      spec:
+        containers:
+        - name: manageiq
+          image: "${APPLICATION_IMG_NAME}:${BACKEND_APPLICATION_IMG_TAG}"
+          livenessProbe:
+            exec:
+              command:
+                - pidof
+                - "MIQ Server"
+            initialDelaySeconds: 480
+          volumeMounts:
+              -
+                name: "${NAME}-server"
+                mountPath: "/persistent"
+          env:
+            -
+              name: "APPLICATION_INIT_DELAY"
+              value: "${APPLICATION_INIT_DELAY}"
+            -
+              name: "DATABASE_URL"
+              valueFrom:
+                secretKeyRef:
+                  name: "${NAME}-secrets"
+                  key: "database-url"
+            -
+              name: "MIQ_SERVER_DEFAULT_ROLES"
+              value: "database_operations,event,reporting,scheduler,smartstate,ems_operations,ems_inventory,automate"
+            -
+              name: "FRONTEND_SERVICE_NAME"
+              value: "${NAME}"
+            -
+              name: "MEMCACHED_SERVER"
+              value: "${MEMCACHED_SERVICE_NAME}:11211"
+            -
+              name: "V2_KEY"
+              valueFrom:
+                secretKeyRef:
+                  name: "${NAME}-secrets"
+                  key: "v2-key"
+            -
+              name: "ANSIBLE_SERVICE_NAME"
+              value: "${ANSIBLE_SERVICE_NAME}"
+            -
+              name: "ANSIBLE_ADMIN_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "${ANSIBLE_SERVICE_NAME}-secrets"
+                  key: "admin-password"
+          resources:
+            requests:
+              memory: "${APPLICATION_MEM_REQ}"
+              cpu: "${APPLICATION_CPU_REQ}"
+            limits:
+              memory: "${APPLICATION_MEM_LIMIT}"
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /opt/manageiq/container-scripts/sync-pv-data
+        serviceAccount: miq-anyuid
+        serviceAccountName: miq-anyuid
+        terminationGracePeriodSeconds: 90
+    volumeClaimTemplates:
+      - metadata:
+          name: "${NAME}-backend-server"
+          annotations:
+            # Uncomment this if using dynamic volume provisioning.
+            # https://docs.openshift.org/latest/install_config/persistent_storage/dynamically_provisioning_pvs.html
+            # volume.alpha.kubernetes.io/storage-class: anything
+        spec:
+          accessModes: [ ReadWriteOnce ]
+          resources:
+            requests:
+              storage: "${APPLICATION_VOLUME_CAPACITY}"
+
+
 - apiVersion: v1
   kind: "Service"
   metadata:
@@ -672,10 +763,15 @@ parameters:
     description: "This is the Application image name requested to deploy."
     value: "docker.io/manageiq/manageiq-pods"
   -
-    name: "APPLICATION_IMG_TAG"
-    displayName: "Application Image Tag"
-    description: "This is the Application image tag/version requested to deploy."
-    value: "app-latest"
+    name: "FRONTEND_APPLICATION_IMG_TAG"
+    displayName: "Front end Application Image Tag"
+    description: "This is the ManageIQ Frontend Application image tag/version requested to deploy."
+    value: "frontend-latest"
+  -
+    name: "BACKEND_APPLICATION_IMG_TAG"
+    displayName: "Back end Application Image Tag"
+    description: "This is the ManageIQ Backend Application image tag/version requested to deploy."
+    value: "backend-latest"
   -
     name: "ANSIBLE_IMG_NAME"
     displayName: "Ansible Image Name"

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -125,7 +125,7 @@ objects:
       spec:
         containers:
         - name: manageiq
-          image: "${APPLICATION_IMG_NAME}:${APPLICATION_IMG_TAG}"
+          image: "${APPLICATION_IMG_NAME}:${FRONTEND_APPLICATION_IMG_TAG}"
           livenessProbe:
             tcpSocket:
               port: 443
@@ -200,6 +200,95 @@ objects:
         terminationGracePeriodSeconds: 90
     volumeClaimTemplates:
       - metadata:
+          name: "${NAME}-backend-server"
+          annotations:
+            # Uncomment this if using dynamic volume provisioning.
+            # https://docs.openshift.org/latest/install_config/persistent_storage/dynamically_provisioning_pvs.html
+            # volume.alpha.kubernetes.io/storage-class: anything
+        spec:
+          accessModes: [ ReadWriteOnce ]
+          resources:
+            requests:
+              storage: "${APPLICATION_VOLUME_CAPACITY}"
+
+
+- apiVersion: apps/v1beta1
+  kind: "StatefulSet"
+  metadata:
+    name: ${NAME}-backend
+    annotations:
+      description: "Defines how to deploy the ManageIQ appliance"
+  spec:
+    replicas: 0
+    template:
+      metadata:
+        labels:
+          name: ${NAME}-backend
+        name: ${NAME}-backend
+      spec:
+        containers:
+        - name: manageiq
+          image: "${APPLICATION_IMG_NAME}:${BACKEND_APPLICATION_IMG_TAG}"
+          livenessProbe:
+            exec:
+              command:
+                - pidof
+                - "MIQ Server"
+            initialDelaySeconds: 480
+          volumeMounts:
+              -
+                name: "${NAME}-server"
+                mountPath: "/persistent"
+          env:
+            -
+              name: "APPLICATION_INIT_DELAY"
+              value: "${APPLICATION_INIT_DELAY}"
+            -
+              name: "DATABASE_URL"
+              valueFrom:
+                secretKeyRef:
+                  name: "${NAME}-secrets"
+                  key: "database-url"
+            -
+              name: "MIQ_SERVER_DEFAULT_ROLES"
+              value: "database_operations,event,reporting,scheduler,smartstate,ems_operations,ems_inventory,automate"
+            -
+              name: "FRONTEND_SERVICE_NAME"
+              value: "${NAME}"
+            -
+              name: "MEMCACHED_SERVER"
+              value: "${MEMCACHED_SERVICE_NAME}:11211"
+            -
+              name: "V2_KEY"
+              valueFrom:
+                secretKeyRef:
+                  name: "${NAME}-secrets"
+                  key: "v2-key"
+            -
+              name: "ANSIBLE_SERVICE_NAME"
+              value: "${ANSIBLE_SERVICE_NAME}"
+            -
+              name: "ANSIBLE_ADMIN_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "${ANSIBLE_SERVICE_NAME}-secrets"
+                  key: "admin-password"
+          resources:
+            requests:
+              memory: "${APPLICATION_MEM_REQ}"
+              cpu: "${APPLICATION_CPU_REQ}"
+            limits:
+              memory: "${APPLICATION_MEM_LIMIT}"
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /opt/manageiq/container-scripts/sync-pv-data
+        serviceAccount: miq-anyuid
+        serviceAccountName: miq-anyuid
+        terminationGracePeriodSeconds: 90
+    volumeClaimTemplates:
+      - metadata:
           name: "${NAME}-server"
           annotations:
             # Uncomment this if using dynamic volume provisioning.
@@ -210,6 +299,8 @@ objects:
           resources:
             requests:
               storage: "${APPLICATION_VOLUME_CAPACITY}"
+
+
 - apiVersion: v1
   kind: "Service"
   metadata:
@@ -789,10 +880,15 @@ parameters:
     description: "This is the Application image name requested to deploy."
     value: "docker.io/manageiq/manageiq-pods"
   -
-    name: "APPLICATION_IMG_TAG"
-    displayName: "Application Image Tag"
-    description: "This is the Application image tag/version requested to deploy."
-    value: "app-latest"
+    name: "FRONTEND_APPLICATION_IMG_TAG"
+    displayName: "Front end Application Image Tag"
+    description: "This is the ManageIQ Frontend Application image tag/version requested to deploy."
+    value: "frontend-latest"
+  -
+    name: "BACKEND_APPLICATION_IMG_TAG"
+    displayName: "Back end Application Image Tag"
+    description: "This is the ManageIQ Backend Application image tag/version requested to deploy."
+    value: "backend-latest"
   -
     name: "ANSIBLE_IMG_NAME"
     displayName: "Ansible Image Name"


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/15470

The frontend ManageIQ pod will receive all web traffic, all frontend replicas must run the UI, API and WS roles (no change here).

Backend replicas will not receive any UI / API / WS requests, so those roles should not be enabled by default.  Backend replicas should also wait for the frontend service to become available before attempting to start the application.  Backend replicas should be set to 0 by default and users can scale it based on their needs.

This change allows us to scale with a smaller footprint since we usually need more MiqServers for operations and inventory roles than for UI/API roles.