### PR TITLE
Update the default build template ref to the pods master branch

### DIFF
--- a/templates/build-template.yaml
+++ b/templates/build-template.yaml
@@ -184,7 +184,7 @@ parameters:
 - name: SOURCE_REPOSITORY_URL
   value: https://github.com/ManageIQ/manageiq-pods
 - name: SOURCE_REPOSITORY_REF
-  value: rearch
+  value: master
 - name: MIQ_REF
   value: master
 - name: MIQ_ORG


### PR DESCRIPTION
We can do this now that we merged the rearch branch back into master