### PR TITLE
[HAMMER] Use the ruby 2.4 image

### DIFF
--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM manageiq/ruby:2.3.6
+FROM manageiq/ruby:2.4
 MAINTAINER ManageIQ https://github.com/ManageIQ/manageiq-appliance-build
 
 ## Set build ARGs


### PR DESCRIPTION
As a part of the upgrade in https://github.com/ManageIQ/manageiq-appliance-build/pull/280