### PR TITLE
Adding external authentication httpd configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ The config map includes the following:
 
 * The httpd configuration type `auth-configuration`, default is `internal`
 
-	This parameter drive which configuration files httpd will load upon start-up. Supported values are:
+	This parameter drives which configuration files httpd will load upon start-up. Supported values are:
 
 
 	| Value    | External-Authentication Configuration |
@@ -585,9 +585,11 @@ The config map includes the following:
 	| active-directory | Active Directory domain realm join
 	| saml | SAML based authentication (Keycloak, etc.)
 
-* The kerberos realms joined `auth-kerberos-realms`, default is `undefined`
+* The kerberos realms to join `auth-kerberos-realms`, default is `undefined`
 
 	When configuring external authentication against IPA, Active Directory or Ldap, this parameter defines the kerberos realm httpd is configured against, i.e. `example.com`
+
+	When specifying multiple Kerberos realms, they need to be space separated.
 
 * The external authentication configuration file `auth-configuration.conf` which declares the list of files to overlay upon startup if `auth-type` is other than `internal`.
 
@@ -622,6 +624,8 @@ _Examples_:
 * 644:root:apache
 
 Binary files can be specified in the configuration map in their base64 encoded format with a basename having a `.base64` extension. Such files are then converted back to binary as they are copied to their target path.
+
+When an /etc/sssd/sssd.conf file is included in the configuration map, the httpd pod automatically enables the sssd service upon startup.
 
 ### Auth-type and auth-configuration specification matrix in a configmap:
 

--- a/README.md
+++ b/README.md
@@ -623,6 +623,19 @@ _Examples_:
 
 Binary files can be specified in the configuration map in their base64 encoded format with a basename having a `.base64` extension. Such files are then converted back to binary as they are copied to their target path.
 
+### Auth-type and auth-configuration specification matrix in a configmap:
+
+* auth-type depicts the Identity Provider external authentication is being configured against.
+* auth-configuration identifies which Httpd external authentication configuration files to load.
+
+| auth-type | auth-configuration | Note |
+|-----------|--------------------|------|
+| internal  | internal           | Database / ManageIQ Ldap(s) / Amazon    |
+| ldap      | external           |     |
+| ipa       | external           |     |
+| active-directory | external | Configured against AD via SSSD as an Ldap directory |
+| active-directory | active-directory | Configured against AD domain via realm join |
+| saml | saml | Keycloak / ADFS / etc. |
 
 ### Sample external authentication configuration:
 

--- a/README.md
+++ b/README.md
@@ -571,19 +571,14 @@ The config map includes the following:
 
 * The authentication type `auth-type`, default is `internal`
 
-	`internal` is the default type, anything else is considered external. `auth-type` could include strings like: ipa, ldap, active_directory, saml or simply custom.
-
-* The httpd configuration type `auth-configuration`, default is `internal`
-
 	This parameter drives which configuration files httpd will load upon start-up. Supported values are:
-
 
 	| Value    | External-Authentication Configuration |
 	| ---------|---------------------------------------|
-	|internal | Application Based Authentication (_default_) - Database, Ldap/Ldaps, Amazon |
+	| internal | Application Based Authentication (_default_) - Database, Ldap/Ldaps, Amazon |
 	| external | IPA, IPA 2-factor authentication, IPA/AD Trust, Ldap (OpenLdap, RHDS, Active Directory, etc.)
 	| active-directory | Active Directory domain realm join
-	| saml | SAML based authentication (Keycloak, etc.)
+	| saml | SAML based authentication (Keycloak, ADFS, etc.)
 
 * The kerberos realms to join `auth-kerberos-realms`, default is `undefined`
 
@@ -627,20 +622,6 @@ Binary files can be specified in the configuration map in their base64 encoded f
 
 When an /etc/sssd/sssd.conf file is included in the configuration map, the httpd pod automatically enables the sssd service upon startup.
 
-### Auth-type and auth-configuration specification matrix in a configmap:
-
-* auth-type depicts the Identity Provider external authentication is being configured against.
-* auth-configuration identifies which Httpd external authentication configuration files to load.
-
-| auth-type | auth-configuration | Note |
-|-----------|--------------------|------|
-| internal  | internal           | Database / ManageIQ Ldap(s) / Amazon    |
-| ldap      | external           |     |
-| ipa       | external           |     |
-| active-directory | external | Configured against AD via SSSD as an Ldap directory |
-| active-directory | active-directory | Configured against AD domain via realm join |
-| saml | saml | Keycloak / ADFS / etc. |
-
 ### Sample external authentication configuration:
 
 Excluding the content of the files, a SAML auth-config map data section may look like:
@@ -649,7 +630,6 @@ Excluding the content of the files, a SAML auth-config map data section may look
 apiVersion: v1
 data:
   auth-type: saml
-  auth-configuration: saml
   auth-kerberos-realms: example.com
   auth-configuration.conf: |
     #

--- a/README.md
+++ b/README.md
@@ -573,6 +573,22 @@ The config map includes the following:
 
 	`internal` is the default type, anything else is considered external. `auth-type` could include strings like: ipa, ldap, active_directory, saml or simply custom.
 
+* The httpd configuration type `auth-configuration`, default is `internal`
+
+	This parameter drive which configuration files httpd will load upon start-up. Supported values are:
+
+
+	| Value    | External-Authentication Configuration |
+	| ---------|---------------------------------------|
+	|internal | Application Based Authentication (_default_) - Database, Ldap/Ldaps, Amazon |
+	| external | IPA, IPA 2-factor authentication, IPA/AD Trust, Ldap (OpenLdap, RHDS, Active Directory, etc.)
+	| active-directory | Active Directory domain realm join
+	| saml | SAML based authentication (Keycloak, etc.)
+
+* The kerberos realms joined `auth-kerberos-realms`, default is `undefined`
+
+	When configuring external authentication against IPA, Active Directory or Ldap, this parameter defines the kerberos realm httpd is configured against, i.e. `example.com`
+
 * The external authentication configuration file `auth-configuration.conf` which declares the list of files to overlay upon startup if `auth-type` is other than `internal`.
 
 	Syntax for the file is as follows:
@@ -607,7 +623,6 @@ _Examples_:
 
 Binary files can be specified in the configuration map in their base64 encoded format with a basename having a `.base64` extension. Such files are then converted back to binary as they are copied to their target path.
 
-When an /etc/sssd/sssd.conf file is included in the configuration map, the httpd pod automatically enables the sssd service upon startup.
 
 ### Sample external authentication configuration:
 
@@ -617,6 +632,8 @@ Excluding the content of the files, a SAML auth-config map data section may look
 apiVersion: v1
 data:
   auth-type: saml
+  auth-configuration: saml
+  auth-kerberos-realms: example.com
   auth-configuration.conf: |
     #
     # Configuration for SAML authentication
@@ -655,6 +672,12 @@ The authentication configuration map can be defined and customized in the httpd 
 
 ```bash
 $ oc edit configmaps httpd-auth-configs
+```
+
+Or simply replaced if generated and edited externally as follows:
+
+```bash
+$ oc replace configmaps httpd-auth-configs --filename external-auth-configmap.yaml
 ```
 
 Then redeploy the httpd pod for the new authentication configuration to take effect.

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -440,6 +440,9 @@ objects:
         ProxyPass        /ws/ ws://${NAME}/ws/
         ProxyPassReverse /ws/ ws://${NAME}/ws/
 
+        # For httpd, some ErrorDocuments must by served by the front-end httpd
+        RewriteCond %{REQUEST_URI} !^/proxy_pages
+
         # For SAML /saml2 is only served by front-end httpd by mod_auth_mellon
         RewriteCond %{REQUEST_URI} !^/saml2
         RewriteRule ^/ http://${NAME}%{REQUEST_URI} [P,QSA,L]
@@ -462,6 +465,7 @@ objects:
         KrbMethodK5Passwd          Off
         KrbAuthRealms              ${HTTPD_AUTH_KERBEROS_REALMS}
         Krb5KeyTab                 /etc/http.keytab
+        KrbServiceName             Any
         Require                    pam-account httpd-auth
 
         ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -451,7 +451,7 @@ objects:
     authentication.conf: |
       # Load appropriate authentication configuration files
       #
-      Include "conf.d/configuration-${HTTPD_AUTH_CONFIGURATION}-auth"
+      Include "conf.d/configuration-${HTTPD_AUTH_TYPE}-auth"
     configuration-internal-auth: |
       # Internal authentication
       #
@@ -592,7 +592,6 @@ objects:
     name: "${HTTPD_SERVICE_NAME}-auth-configs"
   data:
     auth-type: internal
-    auth-configuration: internal
     auth-kerberos-realms: undefined
     auth-configuration.conf: |
       # External Authentication Configuration File
@@ -692,11 +691,6 @@ objects:
               configMapKeyRef:
                 name: "${HTTPD_SERVICE_NAME}-auth-configs"
                 key: auth-type
-          - name: HTTPD_AUTH_CONFIGURATION
-            valueFrom:
-              configMapKeyRef:
-                name: "${HTTPD_SERVICE_NAME}-auth-configs"
-                key: auth-configuration
           - name: HTTPD_AUTH_KERBEROS_REALMS
             valueFrom:
               configMapKeyRef:

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -433,18 +433,163 @@ objects:
 
       <VirtualHost *:80>
         KeepAlive on
+        # Without ServerName mod_auth_mellon compares against http:// and not https:// from the IdP
+        ServerName https://%{REQUEST_HOST}
+
         ProxyPreserveHost on
         ProxyPass        /ws/ ws://${NAME}/ws/
         ProxyPassReverse /ws/ ws://${NAME}/ws/
-        ProxyPass        / http://${NAME}/
+
+        # For SAML /saml2 is only served by front-end httpd by mod_auth_mellon
+        RewriteCond %{REQUEST_URI} !^/saml2
+        RewriteRule ^/ http://${NAME}%{REQUEST_URI} [P,QSA,L]
         ProxyPassReverse / http://${NAME}/
       </VirtualHost>
+    authentication.conf: |
+      # Load appropriate authentication configuration files
+      #
+      Include "conf.d/configuration-${HTTPD_AUTH_CONFIGURATION}-auth"
+    configuration-internal-auth: |
+      # Internal authentication
+      #
+    configuration-external-auth: |
+      Include "conf.d/external-auth-load-modules-conf"
+
+      <Location /dashboard/kerberos_authenticate>
+        AuthType                   Kerberos
+        AuthName                   "Kerberos Login"
+        KrbMethodNegotiate         On
+        KrbMethodK5Passwd          Off
+        KrbAuthRealms              ${HTTPD_AUTH_KERBEROS_REALMS}
+        Krb5KeyTab                 /etc/http.keytab
+        Require                    pam-account httpd-auth
+
+        ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js
+      </Location>
+
+      Include "conf.d/external-auth-login-form-conf"
+      Include "conf.d/external-auth-application-api-conf"
+      Include "conf.d/external-auth-lookup-user-details-conf"
+      Include "conf.d/external-auth-remote-user-conf"
+    configuration-active-directory-auth: |
+      Include "conf.d/external-auth-load-modules-conf"
+
+      <Location /dashboard/kerberos_authenticate>
+        AuthType                   Kerberos
+        AuthName                   "Kerberos Login"
+        KrbMethodNegotiate         On
+        KrbMethodK5Passwd          Off
+        KrbAuthRealms              ${HTTPD_AUTH_KERBEROS_REALMS}
+        Krb5KeyTab                 /etc/krb5.keytab
+        KrbServiceName             Any
+        Require                    pam-account httpd-auth
+
+        ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js
+      </Location>
+
+      Include "conf.d/external-auth-login-form-conf"
+      Include "conf.d/external-auth-application-api-conf"
+      Include "conf.d/external-auth-lookup-user-details-conf"
+      Include "conf.d/external-auth-remote-user-conf"
+    configuration-saml-auth: |
+      LoadModule auth_mellon_module modules/mod_auth_mellon.so
+
+      <Location />
+        MellonEnable               "info"
+
+        MellonIdPMetadataFile      "/etc/httpd/saml2/idp-metadata.xml"
+
+        MellonSPPrivateKeyFile     "/etc/httpd/saml2/miqsp-key.key"
+        MellonSPCertFile           "/etc/httpd/saml2/miqsp-cert.cert"
+        MellonSPMetadataFile       "/etc/httpd/saml2/miqsp-metadata.xml"
+
+        MellonVariable             "miq-cookie"
+        MellonSecureCookie         On
+        MellonCookiePath           "/"
+
+        MellonIdP                  "IDP"
+
+        MellonEndpointPath         "/saml2"
+
+        MellonUser                 username
+        MellonMergeEnvVars         On
+
+        MellonSetEnvNoPrefix       "REMOTE_USER"            username
+        MellonSetEnvNoPrefix       "REMOTE_USER_EMAIL"      email
+        MellonSetEnvNoPrefix       "REMOTE_USER_FIRSTNAME"  firstname
+        MellonSetEnvNoPrefix       "REMOTE_USER_LASTNAME"   lastname
+        MellonSetEnvNoPrefix       "REMOTE_USER_FULLNAME"   fullname
+        MellonSetEnvNoPrefix       "REMOTE_USER_GROUPS"     groups
+      </Location>
+
+      <Location /saml_login>
+        AuthType                   "Mellon"
+        MellonEnable               "auth"
+        Require                    valid-user
+      </Location>
+
+      Include "conf.d/external-auth-remote-user-conf"
+    external-auth-load-modules-conf: |
+      LoadModule authnz_pam_module            modules/mod_authnz_pam.so
+      LoadModule intercept_form_submit_module modules/mod_intercept_form_submit.so
+      LoadModule lookup_identity_module       modules/mod_lookup_identity.so
+      LoadModule auth_kerb_module             modules/mod_auth_kerb.so
+    external-auth-login-form-conf: |
+      <Location /dashboard/external_authenticate>
+        InterceptFormPAMService    httpd-auth
+        InterceptFormLogin         user_name
+        InterceptFormPassword      user_password
+        InterceptFormLoginSkip     admin
+        InterceptFormClearRemoteUserForSkipped on
+      </Location>
+    external-auth-application-api-conf: |
+      <LocationMatch ^/api>
+        SetEnvIf Authorization     '^Basic +YWRtaW46' let_admin_in
+        SetEnvIf X-Auth-Token      '^.+$'             let_api_token_in
+        SetEnvIf X-MIQ-Token       '^.+$'             let_sys_token_in
+
+        AuthType                   Basic
+        AuthName                   "External Authentication (httpd) for API"
+        AuthBasicProvider          PAM
+
+        AuthPAMService             httpd-auth
+        Require                    valid-user
+        Order                      Allow,Deny
+        Allow from                 env=let_admin_in
+        Allow from                 env=let_api_token_in
+        Allow from                 env=let_sys_token_in
+        Satisfy                    Any
+      </LocationMatch>
+    external-auth-lookup-user-details-conf: |
+      <LocationMatch ^/dashboard/external_authenticate$|^/dashboard/kerberos_authenticate$|^/api>
+        LookupUserAttr mail        REMOTE_USER_EMAIL
+        LookupUserAttr givenname   REMOTE_USER_FIRSTNAME
+        LookupUserAttr sn          REMOTE_USER_LASTNAME
+        LookupUserAttr displayname REMOTE_USER_FULLNAME
+        LookupUserAttr domainname  REMOTE_USER_DOMAIN
+
+        LookupUserGroups           REMOTE_USER_GROUPS ":"
+        LookupDbusTimeout          5000
+      </LocationMatch>
+    external-auth-remote-user-conf: |
+      RequestHeader unset X_REMOTE_USER
+
+      RequestHeader set X_REMOTE_USER           %{REMOTE_USER}e           env=REMOTE_USER
+      RequestHeader set X_EXTERNAL_AUTH_ERROR   %{EXTERNAL_AUTH_ERROR}e   env=EXTERNAL_AUTH_ERROR
+      RequestHeader set X_REMOTE_USER_EMAIL     %{REMOTE_USER_EMAIL}e     env=REMOTE_USER_EMAIL
+      RequestHeader set X_REMOTE_USER_FIRSTNAME %{REMOTE_USER_FIRSTNAME}e env=REMOTE_USER_FIRSTNAME
+      RequestHeader set X_REMOTE_USER_LASTNAME  %{REMOTE_USER_LASTNAME}e  env=REMOTE_USER_LASTNAME
+      RequestHeader set X_REMOTE_USER_FULLNAME  %{REMOTE_USER_FULLNAME}e  env=REMOTE_USER_FULLNAME
+      RequestHeader set X_REMOTE_USER_GROUPS    %{REMOTE_USER_GROUPS}e    env=REMOTE_USER_GROUPS
+      RequestHeader set X_REMOTE_USER_DOMAIN    %{REMOTE_USER_DOMAIN}e    env=REMOTE_USER_DOMAIN
 - apiVersion: v1
   kind: ConfigMap
   metadata:
     name: "${HTTPD_SERVICE_NAME}-auth-configs"
   data:
     auth-type: internal
+    auth-configuration: internal
+    auth-kerberos-realms: undefined
     auth-configuration.conf: |
       # External Authentication Configuration File
       #
@@ -543,6 +688,16 @@ objects:
               configMapKeyRef:
                 name: "${HTTPD_SERVICE_NAME}-auth-configs"
                 key: auth-type
+          - name: HTTPD_AUTH_CONFIGURATION
+            valueFrom:
+              configMapKeyRef:
+                name: "${HTTPD_SERVICE_NAME}-auth-configs"
+                key: auth-configuration
+          - name: HTTPD_AUTH_KERBEROS_REALMS
+            valueFrom:
+              configMapKeyRef:
+                name: "${HTTPD_SERVICE_NAME}-auth-configs"
+                key: auth-kerberos-realms
           lifecycle:
             postStart:
               exec:

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -440,10 +440,10 @@ objects:
         ProxyPass        /ws/ ws://${NAME}/ws/
         ProxyPassReverse /ws/ ws://${NAME}/ws/
 
-        # For httpd, some ErrorDocuments must by served by the front-end httpd
+        # For httpd, some ErrorDocuments must by served by the httpd pod
         RewriteCond %{REQUEST_URI} !^/proxy_pages
 
-        # For SAML /saml2 is only served by front-end httpd by mod_auth_mellon
+        # For SAML /saml2 is only served by mod_auth_mellon in the httpd pod
         RewriteCond %{REQUEST_URI} !^/saml2
         RewriteRule ^/ http://${NAME}%{REQUEST_URI} [P,QSA,L]
         ProxyPassReverse / http://${NAME}/

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -134,12 +134,151 @@ objects:
         ProxyPass        / http://${NAME}/
         ProxyPassReverse / http://${NAME}/
       </VirtualHost>
+    authentication.conf: |
+      # Load appropriate authentication configuration files
+      #
+      Include "conf.d/configuration-${HTTPD_AUTH_CONFIGURATION}-auth"
+    configuration-internal-auth: |
+      # Internal authentication
+      #
+    configuration-external-auth: |
+      Include "conf.d/external-auth-load-modules-conf"
+
+      <Location /dashboard/kerberos_authenticate>
+        AuthType                   Kerberos
+        AuthName                   "Kerberos Login"
+        KrbMethodNegotiate         On
+        KrbMethodK5Passwd          Off
+        KrbAuthRealms              ${HTTPD_AUTH_KERBEROS_REALMS}
+        Krb5KeyTab                 /etc/http.keytab
+        Require                    pam-account httpd-auth
+
+        ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js
+      </Location>
+
+      Include "conf.d/external-auth-login-form-conf"
+      Include "conf.d/external-auth-application-api-conf"
+      Include "conf.d/external-auth-lookup-user-details-conf"
+      Include "conf.d/external-auth-remote-user-conf"
+    configuration-active-directory-auth: |
+      Include "conf.d/external-auth-load-modules-conf"
+
+      <Location /dashboard/kerberos_authenticate>
+        AuthType                   Kerberos
+        AuthName                   "Kerberos Login"
+        KrbMethodNegotiate         On
+        KrbMethodK5Passwd          Off
+        KrbAuthRealms              ${HTTPD_AUTH_KERBEROS_REALMS}
+        Krb5KeyTab                 /etc/krb5.keytab
+        KrbServiceName             Any
+        Require                    pam-account httpd-auth
+
+        ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js
+      </Location>
+
+      Include "conf.d/external-auth-login-form-conf"
+      Include "conf.d/external-auth-application-api-conf"
+      Include "conf.d/external-auth-lookup-user-details-conf"
+      Include "conf.d/external-auth-remote-user-conf"
+    configuration-saml-auth: |
+      LoadModule auth_mellon_module modules/mod_auth_mellon.so
+
+      <Location />
+        MellonEnable               "info"
+
+        MellonIdPMetadataFile      "/etc/httpd/saml2/idp-metadata.xml"
+
+        MellonSPPrivateKeyFile     "/etc/httpd/saml2/miqsp-key.key"
+        MellonSPCertFile           "/etc/httpd/saml2/miqsp-cert.cert"
+        MellonSPMetadataFile       "/etc/httpd/saml2/miqsp-metadata.xml"
+
+        MellonVariable             "miq-cookie"
+        MellonSecureCookie         On
+        MellonCookiePath           "/"
+
+        MellonIdP                  "IDP"
+
+        MellonEndpointPath         "/saml2"
+
+        MellonUser                 username
+        MellonMergeEnvVars         On
+
+        MellonSetEnvNoPrefix       "REMOTE_USER"            username
+        MellonSetEnvNoPrefix       "REMOTE_USER_EMAIL"      email
+        MellonSetEnvNoPrefix       "REMOTE_USER_FIRSTNAME"  firstname
+        MellonSetEnvNoPrefix       "REMOTE_USER_LASTNAME"   lastname
+        MellonSetEnvNoPrefix       "REMOTE_USER_FULLNAME"   fullname
+        MellonSetEnvNoPrefix       "REMOTE_USER_GROUPS"     groups
+      </Location>
+
+      <Location /saml_login>
+        AuthType                   "Mellon"
+        MellonEnable               "auth"
+        Require                    valid-user
+      </Location>
+
+      Include "conf.d/external-auth-remote-user-conf"
+    external-auth-load-modules-conf: |
+      LoadModule authnz_pam_module            modules/mod_authnz_pam.so
+      LoadModule intercept_form_submit_module modules/mod_intercept_form_submit.so
+      LoadModule lookup_identity_module       modules/mod_lookup_identity.so
+      LoadModule auth_kerb_module             modules/mod_auth_kerb.so
+    external-auth-login-form-conf: |
+      <Location /dashboard/external_authenticate>
+        InterceptFormPAMService    httpd-auth
+        InterceptFormLogin         user_name
+        InterceptFormPassword      user_password
+        InterceptFormLoginSkip     admin
+        InterceptFormClearRemoteUserForSkipped on
+      </Location>
+    external-auth-application-api-conf: |
+      <LocationMatch ^/api>
+        SetEnvIf Authorization     '^Basic +YWRtaW46' let_admin_in
+        SetEnvIf X-Auth-Token      '^.+$'             let_api_token_in
+        SetEnvIf X-MIQ-Token       '^.+$'             let_sys_token_in
+
+        AuthType                   Basic
+        AuthName                   "External Authentication (httpd) for API"
+        AuthBasicProvider          PAM
+
+        AuthPAMService             httpd-auth
+        Require                    valid-user
+        Order                      Allow,Deny
+        Allow from                 env=let_admin_in
+        Allow from                 env=let_api_token_in
+        Allow from                 env=let_sys_token_in
+        Satisfy                    Any
+      </LocationMatch>
+    external-auth-lookup-user-details-conf: |
+      <LocationMatch ^/dashboard/external_authenticate$|^/dashboard/kerberos_authenticate$|^/api>
+        LookupUserAttr mail        REMOTE_USER_EMAIL
+        LookupUserAttr givenname   REMOTE_USER_FIRSTNAME
+        LookupUserAttr sn          REMOTE_USER_LASTNAME
+        LookupUserAttr displayname REMOTE_USER_FULLNAME
+        LookupUserAttr domainname  REMOTE_USER_DOMAIN
+
+        LookupUserGroups           REMOTE_USER_GROUPS ":"
+        LookupDbusTimeout          5000
+      </LocationMatch>
+    external-auth-remote-user-conf: |
+      RequestHeader unset X_REMOTE_USER
+
+      RequestHeader set X_REMOTE_USER           %{REMOTE_USER}e           env=REMOTE_USER
+      RequestHeader set X_EXTERNAL_AUTH_ERROR   %{EXTERNAL_AUTH_ERROR}e   env=EXTERNAL_AUTH_ERROR
+      RequestHeader set X_REMOTE_USER_EMAIL     %{REMOTE_USER_EMAIL}e     env=REMOTE_USER_EMAIL
+      RequestHeader set X_REMOTE_USER_FIRSTNAME %{REMOTE_USER_FIRSTNAME}e env=REMOTE_USER_FIRSTNAME
+      RequestHeader set X_REMOTE_USER_LASTNAME  %{REMOTE_USER_LASTNAME}e  env=REMOTE_USER_LASTNAME
+      RequestHeader set X_REMOTE_USER_FULLNAME  %{REMOTE_USER_FULLNAME}e  env=REMOTE_USER_FULLNAME
+      RequestHeader set X_REMOTE_USER_GROUPS    %{REMOTE_USER_GROUPS}e    env=REMOTE_USER_GROUPS
+      RequestHeader set X_REMOTE_USER_DOMAIN    %{REMOTE_USER_DOMAIN}e    env=REMOTE_USER_DOMAIN
 - apiVersion: v1
   kind: ConfigMap
   metadata:
     name: "${HTTPD_SERVICE_NAME}-auth-configs"
   data:
     auth-type: internal
+    auth-configuration: internal
+    auth-kerberos-realms: undefined
     auth-configuration.conf: |
       # External Authentication Configuration File
       #
@@ -690,6 +829,16 @@ objects:
               configMapKeyRef:
                 name: "${HTTPD_SERVICE_NAME}-auth-configs"
                 key: auth-type
+          - name: HTTPD_AUTH_CONFIGURATION
+            valueFrom:
+              configMapKeyRef:
+                name: "${HTTPD_SERVICE_NAME}-auth-configs"
+                key: auth-configuration
+          - name: HTTPD_AUTH_KERBEROS_REALMS
+            valueFrom:
+              configMapKeyRef:
+                name: "${HTTPD_SERVICE_NAME}-auth-configs"
+                key: auth-kerberos-realms
           lifecycle:
             postStart:
               exec:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -146,7 +146,7 @@ objects:
     authentication.conf: |
       # Load appropriate authentication configuration files
       #
-      Include "conf.d/configuration-${HTTPD_AUTH_CONFIGURATION}-auth"
+      Include "conf.d/configuration-${HTTPD_AUTH_TYPE}-auth"
     configuration-internal-auth: |
       # Internal authentication
       #
@@ -287,7 +287,6 @@ objects:
     name: "${HTTPD_SERVICE_NAME}-auth-configs"
   data:
     auth-type: internal
-    auth-configuration: internal
     auth-kerberos-realms: undefined
     auth-configuration.conf: |
       # External Authentication Configuration File
@@ -839,11 +838,6 @@ objects:
               configMapKeyRef:
                 name: "${HTTPD_SERVICE_NAME}-auth-configs"
                 key: auth-type
-          - name: HTTPD_AUTH_CONFIGURATION
-            valueFrom:
-              configMapKeyRef:
-                name: "${HTTPD_SERVICE_NAME}-auth-configs"
-                key: auth-configuration
           - name: HTTPD_AUTH_KERBEROS_REALMS
             valueFrom:
               configMapKeyRef:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -135,6 +135,9 @@ objects:
         ProxyPass        /ws/ ws://${NAME}/ws/
         ProxyPassReverse /ws/ ws://${NAME}/ws/
 
+        # For httpd, some ErrorDocuments must by served by the front-end httpd
+        RewriteCond %{REQUEST_URI} !^/proxy_pages
+
         # For SAML /saml2 is only served by front-end httpd by mod_auth_mellon
         RewriteCond %{REQUEST_URI} !^/saml2
         RewriteRule ^/ http://${NAME}%{REQUEST_URI} [P,QSA,L]
@@ -157,6 +160,7 @@ objects:
         KrbMethodK5Passwd          Off
         KrbAuthRealms              ${HTTPD_AUTH_KERBEROS_REALMS}
         Krb5KeyTab                 /etc/http.keytab
+        KrbServiceName             Any
         Require                    pam-account httpd-auth
 
         ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -135,10 +135,10 @@ objects:
         ProxyPass        /ws/ ws://${NAME}/ws/
         ProxyPassReverse /ws/ ws://${NAME}/ws/
 
-        # For httpd, some ErrorDocuments must by served by the front-end httpd
+        # For httpd, some ErrorDocuments must by served by the httpd pod
         RewriteCond %{REQUEST_URI} !^/proxy_pages
 
-        # For SAML /saml2 is only served by front-end httpd by mod_auth_mellon
+        # For SAML /saml2 is only served by mod_auth_mellon in the httpd pod
         RewriteCond %{REQUEST_URI} !^/saml2
         RewriteRule ^/ http://${NAME}%{REQUEST_URI} [P,QSA,L]
         ProxyPassReverse / http://${NAME}/

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -128,10 +128,16 @@ objects:
 
       <VirtualHost *:80>
         KeepAlive on
+        # Without ServerName mod_auth_mellon compares against http:// and not https:// from the IdP
+        ServerName https://%{REQUEST_HOST}
+
         ProxyPreserveHost on
         ProxyPass        /ws/ ws://${NAME}/ws/
         ProxyPassReverse /ws/ ws://${NAME}/ws/
-        ProxyPass        / http://${NAME}/
+
+        # For SAML /saml2 is only served by front-end httpd by mod_auth_mellon
+        RewriteCond %{REQUEST_URI} !^/saml2
+        RewriteRule ^/ http://${NAME}%{REQUEST_URI} [P,QSA,L]
         ProxyPassReverse / http://${NAME}/
       </VirtualHost>
     authentication.conf: |


### PR DESCRIPTION
- Introduced HTTPD_AUTH_CONFIGURATION to select which authentication configuration files to include
- authentication.conf includes the configuration-* file based on HTTPD_AUTH_CONFIGURATION
- common configurations sections are shared by different types minimizing duplication.
- Introduced HTTPD_AUTH_KERBEROS_REALMS needed for kerberos authentication