### PR TITLE
Rename API redirects httpd conf file

### DIFF
--- a/images/miq-app-frontend/docker-assets/manageiq-http.conf
+++ b/images/miq-app-frontend/docker-assets/manageiq-http.conf
@@ -12,7 +12,7 @@ Options SymLinksIfOwnerMatch
 <VirtualHost *:80>
   DocumentRoot /var/www/miq/vmdb/public
   Include conf.d/manageiq-redirects-ui
-  Include conf.d/manageiq-redirects-ws
+  Include conf.d/manageiq-redirects-api
   Include conf.d/manageiq-redirects-websocket
   ProxyPreserveHost on
   <Location /assets/>

--- a/images/miq-app-frontend/docker-assets/manageiq-http.conf
+++ b/images/miq-app-frontend/docker-assets/manageiq-http.conf
@@ -11,8 +11,8 @@ Options SymLinksIfOwnerMatch
 
 <VirtualHost *:80>
   DocumentRoot /var/www/miq/vmdb/public
-  Include conf.d/manageiq-redirects-ui
   Include conf.d/manageiq-redirects-api
+  Include conf.d/manageiq-redirects-ui
   Include conf.d/manageiq-redirects-websocket
   ProxyPreserveHost on
   <Location /assets/>


### PR DESCRIPTION
This goes along with the changes in https://github.com/ManageIQ/manageiq-appliance/pull/131

This should be merged after that patch so that the file actually exists.