### PR TITLE
Create separate reverse proxying for websocket connections

### DIFF
--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -446,6 +446,8 @@ objects:
       <VirtualHost *:80>
         KeepAlive on
         ProxyPreserveHost on
+        ProxyPass        /ws/ ws://${NAME}/ws/
+        ProxyPassReverse /ws/ ws://${NAME}/ws/
         ProxyPass        / http://${NAME}/
         ProxyPassReverse / http://${NAME}/
       </VirtualHost>

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -129,6 +129,8 @@ objects:
       <VirtualHost *:80>
         KeepAlive on
         ProxyPreserveHost on
+        ProxyPass        /ws/ ws://${NAME}/ws/
+        ProxyPassReverse /ws/ ws://${NAME}/ws/
         ProxyPass        / http://${NAME}/
         ProxyPassReverse / http://${NAME}/
       </VirtualHost>


### PR DESCRIPTION
While experimenting with redis-backed actioncable I found out that websockets aren't working at all because the configuration of the HTTPD pod's configuration.