### PR TITLE
Allow MIQ database backup and restore via OpenShift jobs

### DIFF
--- a/templates/miq-backup-job.yaml
+++ b/templates/miq-backup-job.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
       - name: postgresql
-        image: docker.io/fbladilo/miq-postgresql:latest
+        image: docker.io/manageiq/postgresql:latest
         command:
         - "/opt/manageiq/container-scripts/backup_db"
         env:

--- a/templates/miq-backup-job.yaml
+++ b/templates/miq-backup-job.yaml
@@ -10,17 +10,17 @@ spec:
       containers:
       - name: postgresql
         image: docker.io/fbladilo/miq-postgresql:latest
-        command: ["/opt/manageiq/container-scripts/backup_db"]
+        command:
+        - "/opt/manageiq/container-scripts/backup_db"
         env:
-          -
-            name: "DATABASE_URL"
-            valueFrom:
-              secretKeyRef:
-                name: "manageiq-secrets"
-                key: "database-url"
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: manageiq-secrets
+              key: database-url
         volumeMounts:
         - name: miq-backup-vol
-          mountPath: /backups
+          mountPath: "/backups"
       volumes:
       - name: miq-backup-vol
         persistentVolumeClaim:

--- a/templates/miq-backup-job.yaml
+++ b/templates/miq-backup-job.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: manageiq-backup
+spec:
+  template:
+    metadata:
+      name: manageiq-backup
+    spec:
+      containers:
+      - name: postgresql
+        image: docker.io/fbladilo/miq-postgresql:latest
+        command: ["/opt/manageiq/container-scripts/backup_db"]
+        env:
+          -
+            name: "DATABASE_URL"
+            valueFrom:
+              secretKeyRef:
+                name: "manageiq-secrets"
+                key: "database-url"
+        volumeMounts:
+        - name: miq-backup-vol
+          mountPath: /backups
+      volumes:
+      - name: miq-backup-vol
+        persistentVolumeClaim:
+          claimName: manageiq-backup
+      restartPolicy: Never

--- a/templates/miq-backup-pvc.yaml
+++ b/templates/miq-backup-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "manageiq-backup"
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: "15Gi"

--- a/templates/miq-backup-pvc.yaml
+++ b/templates/miq-backup-pvc.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: "manageiq-backup"
+  name: manageiq-backup
 spec:
   accessModes:
   - ReadWriteOnce
   resources:
     requests:
-      storage: "15Gi"
+      storage: 15Gi

--- a/templates/miq-pv-backup-example.yaml
+++ b/templates/miq-pv-backup-example.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: miq-pv03
+spec:
+  capacity:
+    storage: 15Gi
+  accessModes:
+  - ReadWriteOnce
+  nfs:
+    path: "/exports/miq-pv03"
+    server: "<your-nfs-host-here>"
+  persistentVolumeReclaimPolicy: Retain

--- a/templates/miq-restore-job.yaml
+++ b/templates/miq-restore-job.yaml
@@ -10,22 +10,21 @@ spec:
       containers:
       - name: postgresql
         image: docker.io/fbladilo/miq-postgresql:latest
-        command: ["/opt/manageiq/container-scripts/restore_db"]
+        command:
+        - "/opt/manageiq/container-scripts/restore_db"
         env:
-          -
-            name: "DATABASE_URL"
-            valueFrom:
-              secretKeyRef:
-                name: "manageiq-secrets"
-                key: "database-url"
-          -
-            name: "BACKUP_VERSION"
-            value: "latest"
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: manageiq-secrets
+              key: database-url
+        - name: BACKUP_VERSION
+          value: latest
         volumeMounts:
         - name: miq-backup-vol
-          mountPath: /backups
+          mountPath: "/backups"
         - name: miq-prod-vol
-          mountPath: /restore
+          mountPath: "/restore"
       volumes:
       - name: miq-backup-vol
         persistentVolumeClaim:

--- a/templates/miq-restore-job.yaml
+++ b/templates/miq-restore-job.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
       - name: postgresql
-        image: docker.io/fbladilo/miq-postgresql:latest
+        image: docker.io/manageiq/postgresql:latest
         command:
         - "/opt/manageiq/container-scripts/restore_db"
         env:

--- a/templates/miq-restore-job.yaml
+++ b/templates/miq-restore-job.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: manageiq-restore
+spec:
+  template:
+    metadata:
+      name: manageiq-restore
+    spec:
+      containers:
+      - name: postgresql
+        image: docker.io/fbladilo/miq-postgresql:latest
+        command: ["/opt/manageiq/container-scripts/restore_db"]
+        env:
+          -
+            name: "DATABASE_URL"
+            valueFrom:
+              secretKeyRef:
+                name: "manageiq-secrets"
+                key: "database-url"
+          -
+            name: "BACKUP_VERSION"
+            value: "latest"
+        volumeMounts:
+        - name: miq-backup-vol
+          mountPath: /backups
+        - name: miq-prod-vol
+          mountPath: /restore
+      volumes:
+      - name: miq-backup-vol
+        persistentVolumeClaim:
+          claimName: manageiq-backup
+      - name: miq-prod-vol
+        persistentVolumeClaim:
+          claimName: manageiq-postgresql
+      restartPolicy: Never


### PR DESCRIPTION
@carbonin @bdunne Please review, some considerations : 

- Depends on https://github.com/ManageIQ/container-postgresql/pull/3
- Jobs execute in restricted SCC, identical to PG pod
- Arbitrary UID is assigned by OpenShift at a per project level, jobs must run within the same project for succesful results
- Jobs overwrite the PG image ENTRYPOINT with target script to run
- Backup job uses an extra PV/PVC pair
- Restore job uses both volumes, production and backup in order to perform restoration via TAR
- Procedure based on https://bugzilla.redhat.com/show_bug.cgi?id=1459652
- Added yaml templates for all required objects
- Updated README with instructions, notes and sample usage
- Tested on OCP 3.5