### PR TITLE
Remove IS and imagechange trigger from templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,21 +159,6 @@ miq-pv02   5Gi         RWO           Recycle         Available                  
 
 It is strongly suggested that you validate NFS share connectivity from an OpenShift node prior attemping a deployment.
 
-### Increase maximum number of imported images on ImageStream
-
-By default OpenShift will import 5 images per ImageStream, we build and use more than 5 images in our repos for MIQ deployments.
-
-You can modify these settings on the master node at `/etc/origin/master/master-config.yaml`, add the following at the end of the file and re-start the master service:
-
-```yaml
-...
-imagePolicyConfig:
-  maxImagesBulkImportedPerRepository: 100
-```
-```bash
-$ systemctl restart atomic-openshift-master
-```
-
 ## Deploy MIQ
 
 Create the MIQ template for deployment and verify it is now available in your project

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -71,30 +71,6 @@ objects:
     to:
       kind: Service
       name: "${HTTPD_SERVICE_NAME}"
-- apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: miq-app
-    annotations:
-      description: Keeps track of the ManageIQ image changes
-  spec:
-    dockerImageRepository: "${APPLICATION_IMG_NAME}"
-- apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: memcached
-    annotations:
-      description: Keeps track of the Memcached image changes
-  spec:
-    dockerImageRepository: "${MEMCACHED_IMG_NAME}"
-- apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: ansible
-    annotations:
-      description: Keeps track of the Ansible image changes
-  spec:
-    dockerImageRepository: "${ANSIBLE_IMG_NAME}"
 - apiVersion: apps/v1beta1
   kind: StatefulSet
   metadata:
@@ -298,14 +274,6 @@ objects:
     strategy:
       type: Recreate
     triggers:
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-        - memcached
-        from:
-          kind: ImageStreamTag
-          name: memcached:${MEMCACHED_IMG_TAG}
     - type: ConfigChange
     replicas: 1
     selector:
@@ -464,14 +432,6 @@ objects:
         serviceAccount: miq-privileged
         serviceAccountName: miq-privileged
 - apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: httpd
-    annotations:
-      description: Keeps track of the httpd image changes
-  spec:
-    dockerImageRepository: "${HTTPD_IMG_NAME}"
-- apiVersion: v1
   kind: ConfigMap
   metadata:
     name: "${HTTPD_SERVICE_NAME}-configs"
@@ -515,14 +475,6 @@ objects:
       recreateParams:
         timeoutSeconds: 1200
     triggers:
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-        - httpd
-        from:
-          kind: ImageStreamTag
-          name: httpd:${HTTPD_IMG_TAG}
     - type: ConfigChange
     replicas: 1
     selector:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -163,38 +163,6 @@ objects:
       kind: Service
       name: "${HTTPD_SERVICE_NAME}"
 - apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: miq-app
-    annotations:
-      description: Keeps track of the ManageIQ image changes
-  spec:
-    dockerImageRepository: "${APPLICATION_IMG_NAME}"
-- apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: postgresql
-    annotations:
-      description: Keeps track of the PostgreSQL image changes
-  spec:
-    dockerImageRepository: "${POSTGRESQL_IMG_NAME}"
-- apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: memcached
-    annotations:
-      description: Keeps track of the Memcached image changes
-  spec:
-    dockerImageRepository: "${MEMCACHED_IMG_NAME}"
-- apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: ansible
-    annotations:
-      description: Keeps track of the Ansible image changes
-  spec:
-    dockerImageRepository: "${ANSIBLE_IMG_NAME}"
-- apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     name: "${NAME}-${DATABASE_SERVICE_NAME}"
@@ -407,14 +375,6 @@ objects:
     strategy:
       type: Recreate
     triggers:
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-        - memcached
-        from:
-          kind: ImageStreamTag
-          name: memcached:${MEMCACHED_IMG_TAG}
     - type: ConfigChange
     replicas: 1
     selector:
@@ -478,14 +438,6 @@ objects:
     strategy:
       type: Recreate
     triggers:
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-        - postgresql
-        from:
-          kind: ImageStreamTag
-          name: postgresql:${POSTGRESQL_IMG_TAG}
     - type: ConfigChange
     replicas: 1
     selector:
@@ -645,14 +597,6 @@ objects:
         serviceAccount: miq-privileged
         serviceAccountName: miq-privileged
 - apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: httpd
-    annotations:
-      description: Keeps track of the httpd image changes
-  spec:
-    dockerImageRepository: "${HTTPD_IMG_NAME}"
-- apiVersion: v1
   kind: Service
   metadata:
     name: "${HTTPD_SERVICE_NAME}"
@@ -678,14 +622,6 @@ objects:
       recreateParams:
         timeoutSeconds: 1200
     triggers:
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-        - httpd
-        from:
-          kind: ImageStreamTag
-          name: httpd:${HTTPD_IMG_TAG}
     - type: ConfigChange
     replicas: 1
     selector:


### PR DESCRIPTION
@carbonin @bdunne @simon3z @mberube9 Removes the IS objects and related triggers from deployment configs. Some of controllers/deployments were not affected since they either don't currently use them or don't support them (i.e statefulsets). With the following changes image pulls will start immediately without trigger intervention. 

We never took much advantage of what IS can give us, specially considering they were configured with external docker repositories by default without actively tracking changes.

This resolves the long standing and very intrusive master node config change for maxImagesBulkImportedPerRepository.

Related issues :  #191 and https://github.com/openshift/openshift-ansible/issues/4822
