### PR TITLE
Add libguestfs tools for OpenStack OpenSCAP

### DIFF
--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -41,6 +41,7 @@ RUN yum -y install centos-release-scl-rh && \
                    http-parser             \
                    initscripts             \
                    libcurl-devel           \
+                   libguestfs-tools        \
                    libtool                 \
                    libxslt-devel           \
                    logrotate               \


### PR DESCRIPTION
Adding libguestfs-tools package to be able mount OpenStack snapshots
in way suitable to perform OpenSCAP scan.

Tracking issue: https://github.com/ManageIQ/manageiq-providers-openstack/issues/125
Related non-containerized PR: https://github.com/ManageIQ/manageiq-appliance-build/pull/231