### PR TITLE
[IVANCHUK] Template removal of pg shared_preload_librariers

### DIFF
--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -88,7 +88,6 @@ objects:
       # RESOURCE USAGE (except WAL)
       #------------------------------------------------------------------------------
 
-      shared_preload_libraries = 'pglogical,repmgr'
       max_worker_processes = 10
 
       #------------------------------------------------------------------------------


### PR DESCRIPTION
Fix of PostgreSQL ConfigMap `${DATABASE_SERVICE_NAME}-configs`:
* `shared_preload_libraries = 'pglogical,repmgr'` from `templates/miq-template.yaml`
* as PostgreSQL 10 being used in `ivanchuk` release, those parameters are not required - if kept there, PostgreSQL does not start
* resolves issue https://github.com/ManageIQ/manageiq-pods/issues/346