### PR TITLE
Allow server to control ansible pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,22 +52,23 @@ $ oc new-project <project_name> \
    
    _At a minimum, only `<project_name>` is required._
 
-### Add the miq-anyuid service account to the anyuid security context
+### Add the miq-anyuid and miq-orchestrator service accounts to the anyuid security context
 
 _**Note:**_ The current MIQ image requires the root user.
 
-The miq-anyuid service account for your namespace (project) must be added to the anyuid SCC before pods using the service account can run as root.
+These service accounts for your namespace (project) must be added to the anyuid SCC before pods using the service accounts can run as root.
 
 _**As admin**_
 
 ```bash
 $ oc adm policy add-scc-to-user anyuid system:serviceaccount:<your-namespace>:miq-anyuid
+$ oc adm policy add-scc-to-user anyuid system:serviceaccount:<your-namespace>:miq-orchestrator
 ```
 
-Verify that the miq-anyuid service account is now included in the anyuid scc
+Verify that the service accounts are now included in the anyuid scc
 ```
 $ oc describe scc anyuid | grep Users
-Users:					system:serviceaccount:<your-namespace>:miq-anyuid
+Users:					system:serviceaccount:<your-namespace>:miq-anyuid,system:serviceaccount:<your-namespace>:miq-orchestrator
 ```
 
 ### Add the miq-privileged service account to the privileged security context
@@ -86,6 +87,18 @@ Verify that the miq-privileged service account is now included in the privileged
 ```
 $ oc describe scc privileged | grep Users
 Users:					system:serviceaccount:<your-namespace>:miq-privileged
+```
+
+### Add the view and edit roles to the orchestrator service account
+
+This will allow the ManageIQ pod to scale other pods up and down.
+In particular we use this to scale the Ansible pod when the Embedded Ansible role is enabled.
+
+_**As basic user**_
+
+```bash
+oc policy add-role-to-user view system:serviceaccount:<your-namespace>:miq-orchestrator -n <your-namespace>
+oc policy add-role-to-user edit system:serviceaccount:<your-namespace>:miq-orchestrator -n <your-namespace>
 ```
 
 ### Make persistent volumes to host the MIQ database and application data

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -335,7 +335,7 @@ objects:
     strategy:
       type: "Recreate"
     serviceName: "${ANSIBLE_SERVICE_NAME}"
-    replicas: 1
+    replicas: 0
     template:
       metadata:
         labels:

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -131,6 +131,11 @@ objects:
                 mountPath: "/persistent"
           env:
             -
+              name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            -
               name: "APPLICATION_INIT_DELAY"
               value: "${APPLICATION_INIT_DELAY}"
             -

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -12,6 +12,10 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
+    name: miq-orchestrator
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
     name: miq-anyuid
 - apiVersion: v1
   kind: ServiceAccount
@@ -182,8 +186,8 @@ objects:
               exec:
                 command:
                   - /opt/manageiq/container-scripts/sync-pv-data
-        serviceAccount: miq-anyuid
-        serviceAccountName: miq-anyuid
+        serviceAccount: miq-orchestrator
+        serviceAccountName: miq-orchestrator
         terminationGracePeriodSeconds: 90
     volumeClaimTemplates:
       - metadata:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -426,7 +426,7 @@ objects:
     strategy:
       type: "Recreate"
     serviceName: "${ANSIBLE_SERVICE_NAME}"
-    replicas: 1
+    replicas: 0
     template:
       metadata:
         labels:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -12,6 +12,10 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
+    name: miq-orchestrator
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
     name: miq-anyuid
 - apiVersion: v1
   kind: ServiceAccount
@@ -200,8 +204,8 @@ objects:
               exec:
                 command:
                   - /opt/manageiq/container-scripts/sync-pv-data
-        serviceAccount: miq-anyuid
-        serviceAccountName: miq-anyuid
+        serviceAccount: miq-orchestrator
+        serviceAccountName: miq-orchestrator
         terminationGracePeriodSeconds: 90
     volumeClaimTemplates:
       - metadata:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -149,6 +149,11 @@ objects:
                 mountPath: "/persistent"
           env:
             -
+              name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            -
               name: "APPLICATION_INIT_DELAY"
               value: "${APPLICATION_INIT_DELAY}"
             -


### PR DESCRIPTION
This PR adds a new service account for the manageiq application pod which is intended to have edit and view roles for the namespace the project is running in.

This will allow the app pod itself to scale other pods within the project up and down.

The plan is to use this ability to only scale the ansible pod when it is needed (when the role is enabled).