### PR TITLE
Use the recreate deployment strategy for the orchestrator

### DIFF
--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -333,6 +333,8 @@ objects:
     annotations:
       description: Defines how to deploy the ManageIQ appliance
   spec:
+    strategy:
+      type: Recreate
     replicas: 1
     template:
       metadata:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -407,6 +407,8 @@ objects:
     annotations:
       description: Defines how to deploy the ManageIQ appliance
   spec:
+    strategy:
+      type: Recreate
     replicas: 1
     template:
       metadata:


### PR DESCRIPTION
The default (rolling) will allow two orchestrators to run at the same
time which will cause a bunch of confusion for too many reasons to list
here