### PR TITLE
[GAPRINDASHVILI] Fix container logrotate

### DIFF
--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -104,6 +104,7 @@ COPY container-assets/entrypoint /usr/bin
 COPY container-assets/container.data.persist /
 COPY container-assets/appliance-initialize.sh /bin
 COPY container-assets/check-dependent-services.sh /bin
+COPY container-assets/miq_logs.conf /etc/logrotate.d
 ADD  container-assets/container-scripts ${CONTAINER_SCRIPTS_ROOT}
 
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 && \

--- a/images/miq-app/container-assets/miq_logs.conf
+++ b/images/miq-app/container-assets/miq_logs.conf
@@ -1,4 +1,4 @@
-/var/www/miq/vmdb/log/*.log /var/www/miq/vmdb/log/apache/*.log /var/opt/rh/rh-postgresql95/lib/pgsql/data/pg_log/*.log /var/log/tower/*.log {
+/var/www/miq/vmdb/log/*.log /var/www/miq/vmdb/log/apache/*.log {
   daily
   dateext
   missingok

--- a/images/miq-app/container-assets/miq_logs.conf
+++ b/images/miq-app/container-assets/miq_logs.conf
@@ -6,9 +6,6 @@
   notifempty
   compress
   copytruncate
-  prerotate
-    source /etc/default/evm; /bin/sh ${APPLIANCE_SOURCE_DIRECTORY}/logrotate_free_space_check.sh $1
-  endscript
   lastaction
     /sbin/service httpd reload > /dev/null 2>&1 || true
   endscript

--- a/images/miq-app/container-assets/miq_logs.conf
+++ b/images/miq-app/container-assets/miq_logs.conf
@@ -1,0 +1,15 @@
+/var/www/miq/vmdb/log/*.log /var/www/miq/vmdb/log/apache/*.log /var/opt/rh/rh-postgresql95/lib/pgsql/data/pg_log/*.log /var/log/tower/*.log {
+  daily
+  dateext
+  missingok
+  rotate 14
+  notifempty
+  compress
+  copytruncate
+  prerotate
+    source /etc/default/evm; /bin/sh ${APPLIANCE_SOURCE_DIRECTORY}/logrotate_free_space_check.sh $1
+  endscript
+  lastaction
+    /sbin/service httpd reload > /dev/null 2>&1 || true
+  endscript
+}


### PR DESCRIPTION
This PR adds the logrotate configuration to the app images and alters it so that it will correctly rotate the application logs. In the first commit, the initial file was taken from the [manageiq-appliance repo](https://github.com/ManageIQ/manageiq-appliance/blob/a04b2a8a2a96f7a801e4701cd9c8cd2492079d69/COPY/etc/logrotate.d/miq_logs.conf). Subsequent commits alter the file.

Before this PR logs were not being rotated because the free space check script was failing on the container filesystem. Because filesystem space is not really the concern of the container, the check was removed from this overwrite file.

https://bugzilla.redhat.com/show_bug.cgi?id=1560210