### PR TITLE
Added support for the httpd auth-api service

### DIFF
--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -483,8 +483,8 @@ objects:
   spec:
     ports:
     - name: http-auth-api
-      port: 3301
-      targetPort: 3301
+      port: 8080
+      targetPort: 8080
     selector:
       name: httpd
 - apiVersion: v1
@@ -522,7 +522,7 @@ objects:
           ports:
           - containerPort: 80
             protocol: TCP
-          - containerPort: 3301
+          - containerPort: 8080
             protocol: TCP
           livenessProbe:
             tcpSocket:

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -521,6 +521,9 @@ objects:
           image: "${HTTPD_IMG_NAME}:${HTTPD_IMG_TAG}"
           ports:
           - containerPort: 80
+            protocol: TCP
+          - containerPort: 3301
+            protocol: TCP
           livenessProbe:
             tcpSocket:
               port: 80

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -474,6 +474,20 @@ objects:
     selector:
       name: httpd
 - apiVersion: v1
+  kind: Service
+  metadata:
+    name: "${HTTPD_AUTH_API_SERVICE_NAME}"
+    annotations:
+      description: Exposes the httpd server authentication api
+      service.alpha.openshift.io/dependencies: '[{"name":"${NAME}","namespace":"","kind":"Service"}]'
+  spec:
+    ports:
+    - name: http-auth-api
+      port: 3301
+      targetPort: 3301
+    selector:
+      name: httpd
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     name: "${HTTPD_SERVICE_NAME}"
@@ -736,6 +750,11 @@ parameters:
   displayName: Apache httpd Service Name
   description: The name of the OpenShift Service exposed for the httpd container.
   value: httpd
+- name: HTTPD_AUTH_API_SERVICE_NAME
+  required: true
+  displayName: Apache httpd Authentication API Service Name
+  description: The name of httpd authentication api service.
+  value: httpd-auth-api
 - name: HTTPD_IMG_NAME
   displayName: Apache httpd Image Name
   description: This is the httpd image name requested to deploy.

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -630,8 +630,8 @@ objects:
   spec:
     ports:
     - name: http-auth-api
-      port: 3301
-      targetPort: 3301
+      port: 8080
+      targetPort: 8080
     selector:
       name: httpd
 - apiVersion: v1
@@ -669,7 +669,7 @@ objects:
           ports:
           - containerPort: 80
             protocol: TCP
-          - containerPort: 3301
+          - containerPort: 8080
             protocol: TCP
           livenessProbe:
             tcpSocket:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -668,6 +668,9 @@ objects:
           image: "${HTTPD_IMG_NAME}:${HTTPD_IMG_TAG}"
           ports:
           - containerPort: 80
+            protocol: TCP
+          - containerPort: 3301
+            protocol: TCP
           livenessProbe:
             tcpSocket:
               port: 80

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -621,6 +621,20 @@ objects:
     selector:
       name: httpd
 - apiVersion: v1
+  kind: Service
+  metadata:
+    name: "${HTTPD_AUTH_API_SERVICE_NAME}"
+    annotations:
+      description: Exposes the httpd server authentication api
+      service.alpha.openshift.io/dependencies: '[{"name":"${NAME}","namespace":"","kind":"Service"}]'
+  spec:
+    ports:
+    - name: http-auth-api
+      port: 3301
+      targetPort: 3301
+    selector:
+      name: httpd
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     name: "${HTTPD_SERVICE_NAME}"
@@ -913,6 +927,11 @@ parameters:
   displayName: Apache httpd Service Name
   description: The name of the OpenShift Service exposed for the httpd container.
   value: httpd
+- name: HTTPD_AUTH_API_SERVICE_NAME
+  required: true
+  displayName: Apache httpd Authentication API Service Name
+  description: The name of httpd authentication api service.
+  value: httpd-auth-api
 - name: HTTPD_IMG_NAME
   displayName: Apache httpd Image Name
   description: This is the httpd image name requested to deploy.


### PR DESCRIPTION
- Declared an HTTPD_AUTH_API service
- This provides us with HTTPD_AUTH_API_SERVICE_HOST and HTTPD_AUTH_API_SERVICE_PORT on all pods.

Related PRs:
- [ManageIQ/manageiq-pods PR# 204](https://github.com/ManageIQ/manageiq-pods/pull/204)
- [ManageIQ/container-httpd PR# 15](https://github.com/ManageIQ/container-httpd/pull/15)
- [ManageIQ/manageiq PR# 15881](https://github.com/ManageIQ/manageiq/pull/15881)
