### PR TITLE
Enhance HTTPD pod liveness/readiness probes

### DIFF
--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -510,15 +510,15 @@ objects:
           ports:
           - containerPort: 80
           livenessProbe:
-            tcpSocket:
-              port: 80
+            exec:
+              command:
+              - pidof
+              - httpd
             initialDelaySeconds: 15
             timeoutSeconds: 3
           readinessProbe:
-            httpGet:
-              path: "/"
+            tcpSocket:
               port: 80
-              scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 3
           volumeMounts:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -657,15 +657,15 @@ objects:
           ports:
           - containerPort: 80
           livenessProbe:
-            tcpSocket:
-              port: 80
+            exec:
+              command:
+              - pidof
+              - httpd
             initialDelaySeconds: 15
             timeoutSeconds: 3
           readinessProbe:
-            httpGet:
-              path: "/"
+            tcpSocket:
               port: 80
-              scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 3
           volumeMounts:


### PR DESCRIPTION
- The httpd pod is considered alive if a httpd process is spawned
- The httpd pod is considered ready if a socket can be open on port 80