### PR TITLE
Remove unnecessary service name environment variables

### DIFF
--- a/images/miq-app-frontend/docker-assets/check-dependent-services.sh
+++ b/images/miq-app-frontend/docker-assets/check-dependent-services.sh
@@ -4,5 +4,5 @@
 [[ -s ${CONTAINER_SCRIPTS_ROOT}/container-deploy-common.sh ]] && source "${CONTAINER_SCRIPTS_ROOT}/container-deploy-common.sh"
 
 # Check readiness of external services
-check_svc_status ${MEMCACHED_SERVICE_NAME} 11211
-check_svc_status ${DATABASE_SERVICE_NAME} 5432
+check_svc_status ${MEMCACHED_SERVICE_HOST} ${MEMCACHED_SERVICE_PORT}
+check_svc_status ${POSTGRESQL_SERVICE_HOST} ${POSTGRESQL_SERVICE_PORT}

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -114,8 +114,6 @@ objects:
                 fieldPath: metadata.namespace
           - name: APPLICATION_INIT_DELAY
             value: "${APPLICATION_INIT_DELAY}"
-          - name: DATABASE_SERVICE_NAME
-            value: "${DATABASE_SERVICE_NAME}"
           - name: DATABASE_REGION
             value: "${DATABASE_REGION}"
           - name: DATABASE_URL
@@ -123,17 +121,11 @@ objects:
               secretKeyRef:
                 name: "${NAME}-secrets"
                 key: database-url
-          - name: MEMCACHED_SERVER
-            value: "${MEMCACHED_SERVICE_NAME}:11211"
-          - name: MEMCACHED_SERVICE_NAME
-            value: "${MEMCACHED_SERVICE_NAME}"
           - name: V2_KEY
             valueFrom:
               secretKeyRef:
                 name: "${NAME}-secrets"
                 key: v2-key
-          - name: ANSIBLE_SERVICE_NAME
-            value: "${ANSIBLE_SERVICE_NAME}"
           - name: ANSIBLE_ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:
@@ -213,15 +205,11 @@ objects:
             value: database_operations,event,reporting,scheduler,smartstate,ems_operations,ems_inventory,automate
           - name: FRONTEND_SERVICE_NAME
             value: "${NAME}"
-          - name: MEMCACHED_SERVER
-            value: "${MEMCACHED_SERVICE_NAME}:11211"
           - name: V2_KEY
             valueFrom:
               secretKeyRef:
                 name: "${NAME}-secrets"
                 key: v2-key
-          - name: ANSIBLE_SERVICE_NAME
-            value: "${ANSIBLE_SERVICE_NAME}"
           - name: ANSIBLE_ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -227,8 +227,6 @@ objects:
                 fieldPath: metadata.namespace
           - name: APPLICATION_INIT_DELAY
             value: "${APPLICATION_INIT_DELAY}"
-          - name: DATABASE_SERVICE_NAME
-            value: "${DATABASE_SERVICE_NAME}"
           - name: DATABASE_REGION
             value: "${DATABASE_REGION}"
           - name: DATABASE_URL
@@ -236,17 +234,11 @@ objects:
               secretKeyRef:
                 name: "${NAME}-secrets"
                 key: database-url
-          - name: MEMCACHED_SERVER
-            value: "${MEMCACHED_SERVICE_NAME}:11211"
-          - name: MEMCACHED_SERVICE_NAME
-            value: "${MEMCACHED_SERVICE_NAME}"
           - name: V2_KEY
             valueFrom:
               secretKeyRef:
                 name: "${NAME}-secrets"
                 key: v2-key
-          - name: ANSIBLE_SERVICE_NAME
-            value: "${ANSIBLE_SERVICE_NAME}"
           - name: ANSIBLE_ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:
@@ -326,15 +318,11 @@ objects:
             value: database_operations,event,reporting,scheduler,smartstate,ems_operations,ems_inventory,automate
           - name: FRONTEND_SERVICE_NAME
             value: "${NAME}"
-          - name: MEMCACHED_SERVER
-            value: "${MEMCACHED_SERVICE_NAME}:11211"
           - name: V2_KEY
             valueFrom:
               secretKeyRef:
                 name: "${NAME}-secrets"
                 key: v2-key
-          - name: ANSIBLE_SERVICE_NAME
-            value: "${ANSIBLE_SERVICE_NAME}"
           - name: ANSIBLE_ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
Now that https://github.com/ManageIQ/manageiq/pull/16001 is merged we can remove the environment variables that were previously being used in place of the *_SERVICE_HOST ones.