### PR TITLE
[IVANCHUK] Add yarn available-languages to ui-service build

### DIFF
--- a/images/miq-app-frontend/Dockerfile
+++ b/images/miq-app-frontend/Dockerfile
@@ -49,7 +49,8 @@ RUN source /etc/default/evm && \
 ## Build SUI
 RUN source /etc/default/evm && \
     cd ${SUI_ROOT} && \
-    yarn install --production && \
+    yarn install && \
+    yarn run available-languages && \
     yarn run build && \
     yarn cache clean
 


### PR DESCRIPTION
Related PR: https://github.com/ManageIQ/manageiq-appliance-build/pull/342

`master` was updated as a part of @carbonin 's changes for the new architecture.