### PR TITLE
Increase default httpd recreate strategy timeout

### DIFF
--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -498,6 +498,8 @@ objects:
   spec:
     strategy:
       type: Recreate
+      recreateParams:
+        timeoutSeconds: 1200
     triggers:
     - type: ImageChange
       imageChangeParams:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -581,6 +581,8 @@ objects:
   spec:
     strategy:
       type: Recreate
+      recreateParams:
+        timeoutSeconds: 1200
     triggers:
     - type: ImageChange
       imageChangeParams:


### PR DESCRIPTION
- Increase default recreate strategy to 1200 (20 mins) from 600
- Allows httpd to be more patient with frontend statefulset seeding