### PR TITLE
OpenShift external DB template enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,9 +247,11 @@ Import the MIQ external db template
 
 `$ oc create -f templates/miq-template-ext-db.yaml`
 
-Launch deployment, database server IP is required, rest of settings must match your remote PG server side.
+Launch deployment, database server IP or host name is required, rest of settings must match your remote PG server side.
 
-`$ oc new-app --template=manageiq-ext-db -p DATABASE_IP=<server_ip> -p DATABASE_USER=<user> -p DATABASE_PASSWORD=<password> -p DATABASE_NAME=<database_name>`
+Note: URL encode the user name, if your user name includes special characters like `@`.
+
+`$ oc new-app --template=manageiq-ext-db -p DATABASE_HOST=<server> -p DATABASE_USER=<user> -p DATABASE_PASSWORD=<password> -p DATABASE_NAME=<database_name>`
 
 ## Verifying the setup was successful
 

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -50,7 +50,7 @@ objects:
   stringData:
     pg-password: "${DATABASE_PASSWORD}"
     admin-password: "${APPLICATION_ADMIN_PASSWORD}"
-    database-url: postgresql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_SERVICE_NAME}/${DATABASE_NAME}?encoding=utf8&pool=5&wait_timeout=5
+    database-url: postgresql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?encoding=utf8&pool=5&wait_timeout=5
     v2-key: "${V2_KEY}"
 - apiVersion: v1
   kind: Service
@@ -305,28 +305,6 @@ objects:
               cpu: "${MEMCACHED_CPU_REQ}"
             limits:
               memory: "${MEMCACHED_MEM_LIMIT}"
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: "${DATABASE_SERVICE_NAME}"
-    annotations:
-      description: Remote database service
-  spec:
-    ports:
-    - name: postgresql
-      port: 5432
-      targetPort: "${{DATABASE_PORT}}"
-    selector: {}
-- apiVersion: v1
-  kind: Endpoints
-  metadata:
-    name: "${DATABASE_SERVICE_NAME}"
-  subsets:
-  - addresses:
-    - ip: "${DATABASE_IP}"
-    ports:
-    - port: "${{DATABASE_PORT}}"
-      name: postgresql
 - apiVersion: v1
   kind: ConfigMap
   metadata:
@@ -678,11 +656,6 @@ parameters:
   description: Encryption Key for ManageIQ Passwords
   from: "[a-zA-Z0-9]{43}"
   generate: expression
-- name: DATABASE_SERVICE_NAME
-  displayName: PostgreSQL Service Name
-  required: true
-  description: The name of the OpenShift Service exposed for the PostgreSQL container.
-  value: postgresql
 - name: DATABASE_USER
   displayName: PostgreSQL User
   required: true
@@ -694,10 +667,10 @@ parameters:
   description: Password for the PostgreSQL user.
   from: "[a-zA-Z0-9]{8}"
   generate: expression
-- name: DATABASE_IP
-  displayName: PostgreSQL Server IP
+- name: DATABASE_HOST
+  displayName: PostgreSQL Server IP or host name
   required: true
-  description: PostgreSQL external server IP used to configure service.
+  description: PostgreSQL external server IP or host name used to configure the connection string.
   value: ''
 - name: DATABASE_PORT
   displayName: PostgreSQL Server Port

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -663,7 +663,7 @@ parameters:
 - name: DATABASE_USER
   displayName: PostgreSQL User
   required: true
-  description: PostgreSQL user that will access the database.
+  description: PostgreSQL user that will access the database (Special characters need to be URL encoded).
   value: root
 - name: DATABASE_PASSWORD
   displayName: PostgreSQL Password

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -147,6 +147,7 @@ objects:
               cpu: "${APPLICATION_CPU_REQ}"
             limits:
               memory: "${APPLICATION_MEM_LIMIT}"
+              cpu: "${APPLICATION_CPU_LIMIT}"
           lifecycle:
             preStop:
               exec:
@@ -224,6 +225,7 @@ objects:
               cpu: "${APPLICATION_CPU_REQ}"
             limits:
               memory: "${APPLICATION_MEM_LIMIT}"
+              cpu: "${APPLICATION_CPU_LIMIT}"
           lifecycle:
             preStop:
               exec:
@@ -305,6 +307,7 @@ objects:
               cpu: "${MEMCACHED_CPU_REQ}"
             limits:
               memory: "${MEMCACHED_MEM_LIMIT}"
+              cpu: "${MEMCACHED_CPU_LIMIT}"
 - apiVersion: v1
   kind: ConfigMap
   metadata:
@@ -606,6 +609,7 @@ objects:
               cpu: "${HTTPD_CPU_REQ}"
             limits:
               memory: "${HTTPD_MEM_LIMIT}"
+              cpu: "${HTTPD_CPU_LIMIT}"
           env:
           - name: APPLICATION_DOMAIN
             value: "${APPLICATION_DOMAIN}"
@@ -692,6 +696,50 @@ parameters:
   required: true
   description: Admin password that will be set on the application.
   value: smartvm
+- name: APPLICATION_DOMAIN
+  displayName: Application Hostname
+  description: The exposed hostname that will route to the application service, if left blank a value will be defaulted.
+  value: ''
+- name: APPLICATION_REPLICA_COUNT
+  displayName: Application Replica Count
+  description: This is the number of Application replicas requested to deploy.
+  value: '1'
+- name: APPLICATION_VOLUME_CAPACITY
+  displayName: Application Volume Capacity
+  required: true
+  description: Volume space available for application data.
+  value: 5Gi
+- name: APPLICATION_MEM_REQ
+  displayName: Application Min RAM Requested
+  required: true
+  description: Minimum amount of memory the Application container will need.
+  value: 6144Mi
+- name: APPLICATION_CPU_REQ
+  displayName: Application Min CPU Requested
+  required: true
+  description: Minimum amount of CPU time the Application container will need (expressed in millicores).
+  value: 1000m
+- name: APPLICATION_MEM_LIMIT
+  displayName: Application Max RAM Limit
+  required: true
+  description: Maximum amount of memory the Application container can consume.
+  value: 16384Mi
+- name: APPLICATION_CPU_LIMIT
+  displayName: Application Max CPU Limit
+  description: Maximum amount of CPU cores the Application container can consume.
+  value: 6000m
+- name: APPLICATION_IMG_NAME
+  displayName: Application Image Name
+  description: This is the Application image name requested to deploy.
+  value: docker.io/manageiq/manageiq-pods
+- name: FRONTEND_APPLICATION_IMG_TAG
+  displayName: Front end Application Image Tag
+  description: This is the ManageIQ Frontend Application image tag/version requested to deploy.
+  value: frontend-latest
+- name: BACKEND_APPLICATION_IMG_TAG
+  displayName: Back end Application Image Tag
+  description: This is the ManageIQ Backend Application image tag/version requested to deploy.
+  value: backend-latest
 - name: MEMCACHED_SERVICE_NAME
   required: true
   displayName: Memcached Service Name
@@ -709,36 +757,26 @@ parameters:
   displayName: Memcached Slab Page Size
   description: Memcached size of each slab page.
   value: 1m
-- name: APPLICATION_CPU_REQ
-  displayName: Application Min CPU Requested
-  required: true
-  description: Minimum amount of CPU time the Application container will need (expressed in millicores).
-  value: 1000m
 - name: MEMCACHED_CPU_REQ
   displayName: Memcached Min CPU Requested
   required: true
   description: Minimum amount of CPU time the Memcached container will need (expressed in millicores).
   value: 200m
-- name: APPLICATION_MEM_REQ
-  displayName: Application Min RAM Requested
-  required: true
-  description: Minimum amount of memory the Application container will need.
-  value: 6144Mi
 - name: MEMCACHED_MEM_REQ
   displayName: Memcached Min RAM Requested
   required: true
   description: Minimum amount of memory the Memcached container will need.
   value: 64Mi
-- name: APPLICATION_MEM_LIMIT
-  displayName: Application Max RAM Limit
-  required: true
-  description: Maximum amount of memory the Application container can consume.
-  value: 16384Mi
 - name: MEMCACHED_MEM_LIMIT
   displayName: Memcached Max RAM Limit
   required: true
   description: Maximum amount of memory the Memcached container can consume.
   value: 256Mi
+- name: MEMCACHED_CPU_LIMIT
+  displayName: Memcached Max CPU Limit
+  description: Maximum amount of CPU cores the Memcached container can consume.
+  required: true
+  value: 800m
 - name: MEMCACHED_IMG_NAME
   displayName: Memcached Image Name
   description: This is the Memcached image name requested to deploy.
@@ -747,31 +785,6 @@ parameters:
   displayName: Memcached Image Tag
   description: This is the Memcached image tag/version requested to deploy.
   value: latest
-- name: APPLICATION_IMG_NAME
-  displayName: Application Image Name
-  description: This is the Application image name requested to deploy.
-  value: docker.io/manageiq/manageiq-pods
-- name: FRONTEND_APPLICATION_IMG_TAG
-  displayName: Front end Application Image Tag
-  description: This is the ManageIQ Frontend Application image tag/version requested to deploy.
-  value: frontend-latest
-- name: BACKEND_APPLICATION_IMG_TAG
-  displayName: Back end Application Image Tag
-  description: This is the ManageIQ Backend Application image tag/version requested to deploy.
-  value: backend-latest
-- name: APPLICATION_DOMAIN
-  displayName: Application Hostname
-  description: The exposed hostname that will route to the application service, if left blank a value will be defaulted.
-  value: ''
-- name: APPLICATION_REPLICA_COUNT
-  displayName: Application Replica Count
-  description: This is the number of Application replicas requested to deploy.
-  value: '1'
-- name: APPLICATION_VOLUME_CAPACITY
-  displayName: Application Volume Capacity
-  required: true
-  description: Volume space available for application data.
-  value: 5Gi
 - name: HTTPD_SERVICE_NAME
   required: true
   displayName: Apache httpd Service Name
@@ -782,14 +795,6 @@ parameters:
   displayName: Apache httpd DBus API Service Name
   description: The name of httpd dbus api service.
   value: httpd-dbus-api
-- name: HTTPD_IMG_NAME
-  displayName: Apache httpd Image Name
-  description: This is the httpd image name requested to deploy.
-  value: docker.io/manageiq/httpd
-- name: HTTPD_IMG_TAG
-  displayName: Apache httpd Image Tag
-  description: This is the httpd image tag/version requested to deploy.
-  value: latest
 - name: HTTPD_CONFIG_DIR
   displayName: Apache httpd Configuration Directory
   description: Directory used to store the Apache configuration files.
@@ -813,3 +818,16 @@ parameters:
   required: true
   description: Maximum amount of memory the httpd container can consume.
   value: 8192Mi
+- name: HTTPD_CPU_LIMIT
+  displayName: Apache httpd Max CPU limit
+  required: true
+  description: Maximum amount of CPU cores the httpd container can consume.
+  value: 2000m
+- name: HTTPD_IMG_NAME
+  displayName: Apache httpd Image Name
+  description: This is the httpd image name requested to deploy.
+  value: docker.io/manageiq/httpd
+- name: HTTPD_IMG_TAG
+  displayName: Apache httpd Image Tag
+  description: This is the httpd image tag/version requested to deploy.
+  value: latest


### PR DESCRIPTION
- Added CPU limits to the template because the deployment of the pods will fail when deployed in a NS with configured quotas and limits. If the request is configured request but the limit is left empty, OpenShift will throw an error that the limit can't be lower than the request (happend in OCP 3.11).
- Removed the postgres service and endpoint because they are not needed. You can specify the host name or IP address directly in the postgres connection string. This also enables the use of host names for the DB host, which is not possible for endpoints because they require an IP address in OpenShift.
- Added a note about URL encoding the user name. I've been using Azure DBaaS postgres, which requires the user name to be `<user>@<server_name>` format which will break the connection because of the `@` sign.

Let me know what you think about these changes.

PS: We evaluated this solution and just deployed a production instance last week. Now I wanted to give you guys my feedback about the things I needed to change to get everything running on our OCP cluster.