### PR TITLE
[REARCH] Use a redis container for handling actioncable pubsub

### DIFF
--- a/images/miq-app/docker-assets/appliance-initialize.sh
+++ b/images/miq-app/docker-assets/appliance-initialize.sh
@@ -13,6 +13,8 @@ prepare_init_env
 
 write_v2_key
 
+write_cable_yml
+
 restore_pv_data
 
 cd ${APP_ROOT}

--- a/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
+++ b/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
@@ -29,6 +29,15 @@ function write_v2_key() {
 KEY
 }
 
+function write_cable_yml() {
+  echo "== Writing ActionCable config =="
+  cat > /var/www/miq/vmdb/config/cable.yml << CABLE
+production:
+  adapter: redis
+  url: redis://${REDIS_SERVER}
+CABLE
+}
+
 # Check service status, requires two arguments: SVC name and SVC port (injected via template)
 function check_svc_status() {
   NCAT="$(which ncat)"

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -46,7 +46,7 @@ objects:
   metadata:
     annotations:
       description: Exposes and load balances ManageIQ pods
-      service.alpha.openshift.io/dependencies: '[{"name":"${DATABASE_SERVICE_NAME}","namespace":"","kind":"Service"},{"name":"${MEMCACHED_SERVICE_NAME}","namespace":"","kind":"Service"}]'
+      service.alpha.openshift.io/dependencies: '[{"name":"${DATABASE_SERVICE_NAME}","namespace":"","kind":"Service"},{"name":"${MEMCACHED_SERVICE_NAME}","namespace":"","kind":"Service"},{"name":"${REDIS_SERVICE_NAME}","namespace":"","kind":"Service"}]'
     name: "${NAME}"
   spec:
     clusterIP: None
@@ -127,6 +127,10 @@ objects:
             value: "${MEMCACHED_SERVICE_NAME}:11211"
           - name: MEMCACHED_SERVICE_NAME
             value: "${MEMCACHED_SERVICE_NAME}"
+          - name: REDIS_SERVER
+            value: "${REDIS_SERVICE_NAME}:6379"
+          - name: REDIS_SERVICE_NAME
+            value: "${REDIS_SERVICE_NAME}"
           - name: V2_KEY
             valueFrom:
               secretKeyRef:
@@ -215,6 +219,8 @@ objects:
             value: "${NAME}"
           - name: MEMCACHED_SERVER
             value: "${MEMCACHED_SERVICE_NAME}:11211"
+          - name: REDIS_SERVER
+            value: "${REDIS_SERVICE_NAME}:6379"
           - name: V2_KEY
             valueFrom:
               secretKeyRef:
@@ -314,6 +320,63 @@ objects:
               cpu: "${MEMCACHED_CPU_REQ}"
             limits:
               memory: "${MEMCACHED_MEM_LIMIT}"
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: "${REDIS_SERVICE_NAME}"
+    annotations:
+      description: Exposes the redis server
+  spec:
+    ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+    selector:
+      name: "${REDIS_SERVICE_NAME}"
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    name: "${REDIS_SERVICE_NAME}"
+    annotations:
+      description: Defines how to deploy redis
+  spec:
+    strategy:
+      type: Recreate
+    triggers:
+    - type: ConfigChange
+    replicas: 1
+    selector:
+      name: "${REDIS_SERVICE_NAME}"
+    template:
+      metadata:
+        name: "${REDIS_SERVICE_NAME}"
+        labels:
+          name: "${REDIS_SERVICE_NAME}"
+      spec:
+        volumes: []
+        containers:
+        - name: redis
+          image: "${REDIS_IMG_NAME}:${REDIS_IMG_TAG}"
+          ports:
+          - containerPort: 6379
+          readinessProbe:
+            timeoutSeconds: 1
+            initialDelaySeconds: 5
+            tcpSocket:
+              port: 6379
+          livenessProbe:
+            timeoutSeconds: 1
+            initialDelaySeconds: 30
+            tcpSocket:
+              port: 6379
+          volumeMounts: []
+          env:
+          resources:
+            requests:
+              memory: "${REDIS_MEM_REQ}"
+              cpu: "${REDIS_CPU_REQ}"
+            limits:
+              memory: "${REDIS_MEM_LIMIT}"
 - apiVersion: v1
   kind: Service
   metadata:
@@ -613,6 +676,11 @@ parameters:
   displayName: Memcached Slab Page Size
   description: Memcached size of each slab page.
   value: 1m
+- name: REDIS_SERVICE_NAME
+  required: true
+  displayName: Redis Service Name
+  description: The name of the OpenShift Service exposed for the Redis container.
+  value: redis
 - name: ANSIBLE_SERVICE_NAME
   displayName: Ansible Service Name
   description: The name of the OpenShift Service exposed for the Ansible container.
@@ -650,6 +718,11 @@ parameters:
   required: true
   description: Minimum amount of CPU time the Memcached container will need (expressed in millicores).
   value: 200m
+- name: REDIS_CPU_REQ
+  displayName: Redis Min CPU Requested
+  required: true
+  description: Minimum amount of CPU time the Redis container will need (expressed in millicores).
+  value: 200m
 - name: ANSIBLE_CPU_REQ
   displayName: Ansible Min CPU Requested
   required: true
@@ -664,6 +737,11 @@ parameters:
   displayName: Memcached Min RAM Requested
   required: true
   description: Minimum amount of memory the Memcached container will need.
+  value: 64Mi
+- name: REDIS_MEM_REQ
+  displayName: Redis Min RAM Requested
+  required: true
+  description: Minimum amount of memory the Redis container will need.
   value: 64Mi
 - name: ANSIBLE_MEM_REQ
   displayName: Ansible Min RAM Requested
@@ -680,6 +758,10 @@ parameters:
   required: true
   description: Maximum amount of memory the Memcached container can consume.
   value: 256Mi
+- name: REDIS_MEM_LIMIT
+  displayName: Redis Max RAM Limit
+  required: true
+  description: Maximum amount of memory the Redis container can consume.
 - name: ANSIBLE_MEM_LIMIT
   displayName: Ansible Max RAM Limit
   required: true
@@ -692,6 +774,14 @@ parameters:
 - name: MEMCACHED_IMG_TAG
   displayName: Memcached Image Tag
   description: This is the Memcached image tag/version requested to deploy.
+  value: latest
+- name: REDIS_IMG_NAME
+  displayName: Redis Image Name
+  description: This is the Redis image name requested to deploy.
+  value: docker.io/redis
+- name: REDIS_IMG_TAG
+  displayName: Redis Image Tag
+  description: This is the Redis image tag/version requested to deploy.
   value: latest
 - name: APPLICATION_IMG_NAME
   displayName: Application Image Name

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -147,7 +147,7 @@ objects:
   metadata:
     annotations:
       description: Exposes and load balances ManageIQ pods
-      service.alpha.openshift.io/dependencies: '[{"name":"${DATABASE_SERVICE_NAME}","namespace":"","kind":"Service"},{"name":"${MEMCACHED_SERVICE_NAME}","namespace":"","kind":"Service"}]'
+      service.alpha.openshift.io/dependencies: '[{"name":"${DATABASE_SERVICE_NAME}","namespace":"","kind":"Service"},{"name":"${MEMCACHED_SERVICE_NAME}","namespace":"","kind":"Service"},{"name":"${REDIS_SERVICE_NAME}","namespace":"","kind":"Service"}]'
     name: "${NAME}"
   spec:
     clusterIP: None
@@ -238,6 +238,10 @@ objects:
             value: "${MEMCACHED_SERVICE_NAME}:11211"
           - name: MEMCACHED_SERVICE_NAME
             value: "${MEMCACHED_SERVICE_NAME}"
+          - name: REDIS_SERVER
+            value: "${REDIS_SERVICE_NAME}:6379"
+          - name: REDIS_SERVICE_NAME
+            value: "${REDIS_SERVICE_NAME}"
           - name: V2_KEY
             valueFrom:
               secretKeyRef:
@@ -326,6 +330,8 @@ objects:
             value: "${NAME}"
           - name: MEMCACHED_SERVER
             value: "${MEMCACHED_SERVICE_NAME}:11211"
+          - name: REDIS_SERVER
+            value: "${REDIS_SERVICE_NAME}:6379"
           - name: V2_KEY
             valueFrom:
               secretKeyRef:
@@ -425,6 +431,63 @@ objects:
               cpu: "${MEMCACHED_CPU_REQ}"
             limits:
               memory: "${MEMCACHED_MEM_LIMIT}"
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: "${REDIS_SERVICE_NAME}"
+    annotations:
+      description: Exposes the redis server
+  spec:
+    ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+    selector:
+      name: "${REDIS_SERVICE_NAME}"
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    name: "${REDIS_SERVICE_NAME}"
+    annotations:
+      description: Defines how to deploy redis
+  spec:
+    strategy:
+      type: Recreate
+    triggers:
+    - type: ConfigChange
+    replicas: 1
+    selector:
+      name: "${REDIS_SERVICE_NAME}"
+    template:
+      metadata:
+        name: "${REDIS_SERVICE_NAME}"
+        labels:
+          name: "${REDIS_SERVICE_NAME}"
+      spec:
+        volumes: []
+        containers:
+        - name: redis
+          image: "${REDIS_IMG_NAME}:${REDIS_IMG_TAG}"
+          ports:
+          - containerPort: 6379
+          readinessProbe:
+            timeoutSeconds: 1
+            initialDelaySeconds: 5
+            tcpSocket:
+              port: 6379
+          livenessProbe:
+            timeoutSeconds: 1
+            initialDelaySeconds: 30
+            tcpSocket:
+              port: 6379
+          volumeMounts: []
+          env:
+          resources:
+            requests:
+              memory: "${REDIS_MEM_REQ}"
+              cpu: "${REDIS_CPU_REQ}"
+            limits:
+              memory: "${REDIS_MEM_LIMIT}"
 - apiVersion: v1
   kind: Service
   metadata:
@@ -750,6 +813,11 @@ parameters:
   displayName: Memcached Slab Page Size
   description: Memcached size of each slab page.
   value: 1m
+- name: REDIS_SERVICE_NAME
+  required: true
+  displayName: Redis Service Name
+  description: The name of the OpenShift Service exposed for the Redis container.
+  value: redis
 - name: POSTGRESQL_CONFIG_DIR
   displayName: PostgreSQL Configuration Overrides
   description: Directory used to store PostgreSQL configuration overrides.
@@ -804,6 +872,11 @@ parameters:
   required: true
   description: Minimum amount of CPU time the Memcached container will need (expressed in millicores).
   value: 200m
+- name: REDIS_CPU_REQ
+  displayName: Redis Min CPU Requested
+  required: true
+  description: Minimum amount of CPU time the Redis container will need (expressed in millicores).
+  value: 200m
 - name: ANSIBLE_CPU_REQ
   displayName: Ansible Min CPU Requested
   required: true
@@ -823,6 +896,11 @@ parameters:
   displayName: Memcached Min RAM Requested
   required: true
   description: Minimum amount of memory the Memcached container will need.
+  value: 64Mi
+- name: REDIS_MEM_REQ
+  displayName: Redis Min RAM Requested
+  required: true
+  description: Minimum amount of memory the Redis container will need.
   value: 64Mi
 - name: ANSIBLE_MEM_REQ
   displayName: Ansible Min RAM Requested
@@ -844,6 +922,11 @@ parameters:
   required: true
   description: Maximum amount of memory the Memcached container can consume.
   value: 256Mi
+- name: REDIS_MEM_LIMIT
+  displayName: Redis Max RAM Limit
+  required: true
+  description: Maximum amount of memory the Redis container can consume.
+  value: 256Mi
 - name: ANSIBLE_MEM_LIMIT
   displayName: Ansible Max RAM Limit
   required: true
@@ -864,6 +947,14 @@ parameters:
 - name: MEMCACHED_IMG_TAG
   displayName: Memcached Image Tag
   description: This is the Memcached image tag/version requested to deploy.
+  value: latest
+- name: REDIS_IMG_NAME
+  displayName: Redis Image Name
+  description: This is the Redis image name requested to deploy.
+  value: docker.io/redis
+- name: REDIS_IMG_TAG
+  displayName: Redis Image Tag
+  description: This is the Redis image tag/version requested to deploy.
   value: latest
 - name: APPLICATION_IMG_NAME
   displayName: Application Image Name


### PR DESCRIPTION
Redis is the default pubsub backend for ActionCable and it handles persistent blocking connections way better than postgresql. I created a new pod from the official [`redis`](https://hub.docker.com/r/_/redis/) container available from Docker hub. We might want to create our own container in the fututre for having more configuration options, but I was not sure if I can do it if the package is available in [EPEL only](https://dl.fedoraproject.org/pub/epel/7/x86_64/r/).

I created a new function in the container deployment script for altering the `config/cable.yml`, maybe not the nicest solution but [I was told](https://gitter.im/ManageIQ/rearch?at=599c5137bc46472974aebe63) that I should take a look at how we are dealing with the `v2-key`.

For testing you will need to build custom `frontend` and `backend` container images with the changes in the PR and with https://github.com/ManageIQ/manageiq-pods/pull/208 and https://github.com/ManageIQ/manageiq/pull/15912. Or you can use the ones [built by me](https://hub.docker.com/r/skateman/manageiq-pods/). 