### PR TITLE
Deploy HTTPD pod with anyuid SCC by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,29 +90,38 @@ $ oc describe scc privileged | grep Users
 Users:					system:serviceaccount:<your-namespace>:miq-privileged
 ```
 
-### Add the miq-sysadmin service account
+### Minishift only development environment considerations
 
-_**Note:**_ The application front-end Httpd container requires an anyuid scc with the SYS_ADMIN capability to support systemd and dbus.
+_**Note:**_ Minishift clusters are not equipped with OCI systemd hooks which are used to assist with containerized systemd deployments.
+
+An extra SCC is used on Minishift to compensate for the lack of oci-systemd-hooks. **Please SKIP this step if your cluster is equipped with oci-systemd-hooks.**
 
 __*As admin*__
 
-Create the miq-sysadmin SCC:
+Create the miq-httpd SCC:
 
 ```bash
-$ oc create -f templates/miq-sysadmin.yaml
+$ oc create -f templates/miq-scc-httpd.yaml
 ```
 
-The miq-sysadmin service account must be added to the miq-sysadmin SCC before the front-end Httpd pod can run.
+The miq-httpd service account must be added to the miq-httpd SCC before the front-end httpd pod can run.
 
 ```bash
-$ oc adm policy add-scc-to-user miq-sysadmin system:serviceaccount:<your-namespace>:miq-sysadmin
+$ oc adm policy add-scc-to-user miq-httpd system:serviceaccount:<your-namespace>:miq-httpd
 ```
 
-Verify that the miq-sysadmin service account is now included in the miq-sysadmin scc
+Verify that the miq-httpd service account is now included in the miq-httpd scc
 
 ```bash
-$ oc describe scc miq-sysadmin | grep Users
-Users:              system:serviceaccount:<your-namespace>:miq-sysadmin
+$ oc describe scc miq-httpd | grep Users
+Users:              system:serviceaccount:<your-namespace>:miq-httpd
+```
+
+Lastly, update the requested service account in the httpd DC section of the MIQ template, relevant lines below.
+
+```yaml
+        serviceAccount: miq-httpd
+        serviceAccountName: miq-httpd
 ```
 
 ### Add the view and edit roles to the orchestrator service account

--- a/teardown
+++ b/teardown
@@ -11,7 +11,7 @@ oc delete secret -l app=manageiq-ext-db
 oc delete serviceaccount miq-anyuid
 oc delete serviceaccount miq-privileged
 oc delete serviceaccount miq-orchestrator
-oc delete serviceaccount miq-sysadmin
+oc delete serviceaccount miq-httpd
 
 oc delete cm postgresql-configs
 oc delete cm httpd-configs

--- a/templates/miq-scc-httpd.yaml
+++ b/templates/miq-scc-httpd.yaml
@@ -15,9 +15,9 @@ groups:
 kind: SecurityContextConstraints
 metadata:
   annotations:
-    kubernetes.io/description: miq-sysadmin provides all features of the anyuid SCC but allows users to have SYS_ADMIN capabilities. This is the required scc for Pods requiring to run with systemd and the message bus.
+    kubernetes.io/description: miq-httpd provides all features of the anyuid SCC but allows users to have SYS_ADMIN capabilities. This is the required scc for Pods requiring to run with systemd and the message bus.
   creationTimestamp:
-  name: miq-sysadmin
+  name: miq-httpd
 priority: 10
 readOnlyRootFilesystem: false
 requiredDropCapabilities:

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -24,7 +24,7 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
-    name: miq-sysadmin
+    name: miq-httpd
 - apiVersion: v1
   kind: Secret
   metadata:
@@ -543,8 +543,8 @@ objects:
               exec:
                 command:
                 - "/usr/bin/save-container-environment"
-        serviceAccount: miq-sysadmin
-        serviceAccountName: miq-sysadmin
+        serviceAccount: miq-anyuid
+        serviceAccountName: miq-anyuid
 parameters:
 - name: NAME
   displayName: Name

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -24,7 +24,7 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
-    name: miq-sysadmin
+    name: miq-httpd
 - apiVersion: v1
   kind: Secret
   metadata:
@@ -690,8 +690,8 @@ objects:
               exec:
                 command:
                 - "/usr/bin/save-container-environment"
-        serviceAccount: miq-sysadmin
-        serviceAccountName: miq-sysadmin
+        serviceAccount: miq-anyuid
+        serviceAccountName: miq-anyuid
 parameters:
 - name: NAME
   displayName: Name


### PR DESCRIPTION
@carbonin @abellotti @bdunne @Fryguy Please review guys, see #213.

```
[root@franco-ocp-master manageiq-pods (reassign_sa_httpd_pod)]# oc version
oc v3.5.5.5
kubernetes v1.5.2+43a9be4
features: Basic-Auth GSSAPI Kerberos SPNEGO

Server https://franco-ocp-master.e2e.bos.redhat.com:8443
openshift v3.5.5.5
kubernetes v1.5.2+43a9be4

[root@franco-ocp-master manageiq-pods (reassign_sa_httpd_pod)]# oc get pods | grep httpd
httpd-1-zp82b        1/1       Running   0          40m
[root@franco-ocp-master manageiq-pods (reassign_sa_httpd_pod)]# oc describe pods httpd-1-zp82b | grep "Security Policy"
Security Policy:	anyuid
[root@franco-ocp-master manageiq-pods (reassign_sa_httpd_pod)]# oc exec httpd-1-zp82b pidof httpd
111 110 109 108 107 105 37
```