### PR TITLE
Adding support for OpenID-Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ The config map includes the following:
 	| external | IPA, IPA 2-factor authentication, IPA/AD Trust, Ldap (OpenLdap, RHDS, Active Directory, etc.)
 	| active-directory | Active Directory domain realm join
 	| saml | SAML based authentication (Keycloak, ADFS, etc.)
+	| oidc | OpenID-Connect based authentication (Keycloak, ADFS, etc.)
 
 * The kerberos realms to join `auth-kerberos-realms`, default is `undefined`
 
@@ -623,7 +624,7 @@ Binary files can be specified in the configuration map in their base64 encoded f
 
 When an /etc/sssd/sssd.conf file is included in the configuration map, the httpd pod automatically enables the sssd service upon startup.
 
-### Sample external authentication configuration:
+### Sample external authentication configuration for SAML:
 
 Excluding the content of the files, a SAML auth-config map data section may look like:
 

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -144,6 +144,24 @@ objects:
       </Location>
 
       Include "conf.d/external-auth-remote-user-conf"
+    configuration-openid-connect-auth: |
+      LoadModule auth_openidc_module modules/mod_auth_openidc.so
+
+      OIDCProviderMetadataURL      ${HTTPD_AUTH_OIDC_PROVIDER_METADATA_URL}
+      OIDCClientID                 ${HTTPD_AUTH_OIDC_CLIENT_ID}
+      OIDCClientSecret             ${HTTPD_AUTH_OIDC_CLIENT_SECRET}
+
+      OIDCRedirectURI              https://%{REQUEST_HOST}/oidc_login/redirect_uri
+      OIDCOAuthRemoteUserClaim     username
+
+      OIDCCryptoPassphrase         sp-secret
+
+      <Location /oidc_login>
+        AuthType                   openid-connect
+        Require                    valid-user
+      </Location>
+
+      Include "conf.d/external-auth-openid-connect-remote-user-conf"
     external-auth-load-modules-conf: |
       LoadModule authnz_pam_module            modules/mod_authnz_pam.so
       LoadModule intercept_form_submit_module modules/mod_intercept_form_submit.so
@@ -197,6 +215,17 @@ objects:
       RequestHeader set X_REMOTE_USER_FULLNAME  %{REMOTE_USER_FULLNAME}e  env=REMOTE_USER_FULLNAME
       RequestHeader set X_REMOTE_USER_GROUPS    %{REMOTE_USER_GROUPS}e    env=REMOTE_USER_GROUPS
       RequestHeader set X_REMOTE_USER_DOMAIN    %{REMOTE_USER_DOMAIN}e    env=REMOTE_USER_DOMAIN
+    external-auth-openid-connect-remote-user-conf: |
+      RequestHeader unset X_REMOTE_USER
+
+      RequestHeader set X_REMOTE_USER           %{OIDC_CLAIM_PREFERRED_USERNAME}e env=OIDC_CLAIM_PREFERRED_USERNAME
+      RequestHeader set X_EXTERNAL_AUTH_ERROR   %{EXTERNAL_AUTH_ERROR}e           env=EXTERNAL_AUTH_ERROR
+      RequestHeader set X_REMOTE_USER_EMAIL     %{OIDC_CLAIM_EMAIL}e              env=OIDC_CLAIM_EMAIL
+      RequestHeader set X_REMOTE_USER_FIRSTNAME %{OIDC_CLAIM_GIVEN_NAME}e         env=OIDC_CLAIM_GIVEN_NAME
+      RequestHeader set X_REMOTE_USER_LASTNAME  %{OIDC_CLAIM_FAMILY_NAME}e        env=OIDC_CLAIM_FAMILY_NAME
+      RequestHeader set X_REMOTE_USER_FULLNAME  %{OIDC_CLAIM_NAME}e               env=OIDC_CLAIM_NAME
+      RequestHeader set X_REMOTE_USER_GROUPS    %{OIDC_CLAIM_GROUPS}e             env=OIDC_CLAIM_GROUPS
+      RequestHeader set X_REMOTE_USER_DOMAIN    %{OIDC_CLAIM_DOMAIN}e             env=OIDC_CLAIM_DOMAIN
 - apiVersion: v1
   kind: ConfigMap
   metadata:
@@ -204,6 +233,9 @@ objects:
   data:
     auth-type: internal
     auth-kerberos-realms: undefined
+    auth-oidc-provider-metadata-url: undefined
+    auth-oidc-client-id: undefined
+    auth-oidc-client-secret: undefined
     auth-configuration.conf: |
       # External Authentication Configuration File
       #
@@ -515,6 +547,21 @@ objects:
               configMapKeyRef:
                 name: "${HTTPD_SERVICE_NAME}-auth-configs"
                 key: auth-kerberos-realms
+          - name: HTTPD_AUTH_OIDC_PROVIDER_METADATA_URL
+            valueFrom:
+              configMapKeyRef:
+                name: "${HTTPD_SERVICE_NAME}-auth-configs"
+                key: auth-oidc-provider-metadata-url
+          - name: HTTPD_AUTH_OIDC_CLIENT_ID
+            valueFrom:
+              configMapKeyRef:
+                name: "${HTTPD_SERVICE_NAME}-auth-configs"
+                key: auth-oidc-client-id
+          - name: HTTPD_AUTH_OIDC_CLIENT_SECRET
+            valueFrom:
+              configMapKeyRef:
+                name: "${HTTPD_SERVICE_NAME}-auth-configs"
+                key: auth-oidc-client-secret
           lifecycle:
             postStart:
               exec:

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -554,16 +554,19 @@ objects:
               configMapKeyRef:
                 name: "${HTTPD_SERVICE_NAME}-auth-configs"
                 key: auth-oidc-provider-metadata-url
+                optional: true
           - name: HTTPD_AUTH_OIDC_CLIENT_ID
             valueFrom:
               configMapKeyRef:
                 name: "${HTTPD_SERVICE_NAME}-auth-configs"
                 key: auth-oidc-client-id
+                optional: true
           - name: HTTPD_AUTH_OIDC_CLIENT_SECRET
             valueFrom:
               configMapKeyRef:
                 name: "${HTTPD_SERVICE_NAME}-auth-configs"
                 key: auth-oidc-client-secret
+                optional: true
           lifecycle:
             postStart:
               exec:

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -151,7 +151,7 @@ objects:
       OIDCClientID                 ${HTTPD_AUTH_OIDC_CLIENT_ID}
       OIDCClientSecret             ${HTTPD_AUTH_OIDC_CLIENT_SECRET}
 
-      OIDCRedirectURI              https://%{REQUEST_HOST}/oidc_login/redirect_uri
+      OIDCRedirectURI              https://${APPLICATION_DOMAIN}/oidc_login/redirect_uri
       OIDCOAuthRemoteUserClaim     username
 
       OIDCCryptoPassphrase         sp-secret
@@ -537,6 +537,8 @@ objects:
             limits:
               memory: "${HTTPD_MEM_LIMIT}"
           env:
+          - name: APPLICATION_DOMAIN
+            value: "${APPLICATION_DOMAIN}"
           - name: HTTPD_AUTH_TYPE
             valueFrom:
               configMapKeyRef:

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -151,7 +151,7 @@ objects:
       OIDCClientID                 ${HTTPD_AUTH_OIDC_CLIENT_ID}
       OIDCClientSecret             ${HTTPD_AUTH_OIDC_CLIENT_SECRET}
 
-      OIDCRedirectURI              https://${APPLICATION_DOMAIN}/oidc_login/redirect_uri
+      OIDCRedirectURI              "https://${APPLICATION_DOMAIN}/oidc_login/redirect_uri"
       OIDCOAuthRemoteUserClaim     username
 
       OIDCCryptoPassphrase         sp-secret

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -49,6 +49,10 @@ objects:
 
         # For SAML /saml2 is only served by mod_auth_mellon in the httpd pod
         RewriteCond %{REQUEST_URI} !^/saml2
+
+        # For OpenID-Connect /openid-connect is only served by mod_auth_openidc
+        RewriteCond %{REQUEST_URI} !^/openid-connect
+
         RewriteRule ^/ http://ui:3000%{REQUEST_URI} [P,QSA,L]
         ProxyPassReverse / http://ui:3000/
 

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -699,16 +699,19 @@ objects:
               configMapKeyRef:
                 name: "${HTTPD_SERVICE_NAME}-auth-configs"
                 key: auth-oidc-provider-metadata-url
+                optional: true
           - name: HTTPD_AUTH_OIDC_CLIENT_ID
             valueFrom:
               configMapKeyRef:
                 name: "${HTTPD_SERVICE_NAME}-auth-configs"
                 key: auth-oidc-client-id
+                optional: true
           - name: HTTPD_AUTH_OIDC_CLIENT_SECRET
             valueFrom:
               configMapKeyRef:
                 name: "${HTTPD_SERVICE_NAME}-auth-configs"
                 key: auth-oidc-client-secret
+                optional: true
           lifecycle:
             postStart:
               exec:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -122,6 +122,10 @@ objects:
 
         # For SAML /saml2 is only served by mod_auth_mellon in the httpd pod
         RewriteCond %{REQUEST_URI} !^/saml2
+
+        # For OpenID-Connect /openid-connect is only served by mod_auth_openidc
+        RewriteCond %{REQUEST_URI} !^/openid-connect
+
         RewriteRule ^/ http://ui:3000%{REQUEST_URI} [P,QSA,L]
         ProxyPassReverse / http://ui:3000/
 

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -224,7 +224,7 @@ objects:
       OIDCClientID                 ${HTTPD_AUTH_OIDC_CLIENT_ID}
       OIDCClientSecret             ${HTTPD_AUTH_OIDC_CLIENT_SECRET}
 
-      OIDCRedirectURI              https://%{REQUEST_HOST}/oidc_login/redirect_uri
+      OIDCRedirectURI              https://${APPLICATION_DOMAIN}/oidc_login/redirect_uri
       OIDCOAuthRemoteUserClaim     username
 
       OIDCCryptoPassphrase         sp-secret
@@ -682,6 +682,8 @@ objects:
             limits:
               memory: "${HTTPD_MEM_LIMIT}"
           env:
+          - name: APPLICATION_DOMAIN
+            value: "${APPLICATION_DOMAIN}"
           - name: HTTPD_AUTH_TYPE
             valueFrom:
               configMapKeyRef:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -224,7 +224,7 @@ objects:
       OIDCClientID                 ${HTTPD_AUTH_OIDC_CLIENT_ID}
       OIDCClientSecret             ${HTTPD_AUTH_OIDC_CLIENT_SECRET}
 
-      OIDCRedirectURI              https://${APPLICATION_DOMAIN}/oidc_login/redirect_uri
+      OIDCRedirectURI              "https://${APPLICATION_DOMAIN}/oidc_login/redirect_uri"
       OIDCOAuthRemoteUserClaim     username
 
       OIDCCryptoPassphrase         sp-secret

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -217,6 +217,24 @@ objects:
       </Location>
 
       Include "conf.d/external-auth-remote-user-conf"
+    configuration-openid-connect-auth: |
+      LoadModule auth_openidc_module modules/mod_auth_openidc.so
+
+      OIDCProviderMetadataURL      ${HTTPD_AUTH_OIDC_PROVIDER_METADATA_URL}
+      OIDCClientID                 ${HTTPD_AUTH_OIDC_CLIENT_ID}
+      OIDCClientSecret             ${HTTPD_AUTH_OIDC_CLIENT_SECRET}
+
+      OIDCRedirectURI              https://%{REQUEST_HOST}/oidc_login/redirect_uri
+      OIDCOAuthRemoteUserClaim     username
+
+      OIDCCryptoPassphrase         sp-secret
+
+      <Location /oidc_login>
+        AuthType                   openid-connect
+        Require                    valid-user
+      </Location>
+
+      Include "conf.d/external-auth-openid-connect-remote-user-conf"
     external-auth-load-modules-conf: |
       LoadModule authnz_pam_module            modules/mod_authnz_pam.so
       LoadModule intercept_form_submit_module modules/mod_intercept_form_submit.so
@@ -270,6 +288,17 @@ objects:
       RequestHeader set X_REMOTE_USER_FULLNAME  %{REMOTE_USER_FULLNAME}e  env=REMOTE_USER_FULLNAME
       RequestHeader set X_REMOTE_USER_GROUPS    %{REMOTE_USER_GROUPS}e    env=REMOTE_USER_GROUPS
       RequestHeader set X_REMOTE_USER_DOMAIN    %{REMOTE_USER_DOMAIN}e    env=REMOTE_USER_DOMAIN
+    external-auth-openid-connect-remote-user-conf: |
+      RequestHeader unset X_REMOTE_USER
+
+      RequestHeader set X_REMOTE_USER           %{OIDC_CLAIM_PREFERRED_USERNAME}e env=OIDC_CLAIM_PREFERRED_USERNAME
+      RequestHeader set X_EXTERNAL_AUTH_ERROR   %{EXTERNAL_AUTH_ERROR}e           env=EXTERNAL_AUTH_ERROR
+      RequestHeader set X_REMOTE_USER_EMAIL     %{OIDC_CLAIM_EMAIL}e              env=OIDC_CLAIM_EMAIL
+      RequestHeader set X_REMOTE_USER_FIRSTNAME %{OIDC_CLAIM_GIVEN_NAME}e         env=OIDC_CLAIM_GIVEN_NAME
+      RequestHeader set X_REMOTE_USER_LASTNAME  %{OIDC_CLAIM_FAMILY_NAME}e        env=OIDC_CLAIM_FAMILY_NAME
+      RequestHeader set X_REMOTE_USER_FULLNAME  %{OIDC_CLAIM_NAME}e               env=OIDC_CLAIM_NAME
+      RequestHeader set X_REMOTE_USER_GROUPS    %{OIDC_CLAIM_GROUPS}e             env=OIDC_CLAIM_GROUPS
+      RequestHeader set X_REMOTE_USER_DOMAIN    %{OIDC_CLAIM_DOMAIN}e             env=OIDC_CLAIM_DOMAIN
 - apiVersion: v1
   kind: ConfigMap
   metadata:
@@ -277,6 +306,9 @@ objects:
   data:
     auth-type: internal
     auth-kerberos-realms: undefined
+    auth-oidc-provider-metadata-url: undefined
+    auth-oidc-client-id: undefined
+    auth-oidc-client-secret: undefined
     auth-configuration.conf: |
       # External Authentication Configuration File
       #
@@ -660,6 +692,21 @@ objects:
               configMapKeyRef:
                 name: "${HTTPD_SERVICE_NAME}-auth-configs"
                 key: auth-kerberos-realms
+          - name: HTTPD_AUTH_OIDC_PROVIDER_METADATA_URL
+            valueFrom:
+              configMapKeyRef:
+                name: "${HTTPD_SERVICE_NAME}-auth-configs"
+                key: auth-oidc-provider-metadata-url
+          - name: HTTPD_AUTH_OIDC_CLIENT_ID
+            valueFrom:
+              configMapKeyRef:
+                name: "${HTTPD_SERVICE_NAME}-auth-configs"
+                key: auth-oidc-client-id
+          - name: HTTPD_AUTH_OIDC_CLIENT_SECRET
+            valueFrom:
+              configMapKeyRef:
+                name: "${HTTPD_SERVICE_NAME}-auth-configs"
+                key: auth-oidc-client-secret
           lifecycle:
             postStart:
               exec:


### PR DESCRIPTION
Adding support for OpenID-Connect
- auth-type: openid-connect
- new auth config parameters:
  o HTTPD_AUTH_OIDC_PROVIDER_METADATA_URL   oidc-provider-metadata-url
  o HTTPD_AUTH_OIDC_CLIENT_ID               oidc-client-id
  o HTTPD_AUTH_OIDC_CLIENT_SECRET           oidc-client-secret