### PR TITLE
Ensures httpd error_log and access_log are seen by docker or oc logs commands

### DIFF
--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -447,6 +447,10 @@ objects:
         RewriteCond %{REQUEST_URI} !^/saml2
         RewriteRule ^/ http://${NAME}%{REQUEST_URI} [P,QSA,L]
         ProxyPassReverse / http://${NAME}/
+
+        # Ensures httpd stdout/stderr are seen by docker logs.
+        ErrorLog  "| /usr/bin/tee /proc/1/fd/2 /var/log/httpd/error_log"
+        CustomLog "| /usr/bin/tee /proc/1/fd/1 /var/log/httpd/access_log" common
       </VirtualHost>
     authentication.conf: |
       # Load appropriate authentication configuration files

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -142,6 +142,10 @@ objects:
         RewriteCond %{REQUEST_URI} !^/saml2
         RewriteRule ^/ http://${NAME}%{REQUEST_URI} [P,QSA,L]
         ProxyPassReverse / http://${NAME}/
+
+        # Ensures httpd stdout/stderr are seen by docker logs.
+        ErrorLog  "| /usr/bin/tee /proc/1/fd/2 /var/log/httpd/error_log"
+        CustomLog "| /usr/bin/tee /proc/1/fd/1 /var/log/httpd/access_log" common
       </VirtualHost>
     authentication.conf: |
       # Load appropriate authentication configuration files


### PR DESCRIPTION
Updated httpd application.conf config file so error_log and access_log also sent to the container's stdout/stderr.  This allows the httpd pod logs to be accessed via docker logs or oc logs.