### PR TITLE
Don't remove .so file for compiled gems

### DIFF
--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -88,7 +88,7 @@ RUN source /etc/default/evm && \
     npm cache clean --force && \
     bower cache clean && \
     find ${RUBY_GEMS_ROOT}/gems/ -name .git | xargs rm -rvf && \
-    find ${RUBY_GEMS_ROOT}/gems/ | grep "\.s\?o$" | xargs rm -rvf && \
+    find ${RUBY_GEMS_ROOT}/gems/ | grep "\.o$" | xargs rm -rvf && \
     rm -rvf ${RUBY_GEMS_ROOT}/gems/rugged-*/vendor/libgit2/build && \
     rm -rvf ${RUBY_GEMS_ROOT}/cache/* && \
     rm -rvf /root/.bundle/cache && \


### PR DESCRIPTION
As a part of cleanup, .so files for compiled gems are removed from gem install dir (`/usr/local/lib/ruby/gems/2.5.0/gems/`) in backend image build. This now causes `rake update:ui` to fail in frontend image build.

```
Step 11/17 : RUN source /etc/default/evm &&     export RAILS_USE_MEMORY_STORE="true" &&     rake update:ui &&     bin/rails log:clear tmp:clear &&     rake evm:compile_assets &&     npm cache clean --force &&     bower cache clean &&     rm -rvf ${APP_ROOT}/tmp/cache/assets &&     rm -vf ${APP_ROOT}/log/*.log
 ---> Running in 53f37d537941
rake aborted!
LoadError: Could not open library '/usr/local/lib/ruby/gems/2.5.0/gems/sassc-2.1.0-x86_64-linux/lib/sassc/libsass.so': /usr/local/lib/ruby/gems/2.5.0/gems/sassc-2.1.0-x86_64-linux/lib/sassc/libsass.so: cannot open shared object file: No such file or directory
```
Unlike other compiled gems, `libsass.so` for `sassc` gem isn't copied to `extensions` directory (`/usr/local/lib/ruby/gems/2.5.0/extensions/x86_64-linux/2.5.0/`) and 
 is available only in the gem install directory. So no .so file on the machine after being removed in the backend image.

This started failing last week when `sass-rails` 6.x was released. 5.x required `sass`, but 6.x requires `sassc-rails` which requires `sassc`.