### PR TITLE
Increase PG Pod resource requirements

### DIFF
--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -784,7 +784,7 @@ parameters:
 - name: POSTGRESQL_SHARED_BUFFERS
   displayName: PostgreSQL Shared Buffer Amount
   description: Amount of memory dedicated for PostgreSQL shared memory buffers.
-  value: 1024MB
+  value: 1GB
 - name: ANSIBLE_SERVICE_NAME
   displayName: Ansible Service Name
   description: The name of the OpenShift Service exposed for the Ansible container.
@@ -841,7 +841,7 @@ parameters:
   displayName: PostgreSQL Min RAM Requested
   required: true
   description: Minimum amount of memory the PostgreSQL container will need.
-  value: 4096Mi
+  value: 4Gi
 - name: MEMCACHED_MEM_REQ
   displayName: Memcached Min RAM Requested
   required: true
@@ -861,7 +861,7 @@ parameters:
   displayName: PostgreSQL Max RAM Limit
   required: true
   description: Maximum amount of memory the PostgreSQL container can consume.
-  value: 8192Mi
+  value: 8Gi
 - name: MEMCACHED_MEM_LIMIT
   displayName: Memcached Max RAM Limit
   required: true

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -784,7 +784,7 @@ parameters:
 - name: POSTGRESQL_SHARED_BUFFERS
   displayName: PostgreSQL Shared Buffer Amount
   description: Amount of memory dedicated for PostgreSQL shared memory buffers.
-  value: 256MB
+  value: 1024MB
 - name: ANSIBLE_SERVICE_NAME
   displayName: Ansible Service Name
   description: The name of the OpenShift Service exposed for the Ansible container.
@@ -841,7 +841,7 @@ parameters:
   displayName: PostgreSQL Min RAM Requested
   required: true
   description: Minimum amount of memory the PostgreSQL container will need.
-  value: 1024Mi
+  value: 4096Mi
 - name: MEMCACHED_MEM_REQ
   displayName: Memcached Min RAM Requested
   required: true


### PR DESCRIPTION
@carbonin @bdunne Follow up on this one...

- Provide reasonable minimum default resource requests for a PG/MIQ deployment on OpenShift
- Increased shared_buffers to 1GB
- Increased minimum RAM resource request to 4GB
- References :

https://wiki.postgresql.org/wiki/Tuning_Your_PostgreSQL_Server

https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5/html/deployment_planning_guide/introduction#virtual-hardware-requirements

The kubernetes scheduler will only attempt a pod placement on a node that satisfies the minimum request, the shared buffer calculation is taken from the PG tuning guide at 1/4 of the available RAM. In this case, we calculate from the minimum memory request (guaranteed) and not the max memory limit set by default at 8GB and enforced via cgroups.

