### PR TITLE
Mount the configmap into the directory the new image expects

### DIFF
--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -623,7 +623,7 @@ objects:
           - name: miq-pgdb-volume
             mountPath: "/var/lib/pgsql/data"
           - name: miq-pg-configs
-            mountPath: "${POSTGRESQL_CONFIG_DIR}"
+            mountPath: "/opt/app-root/src/postgresql-config/"
           env:
           - name: POSTGRESQL_USER
             value: "${DATABASE_USER}"
@@ -638,8 +638,6 @@ objects:
             value: "${POSTGRESQL_MAX_CONNECTIONS}"
           - name: POSTGRESQL_SHARED_BUFFERS
             value: "${POSTGRESQL_SHARED_BUFFERS}"
-          - name: POSTGRESQL_CONFIG_DIR
-            value: "${POSTGRESQL_CONFIG_DIR}"
           resources:
             requests:
               memory: "${POSTGRESQL_MEM_REQ}"
@@ -812,10 +810,6 @@ parameters:
   displayName: Memcached Slab Page Size
   description: Memcached size of each slab page.
   value: 1m
-- name: POSTGRESQL_CONFIG_DIR
-  displayName: PostgreSQL Configuration Overrides
-  description: Directory used to store PostgreSQL configuration overrides.
-  value: "/var/lib/pgsql/conf.d"
 - name: POSTGRESQL_MAX_CONNECTIONS
   displayName: PostgreSQL Max Connections
   description: PostgreSQL maximum number of database connections allowed.


### PR DESCRIPTION
This will be included into the main postgresql.conf automatically.
Because this path is tied directly to the implementation, there is no reason to expose it to the user as a parameter.

Requires https://github.com/ManageIQ/container-postgresql/pull/8

https://bugzilla.redhat.com/show_bug.cgi?id=1540957