### PR TITLE
Put the PG config map in the new new include location

### DIFF
--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -623,7 +623,7 @@ objects:
           - name: miq-pgdb-volume
             mountPath: "/var/lib/pgsql/data"
           - name: miq-pg-configs
-            mountPath: "/opt/app-root/src/postgresql-config/"
+            mountPath: "/opt/app-root/src/postgresql-cfg/"
           env:
           - name: POSTGRESQL_USER
             value: "${DATABASE_USER}"


### PR DESCRIPTION
https://github.com/sclorg/postgresql-container/pull/232 changed the directory name from postgresql-config to postgresql-cfg.

Marking this as gap/yes and blocker as it will be both of those as soon as QE finds it.