### PR TITLE
Remove the MY_POD_NAMESPACE env var from the orchestrator

### DIFF
--- a/templates/app/orchestrator.yaml
+++ b/templates/app/orchestrator.yaml
@@ -66,10 +66,6 @@ objects:
               secretKeyRef:
                 name: postgresql-secrets
                 key: username
-          - name: MY_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: ENCRYPTION_KEY
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
This isn't needed as kube always provides a file mounted into the pod
with the current namespace.

Requires https://github.com/ManageIQ/manageiq/pull/19846