### PR TITLE
Allow setting MIQ admin password during deployment

### DIFF
--- a/images/miq-app/docker-assets/appliance-initialize.sh
+++ b/images/miq-app/docker-assets/appliance-initialize.sh
@@ -35,7 +35,6 @@ case $? in
     # Restore symlinks from PV to application rootdir
     restore_pv_data
 
-    # Set admin pwd
     set_admin_pwd
   ;;
   4) # new_replica

--- a/images/miq-app/docker-assets/appliance-initialize.sh
+++ b/images/miq-app/docker-assets/appliance-initialize.sh
@@ -34,6 +34,9 @@ case $? in
 
     # Restore symlinks from PV to application rootdir
     restore_pv_data
+
+    # Set admin pwd
+    set_admin_pwd
   ;;
   4) # new_replica
     echo "== Starting New Replica =="

--- a/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
+++ b/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
@@ -120,6 +120,15 @@ function migrate_db() {
   ) 2>&1 | tee ${PV_MIGRATE_DB_LOG}
 }
 
+# Set EVM admin pwd
+function set_admin_pwd() {
+ echo "== Setting admin password =="
+
+   cd ${APP_ROOT} && bin/rails runner -e production "EvmDatabase.seed_primordial; user = User.find_by_userid('admin'); user.password = ENV['APPLICATION_ADMIN_PASSWORD']; user.save; exit;"
+
+   [ "$?" -ne "0" ] && echo "ERROR: Failed to set admin password, please check appliance logs"
+}
+
 # Process DATA_PERSIST_FILE which contains the desired files/dirs to store on the PV
 # Use rsync to transfer files/dirs, log output and check return status
 # Ensure we always store an initial data backup on PV

--- a/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
+++ b/images/miq-app/docker-assets/container-scripts/container-deploy-common.sh
@@ -124,7 +124,7 @@ function migrate_db() {
 function set_admin_pwd() {
  echo "== Setting admin password =="
 
-   cd ${APP_ROOT} && bin/rails runner -e production "EvmDatabase.seed_primordial; user = User.find_by_userid('admin'); user.password = ENV['APPLICATION_ADMIN_PASSWORD']; user.save; exit;"
+   cd ${APP_ROOT} && bin/rails runner "EvmDatabase.seed_primordial; user = User.find_by_userid('admin').update_attributes!(:password => ENV['APPLICATION_ADMIN_PASSWORD'])"
 
    [ "$?" -ne "0" ] && echo "ERROR: Failed to set admin password, please check appliance logs"
 }

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -762,6 +762,7 @@ parameters:
   required: true
   description: Admin password that will be set on the application.
   from: "[a-zA-Z0-9]{8}"
+  generate: expression
 - name: ANSIBLE_DATABASE_NAME
   displayName: Ansible PostgreSQL database name
   required: true

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -761,8 +761,7 @@ parameters:
   displayName: Application Admin Password
   required: true
   description: Admin password that will be set on the application.
-  from: "[a-zA-Z0-9]{8}"
-  generate: expression
+  value: smartvm
 - name: ANSIBLE_DATABASE_NAME
   displayName: Ansible PostgreSQL database name
   required: true

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -31,6 +31,7 @@ objects:
     name: "${NAME}-secrets"
   stringData:
     pg-password: "${DATABASE_PASSWORD}"
+    admin-password: "${APPLICATION_ADMIN_PASSWORD}"
     database-url: postgresql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_SERVICE_NAME}/${DATABASE_NAME}?encoding=utf8&pool=5&wait_timeout=5
     v2-key: "${V2_KEY}"
 - apiVersion: v1
@@ -126,6 +127,11 @@ objects:
               secretKeyRef:
                 name: "${NAME}-secrets"
                 key: v2-key
+          - name: APPLICATION_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "${NAME}-secrets"
+                key: admin-password
           - name: ANSIBLE_ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:
@@ -751,6 +757,11 @@ parameters:
   displayName: Application Database Region
   description: Database region that will be used for application.
   value: '0'
+- name: APPLICATION_ADMIN_PASSWORD
+  displayName: Application Admin Password
+  required: true
+  description: Admin password that will be set on the application.
+  from: "[a-zA-Z0-9]{8}"
 - name: ANSIBLE_DATABASE_NAME
   displayName: Ansible PostgreSQL database name
   required: true

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -896,7 +896,7 @@ parameters:
   value: '0'
 - name: APPLICATION_ADMIN_PASSWORD
   displayName: Application Admin Password
-  required : true
+  required: true
   description: Admin password that will be set on the application.
   from: "[a-zA-Z0-9]{8}"
   generate: expression

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -31,6 +31,7 @@ objects:
     name: "${NAME}-secrets"
   stringData:
     pg-password: "${DATABASE_PASSWORD}"
+    admin-password: "${APPLICATION_ADMIN_PASSWORD}"
     database-url: postgresql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_SERVICE_NAME}/${DATABASE_NAME}?encoding=utf8&pool=5&wait_timeout=5
     v2-key: "${V2_KEY}"
 - apiVersion: v1
@@ -387,6 +388,11 @@ objects:
               secretKeyRef:
                 name: "${NAME}-secrets"
                 key: v2-key
+          - name: APPLICATION_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "${NAME}-secrets"
+                key: admin-password
           - name: ANSIBLE_ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:
@@ -888,6 +894,12 @@ parameters:
   displayName: Application Database Region
   description: Database region that will be used for application.
   value: '0'
+- name: APPLICATION_ADMIN_PASSWORD
+  displayName: Application Admin Password
+  required : true
+  description: Admin password that will be set on the application.
+  from: "[a-zA-Z0-9]{8}"
+  generate: expression
 - name: ANSIBLE_DATABASE_NAME
   displayName: Ansible PostgreSQL database name
   required: true

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -898,8 +898,7 @@ parameters:
   displayName: Application Admin Password
   required: true
   description: Admin password that will be set on the application.
-  from: "[a-zA-Z0-9]{8}"
-  generate: expression
+  value: smartvm
 - name: ANSIBLE_DATABASE_NAME
   displayName: Ansible PostgreSQL database name
   required: true


### PR DESCRIPTION
* Defines new APPLICATION_ADMIN_PASSWORD param
* Adds necessary element to existing manageiq secrets object
* Adds shell function calling rails runner, seeds minimal models and changes password
* Function is called via appliance-initialize.sh, last step for new_deployment case
* By default password is set to default MIQ value but customizable as desired at deployment time
* Related to #237 

Usage : `oc new-app --template=manageiq -p APPLICATION_ADMIN_PASSWORD=mypasswd`

@carbonin @bdunne 
