### PR TITLE
Enhancement to support the httpd authentication configuration map.

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,10 +627,7 @@ data:
     </EntityDescriptor>
 ```
 
-Support for automatically generating authentication configuration maps for _httpd_ will be provided by
-[ManageIQ/container-httpd-auth-config](https://github.com/ManageIQ/container-httpd-auth-config). Please see the [README.md](https://github.com/ManageIQ/container-httpd-auth-config/blob/master/README.md) in that repo for further details.
-
-The generated authentication configuration map can then be defined in the _httpd_ pod and further customized as follows:
+The authentication configuration map can be defined and customized in the _httpd_ pod as follows:
 
 ```bash
 $ oc edit configmaps httpd-auth-configs

--- a/README.md
+++ b/README.md
@@ -636,6 +636,6 @@ The generated authentication configuration map can then be defined in the _httpd
 $ oc edit configmaps httpd-auth-configs
 ```
 
-Then rebouncing the _httpd_ pod for the new authentication configuration to take effect.
+Then redeploy the _httpd_ pod for the new authentication configuration to take effect.
 
 

--- a/README.md
+++ b/README.md
@@ -543,15 +543,15 @@ $ oc new-app --template=manageiq \
 ```
 
 ## Configuring External Authentication
-Configuring the _httpd_ pod for external authentication is done by updating the _httpd-auth-configs_ configuration map to include all necessary config files and certificates. Upon startup, the _httpd_ pod overlays its files with the ones specified in the _auth-configuration.conf_ file in the configuration map. This is done by the _initialize-httpd-auth_ service that runs before _httpd_.
+Configuring the httpd pod for external authentication is done by updating the `httpd-auth-configs` configuration map to include all necessary config files and certificates. Upon startup, the httpd pod overlays its files with the ones specified in the `auth-configuration.conf` file in the configuration map. This is done by the `initialize-httpd-auth` service that runs before httpd.
 
 The config map includes the following:
 
-* The authentication type _auth-type_, default is _internal_
+* The authentication type `auth-type`, default is `internal`
 
-	_internal_ is the default type, anything else is considered external. _auth-type_ could include strings like: ipa, ldap, active_directory, saml or simply custom.
+	`internal` is the default type, anything else is considered external. `auth-type` could include strings like: ipa, ldap, active_directory, saml or simply custom.
 
-* The external authentication configuration file _auth-configuration.conf_ which declares the list of files to overlay upon startup if _auth-type_ is other than _internal_.
+* The external authentication configuration file `auth-configuration.conf` which declares the list of files to overlay upon startup if `auth-type` is other than `internal`.
 
 	Syntax for the file is as follows:
 
@@ -563,13 +563,13 @@ The config map includes the following:
 
 
 
-For the files to overlay on the _httpd_ pod, one _file_ directive is needed per file.
+For the files to overlay on the httpd pod, one `file` directive is needed per file.
 
-* the _basename_ is the name of the source file in the configuration map.
-* _target\_path_ is the path of the file on the pod to over_write, i.e. _/etc/sssd/sssd.conf_
-* _permission_ is optional, by default files are copied using the pod's default umask, owner and group, so files are created as mode 644 owner root, group root.
+* the `basename` is the name of the source file in the configuration map.
+* `target_path` is the path of the file on the pod to overwrite, i.e. `/etc/sssd/sssd.conf`
+* `permission` is optional, by default files are copied using the pod's default umask, owner and group, so files are created as mode 644 owner root, group root.
 
-optional _permission_ can be specified as follows:
+optional `permission` can be specified as follows:
 
 * mode
 * mode:owner
@@ -583,9 +583,9 @@ _Examples_:
 * 640:root
 * 644:root:apache
 
-Binary files can be specified in the configuration map in their base64 encoded format with a basename having a _.base64_ extension. Such files are then converted back to binary as they are copied to their target path.
+Binary files can be specified in the configuration map in their base64 encoded format with a basename having a `.base64` extension. Such files are then converted back to binary as they are copied to their target path.
 
-When an _/etc/sssd/sssd.conf_ file is included in the configuration map, the _httpd_ pod automatically enables the sssd service upon startup.
+When an /etc/sssd/sssd.conf file is included in the configuration map, the httpd pod automatically enables the sssd service upon startup.
 
 ### Sample external authentication configuration:
 
@@ -629,12 +629,12 @@ data:
     </EntityDescriptor>
 ```
 
-The authentication configuration map can be defined and customized in the _httpd_ pod as follows:
+The authentication configuration map can be defined and customized in the httpd pod as follows:
 
 ```bash
 $ oc edit configmaps httpd-auth-configs
 ```
 
-Then redeploy the _httpd_ pod for the new authentication configuration to take effect.
+Then redeploy the httpd pod for the new authentication configuration to take effect.
 
 

--- a/teardown
+++ b/teardown
@@ -15,3 +15,4 @@ oc delete serviceaccount miq-sysadmin
 
 oc delete cm postgresql-configs
 oc delete cm httpd-configs
+oc delete cm httpd-auth-configs

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -494,11 +494,11 @@ objects:
   metadata:
     name: "${HTTPD_SERVICE_NAME}-auth-configs"
   data:
+    auth-type: internal
     auth-configuration.conf: |
       # External Authentication Configuration File
       #
       # For details on usage please see https://github.com/ManageIQ/manageiq-pods/blob/master/README.md
-      type = internal
 - apiVersion: v1
   kind: Service
   metadata:
@@ -578,6 +578,17 @@ objects:
               cpu: "${HTTPD_CPU_REQ}"
             limits:
               memory: "${HTTPD_MEM_LIMIT}"
+          env:
+          - name: HTTPD_AUTH_TYPE
+            valueFrom:
+              configMapKeyRef:
+                name: "${HTTPD_SERVICE_NAME}-auth-configs"
+                key: auth-type
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - "/usr/bin/entrypoint"
         serviceAccount: miq-sysadmin
         serviceAccountName: miq-sysadmin
 parameters:

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -498,7 +498,7 @@ objects:
     auth-configuration.conf: |
       # External Authentication Configuration File
       #
-      # For details on usage please see https://github.com/ManageIQ/manageiq-pods/blob/master/README.md
+      # For details on usage please see https://github.com/ManageIQ/manageiq-pods/blob/master/README.md#configuring-external-authentication
 - apiVersion: v1
   kind: Service
   metadata:

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -490,6 +490,34 @@ objects:
         ProxyPassReverse / http://${NAME}/
       </VirtualHost>
 - apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: "${HTTPD_SERVICE_NAME}-auth-configs"
+  data:
+    auth-configuration.conf: |
+      #
+      # External Authentication Configuration File
+      #
+      # This file declares the following:
+      #
+      #   The Authentication type, default is internal.
+      #     syntax:  type = internal
+      #
+      #     - other types could include: ipa, ldap, active_directory, saml or simply custom.
+      #
+      #   The list of files to overlay in order to enable external authentication
+      #     syntax:  file = basename target_path mode:owner:group
+      #
+      #     - basename is the name of the file in the config map.
+      #     - target_path is the path of the file to overwrite, i.e. /etc/sssd/sssd.conf
+      #     - mode:owner:group is optional and reflects the mode and ownership to set the file to.
+      #       i.e.  644:root:apache
+      #             755
+      #     - if basename has the .base64 extension, then the file is binary and will be converted
+      #       from its base64 representation in the Config Map before copied to its target_path.
+      #
+      type = internal
+- apiVersion: v1
   kind: Service
   metadata:
     name: "${HTTPD_SERVICE_NAME}"
@@ -537,6 +565,9 @@ objects:
         - name: httpd-config
           configMap:
             name: "${HTTPD_SERVICE_NAME}-configs"
+        - name: httpd-auth-config
+          configMap:
+            name: "${HTTPD_SERVICE_NAME}-auth-configs"
         containers:
         - name: httpd
           image: "${HTTPD_IMG_NAME}:${HTTPD_IMG_TAG}"
@@ -557,6 +588,8 @@ objects:
           volumeMounts:
           - name: httpd-config
             mountPath: "${HTTPD_CONFIG_DIR}"
+          - name: httpd-auth-config
+            mountPath: "${HTTPD_AUTH_CONFIG_DIR}"
           resources:
             requests:
               memory: "${HTTPD_MEM_REQ}"
@@ -770,6 +803,10 @@ parameters:
   displayName: Apache httpd Configuration Directory
   description: Directory used to store the Apache configuration files.
   value: "/etc/httpd/conf.d"
+- name: HTTPD_AUTH_CONFIG_DIR
+  displayName: External Authentication Configuration Directory
+  description: Directory used to store the exxternal authentication configuration files.
+  value: "/etc/httpd/auth-conf.d"
 - name: HTTPD_CPU_REQ
   displayName: Apache httpd Min CPU Requested
   required: true

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -588,7 +588,7 @@ objects:
             postStart:
               exec:
                 command:
-                - "/usr/bin/entrypoint"
+                - "/usr/bin/save-container-environment"
         serviceAccount: miq-sysadmin
         serviceAccountName: miq-sysadmin
 parameters:

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -495,27 +495,9 @@ objects:
     name: "${HTTPD_SERVICE_NAME}-auth-configs"
   data:
     auth-configuration.conf: |
-      #
       # External Authentication Configuration File
       #
-      # This file declares the following:
-      #
-      #   The Authentication type, default is internal.
-      #     syntax:  type = internal
-      #
-      #     - other types could include: ipa, ldap, active_directory, saml or simply custom.
-      #
-      #   The list of files to overlay in order to enable external authentication
-      #     syntax:  file = basename target_path mode:owner:group
-      #
-      #     - basename is the name of the file in the config map.
-      #     - target_path is the path of the file to overwrite, i.e. /etc/sssd/sssd.conf
-      #     - mode:owner:group is optional and reflects the mode and ownership to set the file to.
-      #       i.e.  644:root:apache
-      #             755
-      #     - if basename has the .base64 extension, then the file is binary and will be converted
-      #       from its base64 representation in the Config Map before copied to its target_path.
-      #
+      # For details on usage please see https://github.com/ManageIQ/manageiq-pods/blob/master/README.md
       type = internal
 - apiVersion: v1
   kind: Service

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -787,7 +787,7 @@ parameters:
   value: "/etc/httpd/conf.d"
 - name: HTTPD_AUTH_CONFIG_DIR
   displayName: External Authentication Configuration Directory
-  description: Directory used to store the exxternal authentication configuration files.
+  description: Directory used to store the external authentication configuration files.
   value: "/etc/httpd/auth-conf.d"
 - name: HTTPD_CPU_REQ
   displayName: Apache httpd Min CPU Requested

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -980,7 +980,7 @@ parameters:
   value: "/etc/httpd/conf.d"
 - name: HTTPD_AUTH_CONFIG_DIR
   displayName: External Authentication Configuration Directory
-  description: Directory used to store the exxternal authentication configuration files.
+  description: Directory used to store the external authentication configuration files.
   value: "/etc/httpd/auth-conf.d"
 - name: HTTPD_CPU_REQ
   displayName: Apache httpd Min CPU Requested

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -138,27 +138,9 @@ objects:
     name: "${HTTPD_SERVICE_NAME}-auth-configs"
   data:
     auth-configuration.conf: |
-      #
       # External Authentication Configuration File
       #
-      # This file declares the following:
-      #
-      #   The Authentication type, default is internal.
-      #     syntax:  type = internal
-      #
-      #     - other types could include: ipa, ldap, active_directory, saml or simply custom.
-      #
-      #   The list of files to overlay in order to enable external authentication
-      #     syntax:  file = basename target_path mode:owner:group
-      #
-      #     - basename is the name of the file in the config map.
-      #     - target_path is the path of the file to overwrite, i.e. /etc/sssd/sssd.conf
-      #     - mode:owner:group is optional and reflects the mode and ownership to set the file to.
-      #       i.e.  644:root:apache
-      #             755
-      #     - if basename has the .base64 extension, then the file is binary and will be converted
-      #       from its base64 representation in the Config Map before copied to its target_path.
-      #
+      # For details on usage please see https://github.com/ManageIQ/manageiq-pods/blob/master/README.md
       type = internal
 - apiVersion: v1
   kind: Service

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -141,7 +141,7 @@ objects:
     auth-configuration.conf: |
       # External Authentication Configuration File
       #
-      # For details on usage please see https://github.com/ManageIQ/manageiq-pods/blob/master/README.md
+      # For details on usage please see https://github.com/ManageIQ/manageiq-pods/blob/master/README.md#configuring-external-authentication
 - apiVersion: v1
   kind: Service
   metadata:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -751,7 +751,7 @@ objects:
             postStart:
               exec:
                 command:
-                - "/usr/bin/entrypoint"
+                - "/usr/bin/save-container-environment"
         serviceAccount: miq-sysadmin
         serviceAccountName: miq-sysadmin
 parameters:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -133,6 +133,34 @@ objects:
         ProxyPassReverse / http://${NAME}/
       </VirtualHost>
 - apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: "${HTTPD_SERVICE_NAME}-auth-configs"
+  data:
+    auth-configuration.conf: |
+      #
+      # External Authentication Configuration File
+      #
+      # This file declares the following:
+      #
+      #   The Authentication type, default is internal.
+      #     syntax:  type = internal
+      #
+      #     - other types could include: ipa, ldap, active_directory, saml or simply custom.
+      #
+      #   The list of files to overlay in order to enable external authentication
+      #     syntax:  file = basename target_path mode:owner:group
+      #
+      #     - basename is the name of the file in the config map.
+      #     - target_path is the path of the file to overwrite, i.e. /etc/sssd/sssd.conf
+      #     - mode:owner:group is optional and reflects the mode and ownership to set the file to.
+      #       i.e.  644:root:apache
+      #             755
+      #     - if basename has the .base64 extension, then the file is binary and will be converted
+      #       from its base64 representation in the Config Map before copied to its target_path.
+      #
+      type = internal
+- apiVersion: v1
   kind: Service
   metadata:
     annotations:
@@ -700,6 +728,9 @@ objects:
         - name: httpd-config
           configMap:
             name: "${HTTPD_SERVICE_NAME}-configs"
+        - name: httpd-auth-config
+          configMap:
+            name: "${HTTPD_SERVICE_NAME}-auth-configs"
         containers:
         - name: httpd
           image: "${HTTPD_IMG_NAME}:${HTTPD_IMG_TAG}"
@@ -720,6 +751,8 @@ objects:
           volumeMounts:
           - name: httpd-config
             mountPath: "${HTTPD_CONFIG_DIR}"
+          - name: httpd-auth-config
+            mountPath: "${HTTPD_AUTH_CONFIG_DIR}"
           resources:
             requests:
               memory: "${HTTPD_MEM_REQ}"
@@ -963,6 +996,10 @@ parameters:
   displayName: Apache Configuration Directory
   description: Directory used to store the Apache configuration files.
   value: "/etc/httpd/conf.d"
+- name: HTTPD_AUTH_CONFIG_DIR
+  displayName: External Authentication Configuration Directory
+  description: Directory used to store the exxternal authentication configuration files.
+  value: "/etc/httpd/auth-conf.d"
 - name: HTTPD_CPU_REQ
   displayName: Apache httpd Min CPU Requested
   required: true

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -137,11 +137,11 @@ objects:
   metadata:
     name: "${HTTPD_SERVICE_NAME}-auth-configs"
   data:
+    auth-type: internal
     auth-configuration.conf: |
       # External Authentication Configuration File
       #
       # For details on usage please see https://github.com/ManageIQ/manageiq-pods/blob/master/README.md
-      type = internal
 - apiVersion: v1
   kind: Service
   metadata:
@@ -741,6 +741,17 @@ objects:
               cpu: "${HTTPD_CPU_REQ}"
             limits:
               memory: "${HTTPD_MEM_LIMIT}"
+          env:
+          - name: HTTPD_AUTH_TYPE
+            valueFrom:
+              configMapKeyRef:
+                name: "${HTTPD_SERVICE_NAME}-auth-configs"
+                key: auth-type
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - "/usr/bin/entrypoint"
         serviceAccount: miq-sysadmin
         serviceAccountName: miq-sysadmin
 parameters:


### PR DESCRIPTION
- Added new httpd-auth-configs config map to the templates
- mounted the new configmap for httpd pod as /etc/httpd/auth-conf.d
- updated teardown script to handle the new config map