### PR TITLE
[HAMMER] Move from apache module mod_auth_kerb to mod_auth_gssap

### DIFF
--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -378,16 +378,13 @@ objects:
       Include "conf.d/external-auth-load-modules-conf"
 
       <Location /dashboard/kerberos_authenticate>
-        AuthType                   Kerberos
-        AuthName                   "Kerberos Login"
-        KrbMethodNegotiate         On
-        KrbMethodK5Passwd          Off
-        KrbAuthRealms              ${HTTPD_AUTH_KERBEROS_REALMS}
-        Krb5KeyTab                 /etc/http.keytab
-        KrbServiceName             Any
-        Require                    pam-account httpd-auth
-
         ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js
+        AuthType           GSSAPI
+        AuthName           "GSSAPI Single Sign On Login"
+        GssapiCredStore    keytab:/etc/http.keytab
+        GssapiLocalName    on
+        Require            pam-account httpd-auth
+
       </Location>
 
       Include "conf.d/external-auth-login-form-conf"
@@ -398,13 +395,11 @@ objects:
       Include "conf.d/external-auth-load-modules-conf"
 
       <Location /dashboard/kerberos_authenticate>
-        AuthType                   Kerberos
-        AuthName                   "Kerberos Login"
-        KrbMethodNegotiate         On
-        KrbMethodK5Passwd          Off
-        KrbAuthRealms              ${HTTPD_AUTH_KERBEROS_REALMS}
-        Krb5KeyTab                 /etc/krb5.keytab
-        KrbServiceName             Any
+        AuthType           GSSAPI
+        AuthName           "GSSAPI Single Sign On Login"
+        GssapiCredStore    keytab:/etc/krb5.keytab
+        GssapiLocalName    on
+        Require            pam-account httpd-auth
         Require                    pam-account httpd-auth
 
         ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -400,7 +400,6 @@ objects:
         GssapiCredStore    keytab:/etc/krb5.keytab
         GssapiLocalName    on
         Require            pam-account httpd-auth
-        Require                    pam-account httpd-auth
 
         ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js
       </Location>

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -194,14 +194,11 @@ objects:
       Include "conf.d/external-auth-load-modules-conf"
 
       <Location /dashboard/kerberos_authenticate>
-        AuthType                   Kerberos
-        AuthName                   "Kerberos Login"
-        KrbMethodNegotiate         On
-        KrbMethodK5Passwd          Off
-        KrbAuthRealms              ${HTTPD_AUTH_KERBEROS_REALMS}
-        Krb5KeyTab                 /etc/http.keytab
-        KrbServiceName             Any
-        Require                    pam-account httpd-auth
+        AuthType           GSSAPI
+        AuthName           "GSSAPI Single Sign On Login"
+        GssapiCredStore    keytab:/etc/http.keytab
+        GssapiLocalName    on
+        Require            pam-account httpd-auth
 
         ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js
       </Location>
@@ -214,14 +211,11 @@ objects:
       Include "conf.d/external-auth-load-modules-conf"
 
       <Location /dashboard/kerberos_authenticate>
-        AuthType                   Kerberos
-        AuthName                   "Kerberos Login"
-        KrbMethodNegotiate         On
-        KrbMethodK5Passwd          Off
-        KrbAuthRealms              ${HTTPD_AUTH_KERBEROS_REALMS}
-        Krb5KeyTab                 /etc/krb5.keytab
-        KrbServiceName             Any
-        Require                    pam-account httpd-auth
+        AuthType           GSSAPI
+        AuthName           "GSSAPI Single Sign On Login"
+        GssapiCredStore    keytab:/etc/krb5.keytab
+        GssapiLocalName    on
+        Require            pam-account httpd-auth
 
         ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js
       </Location>


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1610127/stories/160297262

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650583

This PR is one of two that will implement moving external authentication support from
the Apache module mod_auth_kerb to mod_auth_gssapi for the Openshift/podified build

The other PR is:
https://github.com/ManageIQ/container-httpd/pull/38