### PR TITLE
Update external DB section with PG version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Deploy MIQ from template using customized settings
 Before you attempt an external DB deployment please ensure the following conditions are satisfied :
 
 * Your OpenShift cluster can access the external PostgreSQL server
+* The external PostgreSQL server must run at a minimum version 9.4 (9.5 if replication is desired), see [SCL PG instructions for CentOS/RHEL based hosts](https://www.softwarecollections.org/en/scls/rhscl/rh-postgresql95/)
 * MIQ user, password and role have been created on the external PostgreSQL server
 * The intended MIQ database is created and ownership has been assigned to the MIQ user
 


### PR DESCRIPTION
- We require a minimum of PG 9.4 or 9.5 if replication is needed