### PR TITLE
[GAPRINDASHVILI] Lock bundler to 1.15.4

### DIFF
--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -82,7 +82,7 @@ WORKDIR ${APP_ROOT}
 RUN source /etc/default/evm && \
     export RAILS_USE_MEMORY_STORE="true" && \
     npm install bower yarn -g && \
-    gem install bundler --conservative && \
+    gem install bundler -v 1.15.4 && \
     bundle install && \
     rake update:ui && \
     bin/rails log:clear tmp:clear && \


### PR DESCRIPTION
Related PR: https://github.com/ManageIQ/manageiq-appliance-build/pull/245