### PR TITLE
Remove the DISABLE_MIQ_WORKER_HEARTBEAT env var

### DIFF
--- a/images/manageiq-base-worker/container-assets/entrypoint
+++ b/images/manageiq-base-worker/container-assets/entrypoint
@@ -11,8 +11,6 @@ KEY
 
 echo "${GUID}" > ${APP_ROOT}/GUID
 
-export DISABLE_MIQ_WORKER_HEARTBEAT=1
-
 [[ -n $EMS_IDS ]] && WORKER_OPTIONS="--ems-id=${EMS_IDS} "
 
 exec bin/rails r ${APP_ROOT}/lib/workers/bin/run_single_worker.rb ${WORKER_OPTIONS}${WORKER_CLASS_NAME}


### PR DESCRIPTION
Previously this was preventing the worker from heartbeating over drb
but now that file-based heartbeat is the only option it is preventing
the worker from heartbeating at all which is causing the worker pods
to be constantly killed because of the liveness check.

Introduced in ManageIQ/manageiq@20f9cc5a493d5243a77c4e8b66f385bb9f491179