### PR TITLE
Change wrap app/db PV definitions into kube templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ In order to avoid random deployment failures due to resource starvation, we reco
 * 2 x Nodes with at least 4 VCPUs and 8GB of RAM
 * 25GB of storage for MIQ PV use
 
-Other sizing considerations: 
+Other sizing considerations:
 
 * Recommendations assume MIQ will be the only application running on this cluster.
 * Alternatively, you can provision an infrastructure node to run registry/metrics/router/logging pods.
@@ -41,15 +41,15 @@ Login to OpenShift and create a project
 _**Note:**_ This section assumes you have a basic user.
 
 `$ oc login -u <user> -p <password>`
-    
+
    Next, create the project as follows:
-   
+
 ```bash
 $ oc new-project <project_name> \
 --description="<description>" \
 --display-name="<display_name>"
 ```
-   
+
    _At a minimum, only `<project_name>` is required._
 
 ### Add the miq-anyuid and miq-orchestrator service accounts to the anyuid security context
@@ -138,35 +138,72 @@ oc policy add-role-to-user edit system:serviceaccount:<your-namespace>:miq-orche
 
 ### Make persistent volumes to host the MIQ database and application data
 
-A basic (single server/replica) deployment needs at least 2 persistent volumes (PVs) to store MIQ data:
+A basic (single server/replica) deployment needs up to 2 persistent
+volumes (PVs) to store MIQ data:
 
 * Server   (Server specific appliance data)
-* Database (PostgreSQL)
+* Database (PostgreSQL, required if running database podified)
 
-Example NFS PV templates are provided, **please skip this step you have already configured persistent storage.**
+NFS PV templates are provided, **please skip this step you have
+already configured persistent storage.**
 
-For NFS backed volumes, please ensure your NFS server firewall is configured to allow traffic on port 2049 (TCP) from the OpenShift cluster.
+For NFS backed volumes, please ensure your NFS server firewall is
+configured to allow traffic on port 2049 (TCP) from the OpenShift
+cluster.
 
 _**Note:**_ Recommended permissions for the PV volumes are 777, root uid/gid owned.
 
 _**As admin:**_
 
-Please inspect example NFS PV files and edit settings to match your site. You will at a minimum need to configure the correct NFS server host and appropiate path.
+Creating the required PVs may be a one or two step process. You may
+create the initial *templates* now, and then process them and create
+the *PV*s later, or you may do all of the processing and PV creation
+in one pass
 
-Create PV
-```bash
-$ oc create -f templates/miq-pv-db-example.yaml
-$ oc create -f templates/miq-pv-server-example.yaml
+There are three parameters required to process the templates. Only
+`NFS_HOST` is required, `PV_SIZE` and `BASE_PATH` have sane defaults
+already
+
+* `PV_SIZE` - **Defaults** to the recommended PV size for the App/DB
+  template (`5Gi`/`15Gi` respectively)
+* `BASE_PATH` - **Defaults** to `/exports`
+* `NFS_HOST` - **No Default** - Hostname or IP address of the NFS
+  server
+
+_**Note**_ Repeat this process for `templates/miq-pv-db-example.yaml`
+as well if you are running your PostgreSQL database podified. The name
+of the database pv template is `manageiq-db-pv`.
+
+#### Method 1 - Create Template, Process and Create Later
+
+This method first creates the template object in OpenShift and then
+demonstrates how to process the template and fill in the required
+parameters at a later time.
+
 ```
+$ oc create -f templates/miq-pv-server-example.yaml
+# ... do stuff ...
+$ oc process manageiq-app-pv -p NFS_HOST=nfs.example.com | oc create -f -
+```
+
+
+
+#### Method 2 - Process Template and Create PV in one pass
+
+```
+# oc process templates/miq-pv-server-example.yaml -p NFS_HOST=nfs.example.com | oc create -f -
+```
+
 Verify PV creation
+
 ```bash
 $ oc get pv
-NAME       CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS      CLAIM  REASON   AGE
-miq-pv01   15Gi        RWO           Recycle         Available                   30s
-miq-pv02   5Gi         RWO           Recycle         Available                   19s
+NAME      CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS      CLAIM     STORAGECLASS   REASON    AGE
+miq-app   5Gi        RWO           Retain          Available                                      7s
+miq-db    15Gi       RWO           Retain          Available                                      1s
 ```
 
-It is strongly suggested that you validate NFS share connectivity from an OpenShift node prior attemping a deployment.
+It is strongly suggested that you validate NFS share connectivity from an OpenShift node prior attempting a deployment.
 
 ## Deploy MIQ
 
@@ -267,7 +304,7 @@ $ oc describe pods <miq_pod_name>
 ...
 Conditions:
   Type		Status
-  Ready 	True 
+  Ready 	True
 Volumes:
 ...
 ```
@@ -288,13 +325,13 @@ deploymentconfig "postgresql" updated
 
 Please note the config change trigger is kept enabled, if you desire to have full control of your deployments you can alternatively turn it off.
 
-## Scale MIQ 
+## Scale MIQ
 
 We use StatefulSets to allow scaling of MIQ appliances, before you attempt scaling please ensure you have enough PVs available to scale. Each new replica will consume a PV.
 
 Example scaling to 2 replicas/servers
 
-```bash 
+```bash
 $ oc scale statefulset manageiq --replicas=2
 statefulset "manageiq" scaled
 $ oc get pods
@@ -372,7 +409,7 @@ The MIQ secrets object contains important data regarding your deployment such as
 ### Launch a database backup
 
 Backups can be initiated with the database online, the job will attempt to run immediately after creation.
- 
+
 `$ oc create -f miq-backup-job.yaml`
 
 The backup job will connect to the MIQ database pod and perform a full binary backup of the entire database cluster, it is based on pg_basebackup.
@@ -409,7 +446,7 @@ Notes about restore procedure:
 
 * The sample restore job will bind to the backup and production PG volumes via "manageiq-backup" and "manageiq-postgresql" PVCs by default
 * If existing data is found on the production PG volume, the restore job will *NOT* delete this data, it will rename it and place it on the same volume
-* The latest succesful DB backup will be restored by default, this can be adjusted via the BACKUP_VERSION environment variable on restore object template
+* The latest successful DB backup will be restored by default, this can be adjusted via the BACKUP_VERSION environment variable on restore object template
 
 ### Launch a database restore
 
@@ -630,5 +667,3 @@ $ oc edit configmaps httpd-auth-configs
 ```
 
 Then redeploy the httpd pod for the new authentication configuration to take effect.
-
-

--- a/templates/miq-pv-db-example.yaml
+++ b/templates/miq-pv-db-example.yaml
@@ -1,13 +1,38 @@
 apiVersion: v1
-kind: PersistentVolume
+kind: Template
+labels:
+  template: manageiq-db-pv
 metadata:
-  name: miq-pv01
-spec:
-  capacity:
-    storage: 15Gi
-  accessModes:
-  - ReadWriteOnce
-  nfs:
-    path: "/exports/miq-pv01"
-    server: "<your-nfs-host-here>"
-  persistentVolumeReclaimPolicy: Retain
+  name: manageiq-db-pv
+  annotations:
+    description: PV Template for MIQ PostgreSQL DB
+    tags: PVS, MIQ
+objects:
+- apiVersion: v1
+  kind: PersistentVolume
+  metadata:
+    name: miq-db
+  spec:
+    capacity:
+      storage: "${PV_SIZE}"
+    accessModes:
+    - ReadWriteOnce
+    nfs:
+      path: "${BASE_PATH}/miq-db"
+      server: "${NFS_HOST}"
+    persistentVolumeReclaimPolicy: Retain
+parameters:
+- name: PV_SIZE
+  displayName: PV Size for DB
+  required: true
+  description: The size of the MIQ DB PV given in Gi
+  value: 15Gi
+- name: BASE_PATH
+  displayName: Exports Directory Base Path
+  required: true
+  description: The parent directory of your NFS exports
+  value: "/exports"
+- name: NFS_HOST
+  displayName: NFS Server Hostname
+  required: true
+  description: The hostname or IP address of the NFS server

--- a/templates/miq-pv-server-example.yaml
+++ b/templates/miq-pv-server-example.yaml
@@ -1,13 +1,38 @@
 apiVersion: v1
-kind: PersistentVolume
+kind: Template
+labels:
+  template: manageiq-app-pv
 metadata:
-  name: miq-pv02
-spec:
-  capacity:
-    storage: 5Gi
-  accessModes:
-  - ReadWriteOnce
-  nfs:
-    path: "/exports/miq-pv02"
-    server: "<your-nfs-host-here>"
-  persistentVolumeReclaimPolicy: Retain
+  name: manageiq-app-pv
+  annotations:
+    description: PV Template for MIQ Server
+    tags: PVS, MIQ
+objects:
+- apiVersion: v1
+  kind: PersistentVolume
+  metadata:
+    name: miq-app
+  spec:
+    capacity:
+      storage: "${PV_SIZE}"
+    accessModes:
+    - ReadWriteOnce
+    nfs:
+      path: "${BASE_PATH}/miq-app"
+      server: "${NFS_HOST}"
+    persistentVolumeReclaimPolicy: Retain
+parameters:
+- name: PV_SIZE
+  displayName: PV Size for App
+  required: true
+  description: The size of the MIQ APP PV given in Gi
+  value: 5Gi
+- name: BASE_PATH
+  displayName: Exports Directory Base Path
+  required: true
+  description: The parent directory of your NFS exports
+  value: "/exports"
+- name: NFS_HOST
+  displayName: NFS Server Hostname
+  required: true
+  description: The hostname or IP address of the NFS server


### PR DESCRIPTION
This is a follow up to [#222 RFE/Question - Turn PV examples into templates](https://github.com/ManageIQ/manageiq-pods/issues/222)

----

# Description

[The current docs](https://github.com/ManageIQ/manageiq-pods#make-persistent-volumes-to-host-the-miq-database-and-application-data) describe creating the required PVs in terms of simply editing the provided [app](https://github.com/ManageIQ/manageiq-pods/blob/master/templates/miq-pv-server-example.yaml)/[db](https://github.com/ManageIQ/manageiq-pods/blob/master/templates/miq-pv-db-example.yaml) examples with the required NFS paths. This change turns creating PVs into a no-editing-required process by wrapping the PV objects in kube templates.

# Usage

Using a template in this PR is pretty simple! No more editing required

## Template Parameters

* `DB_PV_SIZE` - **Defaults** to the recommended PV size for the DB template
* `APP_PV_SIZE` - ** Defaults to the recommended PV size for the app template
* `BASE_PATH` - **Defaults** to `/exports`
* `NFS_HOST` - **No Default** - Value must be provided when processing/creating

## Method 1 - Create Template, Process and Create Later

```
# oc create -f /path/to/miq-pv-example.yaml
# ... do stuff ...
# oc process miq-pv-example -p NFS_HOST=nfs.example.com | oc create -f -
```

## Method 2 - Process Template and Create in one pass

```
# oc process /path/to/miq-pv-example.yaml -p NFS_HOST=nfs.example.com | oc create -f -
```

----

The current descriptions don't look like the rest of the manageiq descriptions, probably want to re-word these

```
[root@m01 ~]# oc get template
NAME              DESCRIPTION                                  PARAMETERS     OBJECTS
manageiq          ManageIQ appliance with persistent storage   54 (1 blank)   23
manageiq-app-pv   PV Template for MIQ Server                   3 (1 blank)    1
manageiq-db-pv    PV Template for MIQ PostgreSQL DB            3 (1 blank)    1
```

# Questions

1. Do you want to change the template descriptions to match what you already are doing?
2. The app/db templates are using different parameter names for their `spec.capacity.storage` parameters: `APP_PV_SIZE` vs. `DB_PV_SIZE`. Do you want those to stay different, or do you want them to be the same, i.e., unify on a single name like `MIQ_PV_SIZE` or something?