### PR TITLE
Update to support foundational update of container-httpd for external authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,35 @@ $ oc adm policy add-scc-to-user privileged system:serviceaccount:<your-namespace
 ```
 
 Verify that the miq-privileged service account is now included in the privileged scc
+
 ```
 $ oc describe scc privileged | grep Users
 Users:					system:serviceaccount:<your-namespace>:miq-privileged
+```
+
+### Add the miq-sysadmin service account
+
+_**Note:**_ The application front-end Httpd container requires an anyuid scc with the SYS_ADMIN capability to support systemd and dbus.
+
+__*As admin*__
+
+Create the miq-sysadmin SCC:
+
+```bash
+$ oc create -f templates/miq-sysadmin.yaml
+```
+
+The miq-sysadmin service account must be added to the miq-sysadmin SCC before the front-end Httpd pod can run.
+
+```bash
+$ oc adm policy add-scc-to-user miq-sysadmin system:serviceaccount:<your-namespace>:miq-sysadmin
+```
+
+Verify that the miq-sysadmin service account is now included in the miq-sysadmin scc
+
+```bash
+$ oc describe scc miq-sysadmin | grep Users
+Users:              system:serviceaccount:<your-namespace>:miq-sysadmin
 ```
 
 ### Add the view and edit roles to the orchestrator service account

--- a/templates/miq-sysadmin.yaml
+++ b/templates/miq-sysadmin.yaml
@@ -4,7 +4,7 @@ allowHostNetwork: false
 allowHostPID: false
 allowHostPorts: false
 allowPrivilegedContainer: false
-allowedCapabilities: null
+allowedCapabilities:
 apiVersion: v1
 defaultAddCapabilities:
 - SYS_ADMIN
@@ -15,10 +15,8 @@ groups:
 kind: SecurityContextConstraints
 metadata:
   annotations:
-    kubernetes.io/description: miq-sysadmin provides all features of the anyuid SCC
-      but allows users to have SYS_ADMIN capabilities. This is the required scc for
-      Pods requiring to run with systemd and the message bus.
-  creationTimestamp: null
+    kubernetes.io/description: miq-sysadmin provides all features of the anyuid SCC but allows users to have SYS_ADMIN capabilities. This is the required scc for Pods requiring to run with systemd and the message bus.
+  creationTimestamp:
   name: miq-sysadmin
 priority: 10
 readOnlyRootFilesystem: false

--- a/templates/miq-sysadmin.yaml
+++ b/templates/miq-sysadmin.yaml
@@ -1,0 +1,40 @@
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+apiVersion: v1
+defaultAddCapabilities:
+- SYS_ADMIN
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: miq-sysadmin provides all features of the anyuid SCC
+      but allows users to have SYS_ADMIN capabilities. This is the required scc for
+      Pods requiring to run with systemd and the message bus.
+  creationTimestamp: null
+  name: miq-sysadmin
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+- SYS_CHROOT
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- secret

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -22,6 +22,10 @@ objects:
   metadata:
     name: miq-privileged
 - apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: miq-sysadmin
+- apiVersion: v1
   kind: Secret
   metadata:
     name: "${NAME}-secrets"
@@ -468,6 +472,24 @@ objects:
   spec:
     dockerImageRepository: "${HTTPD_IMG_NAME}"
 - apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: "${HTTPD_SERVICE_NAME}-configs"
+  data:
+    application.conf: |
+      # Timeout: The number of seconds before receives and sends time out.
+      Timeout 120
+
+      RewriteEngine On
+      Options SymLinksIfOwnerMatch
+
+      <VirtualHost *:80>
+        KeepAlive on
+        ProxyPreserveHost on
+        ProxyPass        / http://${NAME}/
+        ProxyPassReverse / http://${NAME}/
+      </VirtualHost>
+- apiVersion: v1
   kind: Service
   metadata:
     name: "${HTTPD_SERVICE_NAME}"
@@ -511,7 +533,10 @@ objects:
         labels:
           name: "${HTTPD_SERVICE_NAME}"
       spec:
-        volumes: []
+        volumes:
+        - name: httpd-config
+          configMap:
+            name: "${HTTPD_SERVICE_NAME}-configs"
         containers:
         - name: httpd
           image: "${HTTPD_IMG_NAME}:${HTTPD_IMG_TAG}"
@@ -529,15 +554,17 @@ objects:
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 3
-          volumeMounts: []
+          volumeMounts:
+          - name: httpd-config
+            mountPath: "${HTTPD_CONFIG_DIR}"
           resources:
             requests:
               memory: "${HTTPD_MEM_REQ}"
               cpu: "${HTTPD_CPU_REQ}"
             limits:
               memory: "${HTTPD_MEM_LIMIT}"
-        serviceAccount: miq-anyuid
-        serviceAccountName: miq-anyuid
+        serviceAccount: miq-sysadmin
+        serviceAccountName: miq-sysadmin
 parameters:
 - name: NAME
   displayName: Name
@@ -739,6 +766,10 @@ parameters:
   displayName: Apache httpd Image Tag
   description: This is the httpd image tag/version requested to deploy.
   value: latest
+- name: HTTPD_CONFIG_DIR
+  displayName: Apache httpd Configuration Directory
+  description: Directory used to store the Apache configuration files.
+  value: "/etc/httpd/conf.d"
 - name: HTTPD_CPU_REQ
   displayName: Apache httpd Min CPU Requested
   required: true

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -115,6 +115,52 @@ objects:
       escape_string_warning = off
       standard_conforming_strings = off
 - apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: "${HTTPD_SERVICE_NAME}-configs"
+  data:
+    redirects.conf: |
+      # The following redirects files must be included to handle most specific to least specific URLs.
+
+      ### Cockpit redirects
+      ProxyPreserveHost on
+      RequestHeader unset X-Forwarded-Proto
+      RequestHeader set X-Forwarded-Proto 'https' env=HTTPS
+      <LocationMatch "^/cws/cockpi(t[^/]+|t)?/socket$">
+        ProxyPassMatch "ws://${NAME}:9002/cws/cockpi$1/socket"
+      </LocationMatch>
+      ProxyPass /cws/ http://${NAME}:9002/cws/
+
+      ### API redirects
+      ProxyPass /api https://${NAME}/api
+      ProxyPassReverse /api https://${NAME}/api
+
+      ### UI redirects
+      RewriteCond %{REQUEST_URI} !^/ws
+      RewriteCond %{REQUEST_URI} !^/proxy_pages
+      RewriteCond %{REQUEST_URI} !^/saml2
+      RewriteCond %{REQUEST_URI} !^/api
+      RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_FILENAME} !-f
+      RewriteRule ^/ https://${NAME}%{REQUEST_URI} [P,QSA,L]
+      ProxyPassReverse / https://${NAME}/
+
+      ### WebSocket redirects
+      ProxyPass /ws ws://${NAME}/ws
+      ProxyPassReverse /ws ws://${NAME}/ws
+
+      ProxyPreserveHost on
+      RequestHeader set X_FORWARDED_PROTO 'https'
+
+    logging.conf: |
+      CustomLog /var/log/httpd/ssl_request.log \
+              "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+      LogLevel warn
+
+    environment.conf: |
+      SetEnvIf User-Agent ".*MSIE.*" \
+               nokeepalive ssl-unclean-shutdown \
+               downgrade-1.0 force-response-1.0
+- apiVersion: v1
   kind: Service
   metadata:
     annotations:
@@ -678,7 +724,10 @@ objects:
         labels:
           name: "${HTTPD_SERVICE_NAME}"
       spec:
-        volumes: []
+        volumes:
+        - name: httpd-config
+          configMap:
+            name: "${HTTPD_SERVICE_NAME}-configs"
         containers:
         - name: httpd
           image: "${HTTPD_IMG_NAME}:${HTTPD_IMG_TAG}"
@@ -696,7 +745,12 @@ objects:
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 3
-          volumeMounts: []
+          volumeMounts:
+          - name: httpd-config
+            mountPath: "${HTTPD_CONFIG_DIR}"
+          env:
+          - name: MANAGEIQ_SERVICE_NAME
+            value: "${NAME}"
           resources:
             requests:
               memory: "${HTTPD_MEM_REQ}"
@@ -936,6 +990,10 @@ parameters:
   displayName: Apache httpd Image Tag
   description: This is the httpd image tag/version requested to deploy.
   value: latest
+- name: HTTPD_CONFIG_DIR
+  displayName: Apache Configuration Directory
+  description: Directory used to store the Apache configuration files.
+  value: "/etc/httpd/conf.d"
 - name: HTTPD_CPU_REQ
   displayName: Apache httpd Min CPU Requested
   required: true

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -22,6 +22,10 @@ objects:
   metadata:
     name: miq-privileged
 - apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: miq-sysadmin
+- apiVersion: v1
   kind: Secret
   metadata:
     name: "${NAME}-secrets"
@@ -699,8 +703,8 @@ objects:
               cpu: "${HTTPD_CPU_REQ}"
             limits:
               memory: "${HTTPD_MEM_LIMIT}"
-        serviceAccount: miq-anyuid
-        serviceAccountName: miq-anyuid
+        serviceAccount: miq-sysadmin
+        serviceAccountName: miq-sysadmin
 parameters:
 - name: NAME
   displayName: Name

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -119,47 +119,19 @@ objects:
   metadata:
     name: "${HTTPD_SERVICE_NAME}-configs"
   data:
-    redirects.conf: |
-      # The following redirects files must be included to handle most specific to least specific URLs.
+    application.conf: |
+      # Timeout: The number of seconds before receives and sends time out.
+      Timeout 120
 
-      ### Cockpit redirects
-      ProxyPreserveHost on
-      RequestHeader unset X-Forwarded-Proto
-      RequestHeader set X-Forwarded-Proto 'https' env=HTTPS
-      <LocationMatch "^/cws/cockpi(t[^/]+|t)?/socket$">
-        ProxyPassMatch "ws://${NAME}:9002/cws/cockpi$1/socket"
-      </LocationMatch>
-      ProxyPass /cws/ http://${NAME}:9002/cws/
+      RewriteEngine On
+      Options SymLinksIfOwnerMatch
 
-      ### API redirects
-      ProxyPass /api https://${NAME}/api
-      ProxyPassReverse /api https://${NAME}/api
-
-      ### UI redirects
-      RewriteCond %{REQUEST_URI} !^/ws
-      RewriteCond %{REQUEST_URI} !^/proxy_pages
-      RewriteCond %{REQUEST_URI} !^/saml2
-      RewriteCond %{REQUEST_URI} !^/api
-      RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_FILENAME} !-f
-      RewriteRule ^/ https://${NAME}%{REQUEST_URI} [P,QSA,L]
-      ProxyPassReverse / https://${NAME}/
-
-      ### WebSocket redirects
-      ProxyPass /ws ws://${NAME}/ws
-      ProxyPassReverse /ws ws://${NAME}/ws
-
-      ProxyPreserveHost on
-      RequestHeader set X_FORWARDED_PROTO 'https'
-
-    logging.conf: |
-      CustomLog /var/log/httpd/ssl_request.log \
-              "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
-      LogLevel warn
-
-    environment.conf: |
-      SetEnvIf User-Agent ".*MSIE.*" \
-               nokeepalive ssl-unclean-shutdown \
-               downgrade-1.0 force-response-1.0
+      <VirtualHost *:80>
+        KeepAlive on
+        ProxyPreserveHost on
+        ProxyPass        / http://${NAME}/
+        ProxyPassReverse / http://${NAME}/
+      </VirtualHost>
 - apiVersion: v1
   kind: Service
   metadata:
@@ -748,9 +720,6 @@ objects:
           volumeMounts:
           - name: httpd-config
             mountPath: "${HTTPD_CONFIG_DIR}"
-          env:
-          - name: MANAGEIQ_SERVICE_NAME
-            value: "${NAME}"
           resources:
             requests:
               memory: "${HTTPD_MEM_REQ}"


### PR DESCRIPTION
Updating manageiq-pods so that it defines an miq-sysadmin scc and service account for the container-httpd pod.

This is needed for running httpd under systemd, a requirement for enabling external authentication.