### PR TITLE
 Add rolebindings for the orchestrator to the templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,18 +134,6 @@ $ oc describe scc anyuid | grep Users
 Users:              system:serviceaccount:<your-namespace>:miq-httpd
 ```
 
-### Add the view and edit roles to the orchestrator service account
-
-This will allow the ManageIQ orchestrator pod to dynamically create deployments and other objects at runtime.
-This is how background workers are managed.
-
-_**As basic user**_
-
-```bash
-oc policy add-role-to-user view system:serviceaccount:<your-namespace>:miq-orchestrator -n <your-namespace>
-oc policy add-role-to-user edit system:serviceaccount:<your-namespace>:miq-orchestrator -n <your-namespace>
-```
-
 ### Make a persistent volume to host the MIQ database data (if necessary)
 
 A deployment will need a persistent volume (PV) to store data only if the database is running as a pod.

--- a/teardown
+++ b/teardown
@@ -16,3 +16,6 @@ oc delete serviceaccount miq-httpd
 oc delete cm postgresql-configs
 oc delete cm httpd-configs
 oc delete cm httpd-auth-configs
+
+oc delete rolebinding edit
+oc delete rolebinding view

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -235,6 +235,24 @@ objects:
   metadata:
     name: miq-httpd
 - apiVersion: v1
+  kind: RoleBinding
+  metadata:
+    name: view
+  roleRef:
+    name: view
+  subjects:
+  - kind: ServiceAccount
+    name: miq-orchestrator
+- apiVersion: v1
+  kind: RoleBinding
+  metadata:
+    name: edit
+  roleRef:
+    name: edit
+  subjects:
+  - kind: ServiceAccount
+    name: miq-orchestrator
+- apiVersion: v1
   kind: Service
   metadata:
     name: "${MEMCACHED_SERVICE_NAME}"

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -318,6 +318,24 @@ objects:
   metadata:
     name: miq-httpd
 - apiVersion: v1
+  kind: RoleBinding
+  metadata:
+    name: view
+  roleRef:
+    name: view
+  subjects:
+  - kind: ServiceAccount
+    name: miq-orchestrator
+- apiVersion: v1
+  kind: RoleBinding
+  metadata:
+    name: edit
+  roleRef:
+    name: edit
+  subjects:
+  - kind: ServiceAccount
+    name: miq-orchestrator
+- apiVersion: v1
   kind: Service
   metadata:
     name: "${MEMCACHED_SERVICE_NAME}"


### PR DESCRIPTION
These can be created as template objects rather than making the user create them manually through the command line.