### PR TITLE
Switch find_by_* to lookup_by_*

### DIFF
--- a/images/miq-app/container-assets/container-scripts/container-deploy-common.sh
+++ b/images/miq-app/container-assets/container-scripts/container-deploy-common.sh
@@ -124,7 +124,7 @@ function migrate_db() {
 function set_admin_pwd() {
  echo "== Setting admin password =="
 
-   cd ${APP_ROOT} && bin/rails runner "EvmDatabase.seed_primordial; user = User.find_by_userid('admin').update_attributes!(:password => ENV['APPLICATION_ADMIN_PASSWORD'])"
+   cd ${APP_ROOT} && bin/rails runner "EvmDatabase.seed_primordial; user = User.lookup_by_userid('admin').update_attributes!(:password => ENV['APPLICATION_ADMIN_PASSWORD'])"
 
    [ "$?" -ne "0" ] && echo "ERROR: Failed to set admin password, please check appliance logs"
 }


### PR DESCRIPTION
The find_by_* methods defined in manageiq repo has conflicts with
rails dynamic finding and now they have been changed to lookup_by_.
Switching the callers in this repo to the lookup_by_ methods.

Depend on ManageIQ/manageiq#19313