### PR TITLE
Allow insecure session

### DIFF
--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -101,12 +101,13 @@ objects:
           - name: "${NAME}-server"
             mountPath: "/persistent"
           env:
-          - name: MY_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: ALLOW_INSECURE_SESSION
             value: true
+          - name: APPLICATION_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "${NAME}-secrets"
+                key: admin-password
           - name: APPLICATION_INIT_DELAY
             value: "${APPLICATION_INIT_DELAY}"
           - name: DATABASE_REGION
@@ -116,16 +117,15 @@ objects:
               secretKeyRef:
                 name: "${NAME}-secrets"
                 key: database-url
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           - name: V2_KEY
             valueFrom:
               secretKeyRef:
                 name: "${NAME}-secrets"
                 key: v2-key
-          - name: APPLICATION_ADMIN_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: "${NAME}-secrets"
-                key: admin-password
           resources:
             requests:
               memory: "${APPLICATION_MEM_REQ}"

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -105,6 +105,8 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: ALLOW_INSECURE_SESSION
+            value: true
           - name: APPLICATION_INIT_DELAY
             value: "${APPLICATION_INIT_DELAY}"
           - name: DATABASE_REGION

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -373,6 +373,8 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: ALLOW_INSECURE_SESSION
+            value: true
           - name: APPLICATION_INIT_DELAY
             value: "${APPLICATION_INIT_DELAY}"
           - name: DATABASE_REGION

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -369,12 +369,13 @@ objects:
           - name: "${NAME}-server"
             mountPath: "/persistent"
           env:
-          - name: MY_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: ALLOW_INSECURE_SESSION
             value: true
+          - name: APPLICATION_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "${NAME}-secrets"
+                key: admin-password
           - name: APPLICATION_INIT_DELAY
             value: "${APPLICATION_INIT_DELAY}"
           - name: DATABASE_REGION
@@ -384,16 +385,15 @@ objects:
               secretKeyRef:
                 name: "${NAME}-secrets"
                 key: database-url
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           - name: V2_KEY
             valueFrom:
               secretKeyRef:
                 name: "${NAME}-secrets"
                 key: v2-key
-          - name: APPLICATION_ADMIN_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: "${NAME}-secrets"
-                key: admin-password
           resources:
             requests:
               memory: "${APPLICATION_MEM_REQ}"


### PR DESCRIPTION
I don't think we need this on the backend pod, right?
I also feel like the variable is a bit backwards, but don't want to set "USE_SECURE_SESSION" everywhere on the appliance.  Maybe this will be reversed in a future release?
