### PR TITLE
Allow changing the GitHub organization when building the images

### DIFF
--- a/images/miq-app-frontend/Dockerfile
+++ b/images/miq-app-frontend/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER ManageIQ https://github.com/ManageIQ/manageiq-appliance-build
 
 ## Set build ARGs
 ARG REF=master
+ARG GHORG=ManageIQ
 
 ## Set ENV, LANG only needed if building with docker-1.8
 ENV SUI_ROOT=/opt/manageiq/manageiq-ui-service
@@ -27,7 +28,7 @@ RUN yum -y install centos-release-scl-rh && \
 
 ## GIT clone service UI repo (SUI)
 RUN mkdir -p ${SUI_ROOT} && \
-    curl -L https://github.com/ManageIQ/manageiq-ui-service/tarball/${REF} | tar vxz -C ${SUI_ROOT} --strip 1
+    curl -L https://github.com/${GHORG}/manageiq-ui-service/tarball/${REF} | tar vxz -C ${SUI_ROOT} --strip 1
 
 ## Setup environment
 RUN rm -f /etc/httpd/conf.d/ssl.conf && \

--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER ManageIQ https://github.com/ManageIQ/manageiq-appliance-build
 
 ## Set build ARGs
 ARG REF=master
+ARG GHORG=ManageIQ
 
 ## Set ENV, LANG only needed if building with docker-1.8
 ENV TERM=xterm \
@@ -68,7 +69,7 @@ RUN mkdir -p ${APPLIANCE_ROOT} && \
 ## GIT clone manageiq
 RUN mkdir -p ${APP_ROOT} && \
     ln -vs ${APP_ROOT} /opt/manageiq/manageiq && \
-    curl -L https://github.com/ManageIQ/manageiq/tarball/${REF} | tar vxz -C ${APP_ROOT} --strip 1
+    curl -L https://github.com/${GHORG}/manageiq/tarball/${REF} | tar vxz -C ${APP_ROOT} --strip 1
 
 ## Setup environment
 RUN ${APPLIANCE_ROOT}/setup && \


### PR DESCRIPTION
This makes it easier to create custom builds of ManageIQ, by telling the image build to pull the sources from a fork instead of pulling them from upstream.

Our specific usecase is for integration testing of pending ManageIQ pull requests. For a while now we've had a fork of this repo with a custom dockerfile, but that got out-of-sync with upstream rather quickly. Having this as a build argument will allow us to stay in sync with upstream when we do our custom builds.

cc: @bazulay 