### PR TITLE
Remove names with miq or manageiq related to the ansible deployment

### DIFF
--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -358,7 +358,7 @@ objects:
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
-    name: "${NAME}-${ANSIBLE_SERVICE_NAME}"
+    name: "${ANSIBLE_SERVICE_NAME}"
     annotations:
       description: Defines how to deploy the Ansible appliance
   spec:
@@ -373,7 +373,7 @@ objects:
         name: "${ANSIBLE_SERVICE_NAME}"
       spec:
         containers:
-        - name: miq-ansible
+        - name: ansible
           image: "${ANSIBLE_IMG_NAME}:${ANSIBLE_IMG_TAG}"
           livenessProbe:
             tcpSocket:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -535,7 +535,7 @@ objects:
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
-    name: "${NAME}-${ANSIBLE_SERVICE_NAME}"
+    name: "${ANSIBLE_SERVICE_NAME}"
     annotations:
       description: Defines how to deploy the Ansible appliance
   spec:
@@ -550,7 +550,7 @@ objects:
         name: "${ANSIBLE_SERVICE_NAME}"
       spec:
         containers:
-        - name: miq-ansible
+        - name: ansible
           image: "${ANSIBLE_IMG_NAME}:${ANSIBLE_IMG_TAG}"
           livenessProbe:
             tcpSocket:


### PR DESCRIPTION
We don't really need these and it will simplify productization if we just leave them out.

cc @simaishi 