### PR TITLE
Add things to teardown

### DIFF
--- a/teardown
+++ b/teardown
@@ -11,3 +11,5 @@ oc delete secret -l app=manageiq-ext-db
 oc delete serviceaccount miq-anyuid
 oc delete serviceaccount miq-privileged
 oc delete serviceaccount miq-orchestrator
+
+oc delete cm postgresql-configs

--- a/teardown
+++ b/teardown
@@ -4,3 +4,5 @@ oc delete all -l app=manageiq
 oc get pvc -o name |xargs oc delete
 oc delete secret -l app=manageiq
 oc delete serviceaccount miq-anyuid
+oc delete serviceaccount miq-privileged
+oc delete serviceaccount miq-orchestrator

--- a/teardown
+++ b/teardown
@@ -1,8 +1,13 @@
 #!/bin/bash
 
 oc delete all -l app=manageiq
+oc delete all -l app=manageiq-ext-db
+
 oc get pvc -o name |xargs oc delete
+
 oc delete secret -l app=manageiq
+oc delete secret -l app=manageiq-ext-db
+
 oc delete serviceaccount miq-anyuid
 oc delete serviceaccount miq-privileged
 oc delete serviceaccount miq-orchestrator


### PR DESCRIPTION
Add external database app, more service accounts, and the PG config map to the teardown script.

With these changes you should get a "Success" message from `oc new-app` after running teardown.

Before, I would get a failure because the service accounts and config map already existed.