### PR TITLE
Use kubernetes compatible objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,10 @@ It is strongly suggested that you validate NFS share connectivity from an OpenSh
 
 ## Deploy MIQ
 
-If you wish to add a SSL certificate now, you can edit the httpd template and provide that now.  Check the Edge Termination section of [Secured Routes](https://docs.okd.io/latest/architecture/networking/routes.html#secured-routes) for more information.
-This can be easily changed later in the Openshift UI by navigating to *Your Project* -> Applications -> Routes -> httpd -> Actions -> Edit.
+If you wish to add a SSL certificate now, you can use your cert and key files to create the required secret:
+```bash
+$ oc create secret tls tls-secret --cert=tls.crt --key=tls.key
+```
 
 Application parameters can be specified in a parameters file. An example file can be found [in the project root](https://github.com/ManageIQ/manageiq-pods/blob/master/parameters)
 The existing parameters file contains all the default values for template parameters. You can create a new file containing any customizations.
@@ -280,19 +282,23 @@ Additional workers for provider operations will be deployed or removed by the or
 
 _**Note:**_ The orchestrator will enforce its desired state over the worker replicas. This means that any changes made to desired replica numbers in the OpenShift UI will be quickly reverted by the orchestrator. 
 
-## POD access and routes
+## Pod access and ingress
 
 ### Get a shell on the MIQ pod
 
 `$ oc rsh <pod_name> bash -l`
 
 ### Obtain host information from route
-A route should have been deployed via template for HTTPS access on the MIQ pod
+An ingress should have been deployed via template for HTTPS access on the MIQ pod
+When an ingress is deployed in OpenShift, a route is automatically created.
 
 ```bash
-$oc get routes
-NAME      HOST/PORT                              PATH      SERVICES   PORT      TERMINATION     WILDCARD
-httpd     miq-dev.apps.example.com                         httpd      http      edge/Redirect   None
+$ oc get ingress
+NAME      HOSTS                              ADDRESS   PORTS     AGE
+httpd     miq-dev.apps.example.com                     80, 443   56s
+$ oc get routes
+NAME          HOST/PORT                          PATH      SERVICES   PORT      TERMINATION     WILDCARD
+httpd-qlvmj   miq-dev.apps.example.com           /         httpd      80        edge/Redirect   None
 ```
 Examine output and point your web browser to the reported URL/HOST.
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -5,7 +5,7 @@ param_file=$1
 
 function apply_template() {
   local template=$1
-  oc process -f templates/app/$template --param-file=$param_file --ignore-unknown-parameters | oc apply -f -
+  oc process --local -f templates/app/$template --param-file=$param_file --ignore-unknown-parameters | oc apply -f -
 }
 
 function secret_missing() {

--- a/bin/deploy
+++ b/bin/deploy
@@ -17,11 +17,18 @@ function parameter_provided() {
   grep -q "^$1=\S" $param_file
 }
 
+function create_tls_secret() {
+  openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout tls.key -out tls.crt -subj "/CN=server"
+  oc create secret tls tls-secret --cert=tls.crt --key=tls.key
+  rm tls.crt tls.key
+}
+
 # For us to safely create the secret we need to have either provided a password
 # or not have created the secret yet. This ensures we don't overwrite the existing
 # password with a newly generated one.
 (parameter_provided "DATABASE_PASSWORD" || secret_missing "postgresql-secrets") && apply_template "postgresql-secrets.yaml"
 (parameter_provided "ENCRYPTION_KEY" || secret_missing "manageiq-secrets") && apply_template "manageiq-secrets.yaml"
+secret_missing "tls-secret" && create_tls_secret
 
 # Orchestrator RBAC
 oc apply -f templates/app/rbac.yaml

--- a/bin/teardown
+++ b/bin/teardown
@@ -5,6 +5,7 @@ oc delete all -l app=manageiq
 oc get pvc -o name |xargs oc delete
 
 oc delete secret -l app=manageiq
+oc delete secret tls-secret
 
 oc delete serviceaccount miq-anyuid
 oc delete serviceaccount miq-orchestrator
@@ -16,3 +17,5 @@ oc delete cm httpd-auth-configs
 
 oc delete rolebinding edit
 oc delete rolebinding view
+
+oc delete ingress httpd

--- a/templates/app/httpd.yaml
+++ b/templates/app/httpd.yaml
@@ -276,9 +276,6 @@ objects:
             name: httpd-auth-configs
         containers:
         - name: httpd
-          securityContext:
-            capabilities:
-              add: ["SYS_ADMIN"]
           image: "${HTTPD_IMAGE_NAME}:${HTTPD_IMAGE_TAG}"
           ports:
           - containerPort: 80

--- a/templates/app/httpd.yaml
+++ b/templates/app/httpd.yaml
@@ -250,18 +250,17 @@ objects:
       port: 8080
     selector:
       name: httpd
-- apiVersion: v1
-  kind: DeploymentConfig
+- apiVersion: apps/v1
+  kind: Deployment
   metadata:
     name: httpd
     labels:
       app: manageiq
   spec:
-    triggers:
-    - type: ConfigChange
     replicas: 1
     selector:
-      name: httpd
+      matchLabels:
+        name: httpd
     template:
       metadata:
         name: httpd
@@ -277,6 +276,9 @@ objects:
             name: httpd-auth-configs
         containers:
         - name: httpd
+          securityContext:
+            capabilities:
+              add: ["SYS_ADMIN"]
           image: "${HTTPD_IMAGE_NAME}:${HTTPD_IMAGE_TAG}"
           ports:
           - containerPort: 80
@@ -342,24 +344,22 @@ objects:
               exec:
                 command:
                 - "/usr/bin/save-container-environment"
-        serviceAccount: miq-httpd
         serviceAccountName: miq-httpd
-- apiVersion: v1
-  kind: Route
+- apiVersion: networking.k8s.io/v1beta1
+  kind: Ingress
   metadata:
     name: httpd
     labels:
       app: manageiq
   spec:
-    host: "${APPLICATION_DOMAIN}"
-    port:
-      targetPort: http
-    tls:
-      termination: edge
-      insecureEdgeTerminationPolicy: Redirect
-    to:
-      kind: Service
-      name: httpd
+    rules:
+    - host: "${APPLICATION_DOMAIN}"
+      http:
+        paths:
+        - path: "/"
+          backend:
+            serviceName: httpd
+            servicePort: 80
 parameters:
 - name: APPLICATION_DOMAIN
   value: ''

--- a/templates/app/httpd.yaml
+++ b/templates/app/httpd.yaml
@@ -345,13 +345,17 @@ objects:
                 command:
                 - "/usr/bin/save-container-environment"
         serviceAccountName: miq-httpd
-- apiVersion: networking.k8s.io/v1beta1
+- apiVersion: extensions/v1beta1
   kind: Ingress
   metadata:
     name: httpd
     labels:
       app: manageiq
   spec:
+    tls:
+    - hosts:
+      - "${APPLICATION_DOMAIN}"
+      secretName: tls-secret
     rules:
     - host: "${APPLICATION_DOMAIN}"
       http:

--- a/templates/app/memcached.yaml
+++ b/templates/app/memcached.yaml
@@ -15,18 +15,17 @@ objects:
       port: 11211
     selector:
       name: memcached
-- apiVersion: v1
-  kind: DeploymentConfig
+- apiVersion: apps/v1
+  kind: Deployment
   metadata:
     name: memcached
     labels:
       app: manageiq
   spec:
-    triggers:
-    - type: ConfigChange
     replicas: 1
     selector:
-      name: memcached
+      matchLabels:
+        name: memcached
     template:
       metadata:
         name: memcached

--- a/templates/app/orchestrator.yaml
+++ b/templates/app/orchestrator.yaml
@@ -3,8 +3,8 @@ kind: Template
 metadata:
   name: manageiq-orchestrator
 objects:
-- apiVersion: v1
-  kind: DeploymentConfig
+- apiVersion: apps/v1
+  kind: Deployment
   metadata:
     name: manageiq-orchestrator
     labels:
@@ -14,7 +14,8 @@ objects:
       type: Recreate
     replicas: 1
     selector:
-      name: manageiq-orchestrator
+      matchLabels:
+        name: manageiq-orchestrator
     template:
       metadata:
         name: manageiq-orchestrator
@@ -82,11 +83,8 @@ objects:
               cpu: "${ORCHESTRATOR_CPU_REQ}"
             limits:
               memory: "${ORCHESTRATOR_MEM_LIMIT}"
-        serviceAccount: miq-orchestrator
         serviceAccountName: miq-orchestrator
         terminationGracePeriodSeconds: 90
-      triggers:
-      - type: ConfigChange
 parameters:
 - name: DATABASE_PORT
   value: '5432'

--- a/templates/app/postgresql.yaml
+++ b/templates/app/postgresql.yaml
@@ -101,8 +101,8 @@ objects:
       port: 5432
     selector:
       name: postgresql
-- apiVersion: v1
-  kind: DeploymentConfig
+- apiVersion: apps/v1
+  kind: Deployment
   metadata:
     name: postgresql
     labels:
@@ -110,11 +110,10 @@ objects:
   spec:
     strategy:
       type: Recreate
-    triggers:
-    - type: ConfigChange
     replicas: 1
     selector:
-      name: postgresql
+      matchLabels:
+        name: postgresql
     template:
       metadata:
         name: postgresql

--- a/templates/app/rbac.yaml
+++ b/templates/app/rbac.yaml
@@ -13,21 +13,25 @@ items:
   kind: ServiceAccount
   metadata:
     name: miq-httpd
-- apiVersion: v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
     name: view
   roleRef:
+    kind: ClusterRole
     name: view
+    apiGroup: rbac.authorization.k8s.io
   subjects:
   - kind: ServiceAccount
     name: miq-orchestrator
-- apiVersion: v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
     name: edit
   roleRef:
+    kind: ClusterRole
     name: edit
+    apiGroup: rbac.authorization.k8s.io
   subjects:
   - kind: ServiceAccount
     name: miq-orchestrator

--- a/templates/examples/minikube-pv.yaml
+++ b/templates/examples/minikube-pv.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv0001
+spec:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 15Gi
+  hostPath:
+    path: "/data/pv0001/"


### PR DESCRIPTION
This PR makes all objects created by our templates usable with either Kubernetes or OpenShift.

The obvious changes here are DeploymentConfig objects become Deployments and the Route becomes an Ingress.

The more subtle changes are to do with ssl and security contexts ...

By default, in production mode, the manageiq application requires us to communicate over https. Previously, our ssl handling was done by the route and routes generated a self-signed cert and key pair for the user if one was not provided. An Ingress object does not. So one change was that if a secret didn't exist already to hold the cert and key, the deploy script creates a keypair and a secret.

For the httpd pod to run correctly it needs the SYS_ADMIN kernel capability. In openshift this was provided by either the custom scc we have in this repo (minishift) or assigned to the container dynamically by the `oci-systemd-hooks` because the container entrypoint is `init`. Kubernetes doesn't have these hooks and also does not have the concept of sccs (by default, that is. There are PodAdmissionControllers, but since that's not on by default I didn't address them here). To get the pod to run correctly on kubernetes, we needed to assign the capability, but doing so in the template prevented the pod from deploying on openshift. I made the choice to keep things working without a patch on openshift and require users to patch the deployment after they create it on kubernetes.

The last choice made in this PR was to keep using openshift templates and, by extension, the `oc` binary in both the README and the deploy script. Without moving the entire repo to Helm (or a home-grown templating tool), kubernetes doesn't really have a solution to the templating problem. If someone wants to take this effort on without involving Tiller (server-side component of Helm) so that it will work on both OpenShift and Kubernetes I would welcome it.

Requires https://github.com/ManageIQ/manageiq/pull/19500