### PR TITLE
Add the ManageIQ copr repo to the app image

### DIFF
--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -25,6 +25,10 @@ LABEL name="manageiq" \
       io.k8s.description="ManageIQ is a management and automation platform for virtual, private, and hybrid cloud infrastructures." \
       io.openshift.tags="ManageIQ,miq,manageiq"
 
+# Fetch MIQ repo for http-parser
+RUN curl -sSLko /etc/yum.repos.d/manageiq-ManageIQ-Fine-epel-7.repo \
+      https://copr.fedorainfracloud.org/coprs/manageiq/ManageIQ-Fine/repo/epel-7/manageiq-ManageIQ-Fine-epel-7.repo
+
 ## Install EPEL repo, yum necessary packages for the build without docs, clean all caches
 RUN yum -y install centos-release-scl-rh && \
     yum -y install --setopt=tsflags=nodocs \


### PR DESCRIPTION
We need access to this repo to install the http-parser package which was removed from EPEL when RHEL 7.4 was released.

It will be available again when CentOS 7.4 is released, but that won't be for at least a few more weeks.

See https://bugzilla.redhat.com/show_bug.cgi?id=1481470 for more details

/cc @simaishi 