### PR TITLE
[HAMMER] Make builds work

### DIFF
--- a/images/miq-app-frontend/Dockerfile
+++ b/images/miq-app-frontend/Dockerfile
@@ -41,7 +41,7 @@ RUN source /etc/default/evm && \
     bin/rails log:clear tmp:clear && \
     rake evm:compile_assets && \
     # Cleanup install artifacts
-    npm cache clean && \
+    npm cache clean --force && \
     bower cache clean && \
     rm -rvf ${APP_ROOT}/tmp/cache/assets && \
     rm -vf ${APP_ROOT}/log/*.log

--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -72,7 +72,7 @@ RUN mkdir -p ${APP_ROOT} && \
 
 ## Setup environment
 RUN ${APPLIANCE_ROOT}/setup && \
-    mkdir ${APP_ROOT}/log/apache && \
+    mkdir -p ${APP_ROOT}/log/apache && \
     mkdir ${APP_ROOT_PERSISTENT} && \
     mkdir -p ${CONTAINER_SCRIPTS_ROOT} && \
     cp ${APP_ROOT}/config/cable.yml.sample ${APP_ROOT}/config/cable.yml

--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -82,7 +82,7 @@ WORKDIR ${APP_ROOT}
 RUN source /etc/default/evm && \
     export RAILS_USE_MEMORY_STORE="true" && \
     npm install bower yarn -g && \
-    gem install bundler -v 1.15.4 && \
+    gem install bundler -v ">=1.16.2" && \
     bundle install && \
     rake update:ui && \
     bin/rails log:clear tmp:clear && \

--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -30,7 +30,8 @@ RUN curl -sSLko /etc/yum.repos.d/manageiq-ManageIQ-Master-epel-7.repo \
       https://copr.fedorainfracloud.org/coprs/manageiq/ManageIQ-Master/repo/epel-7/manageiq-ManageIQ-Master-epel-7.repo
 
 ## Install EPEL repo, yum necessary packages for the build without docs, clean all caches
-RUN yum -y install centos-release-scl-rh && \
+RUN yum -y install centos-release-scl-rh \
+                   https://rpm.nodesource.com/pub_8.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm && \
     yum -y install --setopt=tsflags=nodocs \
                    chrony                  \
                    cmake                   \
@@ -48,7 +49,6 @@ RUN yum -y install centos-release-scl-rh && \
                    net-tools               \
                    nmap-ncat               \
                    nodejs                  \
-                   npm                     \
                    openldap-clients        \
                    openscap-scanner        \
                    patch                   \
@@ -89,7 +89,7 @@ RUN source /etc/default/evm && \
     rake evm:compile_assets && \
     rake evm:compile_sti_loader && \
     # Cleanup install artifacts
-    npm cache clean && \
+    npm cache clean --force && \
     bower cache clean && \
     find ${RUBY_GEMS_ROOT}/gems/ -name .git | xargs rm -rvf && \
     find ${RUBY_GEMS_ROOT}/gems/ | grep "\.s\?o$" | xargs rm -rvf && \


### PR DESCRIPTION
These changes have been made on the appliance side, but have been missing here for months.

Specifically, this PR updates to node 8, creates the `vmdb/log` directory when trying to create the `apache` log directory, and updates to bundler `>=1.16.2`