### PR TITLE
Enhance app-frontend probes

### DIFF
--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -90,15 +90,15 @@ objects:
         - name: manageiq
           image: "${APPLICATION_IMG_NAME}:${FRONTEND_APPLICATION_IMG_TAG}"
           livenessProbe:
-            tcpSocket:
-              port: 80
+            exec:
+              command:
+              - pidof
+              - MIQ Server
             initialDelaySeconds: 480
             timeoutSeconds: 3
           readinessProbe:
-            httpGet:
-              path: "/"
+            tcpSocket:
               port: 80
-              scheme: HTTP
             initialDelaySeconds: 200
             timeoutSeconds: 3
           ports:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -351,15 +351,15 @@ objects:
         - name: manageiq
           image: "${APPLICATION_IMG_NAME}:${FRONTEND_APPLICATION_IMG_TAG}"
           livenessProbe:
-            tcpSocket:
-              port: 80
+            exec:
+              command:
+              - pidof
+              - MIQ Server
             initialDelaySeconds: 480
             timeoutSeconds: 3
           readinessProbe:
-            httpGet:
-              path: "/"
+            tcpSocket:
               port: 80
-              scheme: HTTP
             initialDelaySeconds: 200
             timeoutSeconds: 3
           ports:


### PR DESCRIPTION
- Reconfigure liveness probe to use PID check of MIQ server process
- Reconfigure readiness probe to use TCP check on port 80 instead of HTTP code check
- Initial probe delays were not modified

The PID check is more effective, specially on initial deployments, liveness will succeed as long as MIQ Server is alive, this would prevent OpenShift from killing/restarting the pod unnecessarily when MIQ server is actually in the final stages of seeding and about to come up.

The initial delays for each probe were kept intact, these are heavily dependent on the performance of cluster nodes assigned for a MIQ deployment. Currently 3 mins for readiness and 8 mins for liveness.
