### PR TITLE
If serviceName is not provided, it gets set to '' which is invalid

### DIFF
--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -203,6 +203,16 @@ objects:
               storage: "${APPLICATION_VOLUME_CAPACITY}"
 
 
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: "Headless service for ManageIQ backend pods"
+    name: ${NAME}-backend
+  spec:
+    clusterIP: None
+    selector:
+      name: ${NAME}-backend
 - apiVersion: apps/v1beta1
   kind: "StatefulSet"
   metadata:
@@ -210,6 +220,7 @@ objects:
     annotations:
       description: "Defines how to deploy the ManageIQ appliance"
   spec:
+    serviceName: "${NAME}-backend"
     replicas: 0
     template:
       metadata:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -221,6 +221,16 @@ objects:
               storage: "${APPLICATION_VOLUME_CAPACITY}"
 
 
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: "Headless service for ManageIQ backend pods"
+    name: ${NAME}-backend
+  spec:
+    clusterIP: None
+    selector:
+      name: ${NAME}-backend
 - apiVersion: apps/v1beta1
   kind: "StatefulSet"
   metadata:
@@ -228,6 +238,7 @@ objects:
     annotations:
       description: "Defines how to deploy the ManageIQ appliance"
   spec:
+    serviceName: "${NAME}-backend"
     replicas: 0
     template:
       metadata:


### PR DESCRIPTION
Without this, you get a not so helpful error:
```
pet: manageiq-backend-0, error: Pod "manageiq-backend-0" is invalid: metadata.annotations[pod.beta.kubernetes.io/subdomain]: Invalid value: "": must match the regex [a-z0-9]([-a-z0-9]*[a-z0-9])? (e.g. 'my-name' or '123-abc')
```