### PR TITLE
Enable heartbeat more

### DIFF
--- a/images/manageiq-base-worker/container-assets/entrypoint
+++ b/images/manageiq-base-worker/container-assets/entrypoint
@@ -13,4 +13,4 @@ echo "${GUID}" > ${APP_ROOT}/GUID
 
 [[ -n $EMS_IDS ]] && WORKER_OPTIONS="--ems-id=${EMS_IDS} "
 
-exec bin/rails r ${APP_ROOT}/lib/workers/bin/run_single_worker.rb ${WORKER_OPTIONS}${WORKER_CLASS_NAME}
+exec ruby ${APP_ROOT}/lib/workers/bin/run_single_worker.rb --heartbeat ${WORKER_OPTIONS}${WORKER_CLASS_NAME}


### PR DESCRIPTION
The --heartbeat parameter is required. Otherwise run_single_worker
will set DISABLE_MIQ_WORKER_HEARTBEAT

Additionally change from `rails runner` to `ruby` as the
run_single_worker script will source the environment correctly.
This also makes this entrypoint more similar to how we run
the same script from the appliance architecture.