### PR TITLE
Add support to use non-default npm registry

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -11,7 +11,6 @@ SUI_ORG=${SUI_ORG:-ManageIQ}
 APPLIANCE_ORG=${APPLIANCE_ORG:-ManageIQ}
 
 NPM_REGISTRY_OVERRIDE=${NPM_REGISTRY_OVERRIDE:-""}
-NPM_REGISTRY_RESET=${NPM_REGISTRY_RESET:-false}
 
 while getopts "t:d:r:nhp" opt; do
   case $opt in
@@ -63,7 +62,6 @@ pushd $IMAGE_DIR
                     --build-arg FROM_REPO=$REPO \
                     --build-arg FROM_TAG=$TAG \
                     --build-arg NPM_REGISTRY_OVERRIDE=${NPM_REGISTRY_OVERRIDE} \
-                    --build-arg NPM_REGISTRY_RESET=${NPM_REGISTRY_RESET} \
                     manageiq-ui-worker"
   echo "Building manageiq-ui-worker: $cmd"
   $cmd

--- a/bin/build
+++ b/bin/build
@@ -10,6 +10,9 @@ MIQ_ORG=${MIQ_ORG:-ManageIQ}
 SUI_ORG=${SUI_ORG:-ManageIQ}
 APPLIANCE_ORG=${APPLIANCE_ORG:-ManageIQ}
 
+NPM_REGISTRY_OVERRIDE=${NPM_REGISTRY_OVERRIDE:-""}
+NPM_REGISTRY_RESET=${NPM_REGISTRY_RESET:-false}
+
 while getopts "t:d:r:nhp" opt; do
   case $opt in
     d) IMAGE_DIR=$OPTARG ;;
@@ -31,8 +34,6 @@ if [ -z "$REPO" ]; then
   exit 1
 fi
 
-build_images="manageiq-base-worker manageiq-orchestrator manageiq-webserver-worker manageiq-ui-worker"
-
 set -e
 
 pushd $IMAGE_DIR
@@ -51,11 +52,21 @@ pushd $IMAGE_DIR
   echo "Building manageiq-base: $cmd"
   $cmd manageiq-base
 
+  build_images="manageiq-base-worker manageiq-orchestrator manageiq-webserver-worker"
   for image in $build_images; do
     cmd="docker build -t $REPO/$image:$TAG --build-arg FROM_REPO=$REPO --build-arg FROM_TAG=$TAG $image"
     echo "Building $image: $cmd"
     $cmd
   done
+
+  cmd="docker build --tag $REPO/manageiq-ui-worker:$TAG \
+                    --build-arg FROM_REPO=$REPO \
+                    --build-arg FROM_TAG=$TAG \
+                    --build-arg NPM_REGISTRY_OVERRIDE=${NPM_REGISTRY_OVERRIDE} \
+                    --build-arg NPM_REGISTRY_RESET=${NPM_REGISTRY_RESET} \
+                    manageiq-ui-worker"
+  echo "Building manageiq-ui-worker: $cmd"
+  $cmd
 popd
 
 if [ -n "$PUSH" ]; then

--- a/images/manageiq-ui-worker/Dockerfile
+++ b/images/manageiq-ui-worker/Dockerfile
@@ -5,7 +5,6 @@ FROM ${FROM_REPO}/manageiq-webserver-worker:${FROM_TAG}
 MAINTAINER ManageIQ https://manageiq.org
 
 ARG NPM_REGISTRY_OVERRIDE
-ARG NPM_REGISTRY_RESET=false
 
 LABEL name="manageiq-ui-worker" \
       summary="ManageIQ user interface worker image"
@@ -45,7 +44,7 @@ RUN source /etc/default/evm && \
 RUN source /etc/default/evm && \
     yarn cache clean && \
     cd ${APP_ROOT} && \
-    if [ "${NPM_REGISTRY_RESET}" = "true" ]; then \
+    if [ ! -z "${NPM_REGISTRY_OVERRIDE}" ]; then \
       /tmp/npm_registry/npm_yarn_registry_cleanup.sh; \
     fi && \
     rm -rf /tmp/npm_registry

--- a/images/manageiq-ui-worker/Dockerfile
+++ b/images/manageiq-ui-worker/Dockerfile
@@ -4,6 +4,9 @@ ARG FROM_TAG=latest
 FROM ${FROM_REPO}/manageiq-webserver-worker:${FROM_TAG}
 MAINTAINER ManageIQ https://manageiq.org
 
+ARG NPM_REGISTRY_OVERRIDE
+ARG NPM_REGISTRY_RESET=false
+
 LABEL name="manageiq-ui-worker" \
       summary="ManageIQ user interface worker image"
 
@@ -12,10 +15,18 @@ RUN yum -y install httpd --setopt=tsflags=nodocs && \
     rm -f /etc/httpd/conf.d/* && \
     yum clean all
 
+COPY container-assets/npm_registry /tmp/npm_registry
+
 # Compile assets for ManageIQ UI
 RUN source /etc/default/evm && \
     export RAILS_USE_MEMORY_STORE="true" && \
+    if [ ! -z "${NPM_REGISTRY_OVERRIDE}" ]; then \
+      /tmp/npm_registry/npm_registry_setup.sh; \
+    fi && \
     npm install -g yarn && \
+    if [ ! -z "${NPM_REGISTRY_OVERRIDE}" ]; then \
+      /tmp/npm_registry/yarn_registry_setup.sh; \
+    fi && \
     rake update:ui && \
     RAILS_ENV=production rake evm:compile_assets && \
     rake evm:compile_sti_loader && \
@@ -29,7 +40,14 @@ RUN source /etc/default/evm && \
     cd ${SUI_ROOT} && \
     yarn install && \
     yarn run available-languages && \
-    yarn run build && \
-    yarn cache clean
+    yarn run build
+
+RUN source /etc/default/evm && \
+    yarn cache clean && \
+    cd ${APP_ROOT} && \
+    if [ "${NPM_REGISTRY_RESET}" = "true" ]; then \
+      /tmp/npm_registry/npm_yarn_registry_cleanup.sh; \
+    fi && \
+    rm -rf /tmp/npm_registry
 
 COPY container-assets/manageiq-http.conf /etc/httpd/conf.d

--- a/images/manageiq-ui-worker/container-assets/npm_registry/npm_registry_setup.sh
+++ b/images/manageiq-ui-worker/container-assets/npm_registry/npm_registry_setup.sh
@@ -1,0 +1,2 @@
+npm config set registry ${NPM_REGISTRY_OVERRIDE}
+npm config set strict-ssl false

--- a/images/manageiq-ui-worker/container-assets/npm_registry/npm_yarn_registry_cleanup.sh
+++ b/images/manageiq-ui-worker/container-assets/npm_registry/npm_yarn_registry_cleanup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+npm config delete registry
+npm config delete strict-ssl
+yarn config delete registry
+yarn config delete strict-ssl
+
+# Replace registry in yarn.lock
+default_yarn_registry=`yarn config get registry`
+ui_plugin_repos=`rake update:print_engines | grep path: | cut -d: -f2`
+for repo in ${ui_plugin_repos} ${SUI_ROOT}
+do
+  sed -i "s#${NPM_REGISTRY_OVERRIDE}#${default_yarn_registry}#g" ${repo}/yarn.lock
+done

--- a/images/manageiq-ui-worker/container-assets/npm_registry/yarn_registry_setup.sh
+++ b/images/manageiq-ui-worker/container-assets/npm_registry/yarn_registry_setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+yarn config set registry ${NPM_REGISTRY_OVERRIDE}
+yarn config set strict-ssl false
+
+# Replace registry in existing yarn.lock
+ui_plugin_repos=`rake update:print_engines | grep path: | cut -d: -f2`
+for repo in ${ui_plugin_repos} ${SUI_ROOT}
+do
+  lock_file="${repo}/yarn.lock"
+  if [ -f "${lock_file}" ]; then
+    sed -i "s#https\?://registry.\(npmjs\|yarnpkg\).\(org\|com\)#${NPM_REGISTRY_OVERRIDE}#g" ${lock_file}
+  fi
+done


### PR DESCRIPTION
Podified image version of https://github.com/ManageIQ/manageiq-appliance-build/pull/366

Scripts in container-assets/npm_registry were copied from manageiq-appliance-build and I made minor edits to make them work in this repo (e.g. no erb).