### PR TITLE
Add a script to remove all images for a tag

### DIFF
--- a/bin/remove_images
+++ b/bin/remove_images
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+TAG=latest
+
+while getopts "t:r:h" opt; do
+  case $opt in
+    r) REPO=$OPTARG ;;
+    t) TAG=$OPTARG ;;
+    h) echo "Usage: $0 -r IMAGE_REPOSITORY [-h] [ -t IMAGE_TAG ]"; exit 1
+  esac
+done
+
+if [ -z "$REPO" ]; then
+  echo "Required parameter for repository (-r) is missing"
+  exit 1
+fi
+
+images=(manageiq-base manageiq-base-worker manageiq-orchestrator manageiq-webserver-worker manageiq-ui-worker)
+images=( "${images[@]/#/$REPO/}" )
+images=( "${images[@]/%/:$TAG}" )
+echo "Removing ${images[@]}"
+docker rmi ${images[@]}


### PR DESCRIPTION
I was hoping to find a command that can remove everything built by running `bin/build` (final images along with intermediate layers), but I couldn't find it.... so this will just delete images with a given tag.

On our build machine, I will setup a cron job to prune all `<none>:<none>` images separately.