### PR TITLE
Use httpd service account for all environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ $ oc describe scc privileged | grep Users
 Users:					system:serviceaccount:<your-namespace>:miq-privileged
 ```
 
-### Minishift only development environment considerations
+### Set up the miq-httpd service account
+
+#### If running without OCI systemd hooks (Minishift)
 
 _**Note:**_ Minishift clusters are not equipped with OCI systemd hooks which are used to assist with containerized systemd deployments.
 
@@ -98,30 +100,40 @@ An extra SCC is used on Minishift to compensate for the lack of oci-systemd-hook
 
 __*As admin*__
 
-Create the miq-httpd SCC:
+Create the miq-sysadmin SCC:
 
 ```bash
-$ oc create -f templates/miq-scc-httpd.yaml
+$ oc create -f templates/miq-scc-sysadmin.yaml
 ```
 
-The miq-httpd service account must be added to the miq-httpd SCC before the front-end httpd pod can run.
+The miq-httpd service account must be added to the miq-sysadmin SCC before the front-end httpd pod can run.
 
 ```bash
-$ oc adm policy add-scc-to-user miq-httpd system:serviceaccount:<your-namespace>:miq-httpd
+$ oc adm policy add-scc-to-user miq-sysadmin system:serviceaccount:<your-namespace>:miq-httpd
 ```
 
-Verify that the miq-httpd service account is now included in the miq-httpd scc
+Verify that the miq-httpd service account is now included in the miq-sysadmin scc
 
 ```bash
-$ oc describe scc miq-httpd | grep Users
+$ oc describe scc miq-sysadmin | grep Users
 Users:              system:serviceaccount:<your-namespace>:miq-httpd
 ```
 
-Lastly, update the requested service account in the httpd DC section of the MIQ template, relevant lines below.
+#### If running with OCI systemd hooks
 
-```yaml
-        serviceAccount: miq-httpd
-        serviceAccountName: miq-httpd
+__*As admin*__
+
+Add the miq-httpd service account to the anyuid SCC
+
+```bash
+$ oc adm policy add-scc-to-user anyuid system:serviceaccount:<your-namespace>:miq-httpd
+```
+
+Verify that the miq-httpd service account is now included in the anyuid scc
+
+```bash
+$ oc describe scc anyuid | grep Users
+Users:              system:serviceaccount:<your-namespace>:miq-httpd
 ```
 
 ### Add the view and edit roles to the orchestrator service account

--- a/templates/miq-scc-sysadmin.yaml
+++ b/templates/miq-scc-sysadmin.yaml
@@ -15,9 +15,9 @@ groups:
 kind: SecurityContextConstraints
 metadata:
   annotations:
-    kubernetes.io/description: miq-httpd provides all features of the anyuid SCC but allows users to have SYS_ADMIN capabilities. This is the required scc for Pods requiring to run with systemd and the message bus.
+    kubernetes.io/description: miq-sysadmin provides all features of the anyuid SCC but allows users to have SYS_ADMIN capabilities. This is the required scc for Pods requiring to run with systemd and the message bus.
   creationTimestamp:
-  name: miq-httpd
+  name: miq-sysadmin
 priority: 10
 readOnlyRootFilesystem: false
 requiredDropCapabilities:

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -543,8 +543,8 @@ objects:
               exec:
                 command:
                 - "/usr/bin/save-container-environment"
-        serviceAccount: miq-anyuid
-        serviceAccountName: miq-anyuid
+        serviceAccount: miq-httpd
+        serviceAccountName: miq-httpd
 parameters:
 - name: NAME
   displayName: Name

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -690,8 +690,8 @@ objects:
               exec:
                 command:
                 - "/usr/bin/save-container-environment"
-        serviceAccount: miq-anyuid
-        serviceAccountName: miq-anyuid
+        serviceAccount: miq-httpd
+        serviceAccountName: miq-httpd
 parameters:
 - name: NAME
   displayName: Name


### PR DESCRIPTION
This allows us to use the same template on minishift as well as a full OpenShift cluster. Now the change that needs to be made based on environment is just in documentation steps rather than editing the template.

Technically, this always uses the miq-httpd service account for the httpd pod and allows the user to choose the scc assigned to that service account based on their environment. For minishift that scc will be miq-sysadmin and for the full cluster, it will be anyuid.

@fbladilo This is more what I was thinking would be a good fix for #213 
Now devs using minishift don't have to change the template (and deal with a dirty git status) to run on minishift.