### PR TITLE
Make websockets work again

### DIFF
--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -443,8 +443,11 @@ objects:
         ServerName https://%{REQUEST_HOST}
 
         ProxyPreserveHost on
-        ProxyPass        /ws/ ws://${NAME}/ws/
-        ProxyPassReverse /ws/ ws://${NAME}/ws/
+
+        RewriteCond %{REQUEST_URI}     ^/ws        [NC]
+        RewriteCond %{HTTP:UPGRADE}    ^websocket$ [NC]
+        RewriteCond %{HTTP:CONNECTION} ^Upgrade$   [NC]
+        RewriteRule .* ws://${NAME}%{REQUEST_URI}  [P,QSA,L]
 
         # For httpd, some ErrorDocuments must by served by the httpd pod
         RewriteCond %{REQUEST_URI} !^/proxy_pages

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -133,8 +133,11 @@ objects:
         ServerName https://%{REQUEST_HOST}
 
         ProxyPreserveHost on
-        ProxyPass        /ws/ ws://${NAME}/ws/
-        ProxyPassReverse /ws/ ws://${NAME}/ws/
+
+        RewriteCond %{REQUEST_URI}     ^/ws        [NC]
+        RewriteCond %{HTTP:UPGRADE}    ^websocket$ [NC]
+        RewriteCond %{HTTP:CONNECTION} ^Upgrade$   [NC]
+        RewriteRule .* ws://${NAME}%{REQUEST_URI}  [P,QSA,L]
 
         # For httpd, some ErrorDocuments must by served by the httpd pod
         RewriteCond %{REQUEST_URI} !^/proxy_pages


### PR DESCRIPTION
This commit changes the proxy directives added in #208 to rewrite rules which seem to play better with the existing rules put in place for auth.

Before this, notifications did not work properly and httpd processes were starting constantly and not exiting.

https://bugzilla.redhat.com/show_bug.cgi?id=1526601

Note:
This seems to have been working before 7e86fe9, but somehow the RewriteRule added there messes with the ws proxy.

@abellotti can you test auth out with this change?
@skateman does this make sense to you?