### PR TITLE
Allow for changing the app name using a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ _**Note:**_ This section assumes you have a basic user.
 $ oc new-project <project_name>
 ```
 
-### Add the miq-anyuid and miq-orchestrator service accounts to the anyuid security context
+### Add the anyuid and orchestrator service accounts to the anyuid security context
 
 _**Note:**_ The current MIQ images require the root user.
 
@@ -55,8 +55,8 @@ These service accounts for your namespace (project) must be added to the anyuid 
 _**As admin**_
 
 ```bash
-$ oc adm policy add-scc-to-user anyuid system:serviceaccount:<your-namespace>:miq-anyuid
-$ oc adm policy add-scc-to-user anyuid system:serviceaccount:<your-namespace>:miq-orchestrator
+$ oc adm policy add-scc-to-user anyuid system:serviceaccount:<your-namespace>:<app-name>-anyuid
+$ oc adm policy add-scc-to-user anyuid system:serviceaccount:<your-namespace>:<app-name>-orchestrator
 ```
 
 Verify that the service accounts are now included in the anyuid scc
@@ -65,7 +65,7 @@ $ oc describe scc anyuid | grep Users
 Users:					system:serviceaccount:<your-namespace>:miq-anyuid,system:serviceaccount:<your-namespace>:miq-orchestrator
 ```
 
-### Set up the miq-httpd service account
+### Set up the httpd service account
 
 #### If running without OCI systemd hooks (Minishift)
 
@@ -84,10 +84,10 @@ $ oc create -f templates/miq-scc-sysadmin.yaml
 The miq-httpd service account must be added to the miq-sysadmin SCC before the front-end httpd pod can run.
 
 ```bash
-$ oc adm policy add-scc-to-user miq-sysadmin system:serviceaccount:<your-namespace>:miq-httpd
+$ oc adm policy add-scc-to-user miq-sysadmin system:serviceaccount:<your-namespace>:<app-name>-httpd
 ```
 
-Verify that the miq-httpd service account is now included in the miq-sysadmin scc
+Verify that the service account is now included in the miq-sysadmin scc
 
 ```bash
 $ oc describe scc miq-sysadmin | grep Users
@@ -98,13 +98,13 @@ Users:              system:serviceaccount:<your-namespace>:miq-httpd
 
 __*As admin*__
 
-Add the miq-httpd service account to the anyuid SCC
+Add the httpd service account to the anyuid SCC
 
 ```bash
-$ oc adm policy add-scc-to-user anyuid system:serviceaccount:<your-namespace>:miq-httpd
+$ oc adm policy add-scc-to-user anyuid system:serviceaccount:<your-namespace>:<app-name>-httpd
 ```
 
-Verify that the miq-httpd service account is now included in the anyuid scc
+Verify that the service account is now included in the anyuid scc
 
 ```bash
 $ oc describe scc anyuid | grep Users

--- a/bin/deploy
+++ b/bin/deploy
@@ -27,7 +27,7 @@ function create_tls_secret() {
 # or not have created the secret yet. This ensures we don't overwrite the existing
 # password with a newly generated one.
 (parameter_provided "DATABASE_PASSWORD" || secret_missing "postgresql-secrets") && apply_template "postgresql-secrets.yaml"
-(parameter_provided "ENCRYPTION_KEY" || secret_missing "manageiq-secrets") && apply_template "manageiq-secrets.yaml"
+(parameter_provided "ENCRYPTION_KEY" || secret_missing "app-secrets") && apply_template "app-secrets.yaml"
 secret_missing "tls-secret" && create_tls_secret
 
 # Orchestrator RBAC

--- a/bin/deploy
+++ b/bin/deploy
@@ -31,7 +31,7 @@ function create_tls_secret() {
 secret_missing "tls-secret" && create_tls_secret
 
 # Orchestrator RBAC
-oc apply -f templates/app/rbac.yaml
+apply_template "rbac.yaml"
 
 # Only deploy the database if the user didn't specify an external database host
 parameter_provided "DATABASE_HOSTNAME" || apply_template "postgresql.yaml"

--- a/parameters
+++ b/parameters
@@ -1,3 +1,6 @@
+# Application name used for deployed objects
+APP_NAME=manageiq
+
 # admin user initial password
 APPLICATION_ADMIN_PASSWORD=smartvm
 

--- a/templates/app/app-secrets.yaml
+++ b/templates/app/app-secrets.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: manageiq-secrets
+  name: app-secrets
 objects:
 - apiVersion: v1
   kind: Secret
   metadata:
-    name: manageiq-secrets
+    name: app-secrets
     labels:
       app: manageiq
   stringData:

--- a/templates/app/app-secrets.yaml
+++ b/templates/app/app-secrets.yaml
@@ -8,11 +8,13 @@ objects:
   metadata:
     name: app-secrets
     labels:
-      app: manageiq
+      app: "${APP_NAME}"
   stringData:
     admin-password: "${APPLICATION_ADMIN_PASSWORD}"
     encryption-key: "${ENCRYPTION_KEY}"
 parameters:
+- name: APP_NAME
+  value: manageiq
 - name: APPLICATION_ADMIN_PASSWORD
   value: smartvm
 - name: ENCRYPTION_KEY

--- a/templates/app/httpd.yaml
+++ b/templates/app/httpd.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: manageiq-httpd
+  name: "${APP_NAME}-httpd"
 objects:
 - apiVersion: v1
   kind: ConfigMap
   metadata:
     name: httpd-configs
     labels:
-      app: manageiq
+      app: "${APP_NAME}"
   data:
     application.conf: |
       # Timeout: The number of seconds before receives and sends time out.
@@ -215,7 +215,7 @@ objects:
   metadata:
     name: httpd-auth-configs
     labels:
-      app: manageiq
+      app: "${APP_NAME}"
   data:
     auth-type: internal
     auth-kerberos-realms: undefined
@@ -230,7 +230,7 @@ objects:
   kind: Service
   metadata:
     labels:
-      app: manageiq
+      app: "${APP_NAME}"
     name: ui
   spec:
     ports:
@@ -242,7 +242,7 @@ objects:
   kind: Service
   metadata:
     labels:
-      app: manageiq
+      app: "${APP_NAME}"
     name: web-service
   spec:
     ports:
@@ -254,7 +254,7 @@ objects:
   kind: Service
   metadata:
     labels:
-      app: manageiq
+      app: "${APP_NAME}"
     name: remote-console
   spec:
     ports:
@@ -267,7 +267,7 @@ objects:
   metadata:
     name: httpd
     labels:
-      app: manageiq
+      app: "${APP_NAME}"
   spec:
     ports:
     - name: http
@@ -279,7 +279,7 @@ objects:
   metadata:
     name: httpd-dbus-api
     labels:
-      app: manageiq
+      app: "${APP_NAME}"
   spec:
     ports:
     - name: http-dbus-api
@@ -291,7 +291,7 @@ objects:
   metadata:
     name: httpd
     labels:
-      app: manageiq
+      app: "${APP_NAME}"
   spec:
     replicas: 1
     selector:
@@ -377,13 +377,13 @@ objects:
               exec:
                 command:
                 - "/usr/bin/save-container-environment"
-        serviceAccountName: miq-httpd
+        serviceAccountName: "${APP_NAME}-httpd"
 - apiVersion: extensions/v1beta1
   kind: Ingress
   metadata:
     name: httpd
     labels:
-      app: manageiq
+      app: "${APP_NAME}"
   spec:
     tls:
     - hosts:
@@ -398,6 +398,8 @@ objects:
             serviceName: httpd
             servicePort: 80
 parameters:
+- name: APP_NAME
+  value: manageiq
 - name: APPLICATION_DOMAIN
   value: ''
 - name: HTTPD_IMAGE_NAME

--- a/templates/app/memcached.yaml
+++ b/templates/app/memcached.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: manageiq-memcached
+  name: "${APP_NAME}-memcached"
 objects:
 - apiVersion: v1
   kind: Service
   metadata:
     name: memcached
     labels:
-      app: manageiq
+      app: "${APP_NAME}"
   spec:
     ports:
     - name: memcached
@@ -20,7 +20,7 @@ objects:
   metadata:
     name: memcached
     labels:
-      app: manageiq
+      app: "${APP_NAME}"
   spec:
     replicas: 1
     selector:
@@ -57,6 +57,8 @@ objects:
             limits:
               memory: "${MEMCACHED_MEM_LIMIT}"
 parameters:
+- name: APP_NAME
+  value: manageiq
 - name: MEMCACHED_MAX_MEMORY
   value: '64'
 - name: MEMCACHED_MAX_CONNECTIONS

--- a/templates/app/orchestrator.yaml
+++ b/templates/app/orchestrator.yaml
@@ -38,7 +38,7 @@ objects:
           - name: APPLICATION_ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: manageiq-secrets
+                name: app-secrets
                 key: admin-password
           - name: GUID
             value: "${GUID}"
@@ -73,7 +73,7 @@ objects:
           - name: ENCRYPTION_KEY
             valueFrom:
               secretKeyRef:
-                name: manageiq-secrets
+                name: app-secrets
                 key: encryption-key
           - name: CONTAINER_IMAGE_NAMESPACE
             value: "${ORCHESTRATOR_IMAGE_NAMESPACE}"

--- a/templates/app/orchestrator.yaml
+++ b/templates/app/orchestrator.yaml
@@ -1,29 +1,29 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: manageiq-orchestrator
+  name: "${APP_NAME}-orchestrator"
 objects:
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
-    name: manageiq-orchestrator
+    name: "${APP_NAME}-orchestrator"
     labels:
-      app: manageiq
+      app: "${APP_NAME}"
   spec:
     strategy:
       type: Recreate
     replicas: 1
     selector:
       matchLabels:
-        name: manageiq-orchestrator
+        name: "${APP_NAME}-orchestrator"
     template:
       metadata:
-        name: manageiq-orchestrator
+        name: "${APP_NAME}-orchestrator"
         labels:
-          name: manageiq-orchestrator
+          name: "${APP_NAME}-orchestrator"
       spec:
         containers:
-        - name: manageiq-orchestrator
+        - name: "${APP_NAME}-orchestrator"
           image: "${ORCHESTRATOR_IMAGE_NAMESPACE}/${ORCHESTRATOR_IMAGE_NAME}:${ORCHESTRATOR_IMAGE_TAG}"
           livenessProbe:
             exec:
@@ -35,6 +35,8 @@ objects:
           env:
           - name: ALLOW_INSECURE_SESSION
             value: 'true'
+          - name: APP_NAME
+            value: "${APP_NAME}"
           - name: APPLICATION_ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:
@@ -83,9 +85,11 @@ objects:
               cpu: "${ORCHESTRATOR_CPU_REQ}"
             limits:
               memory: "${ORCHESTRATOR_MEM_LIMIT}"
-        serviceAccountName: miq-orchestrator
+        serviceAccountName: "${APP_NAME}-orchestrator"
         terminationGracePeriodSeconds: 90
 parameters:
+- name: APP_NAME
+  value: manageiq
 - name: DATABASE_PORT
   value: '5432'
 - name: DATABASE_REGION

--- a/templates/app/postgresql-secrets.yaml
+++ b/templates/app/postgresql-secrets.yaml
@@ -8,13 +8,15 @@ objects:
   metadata:
     name: postgresql-secrets
     labels:
-      app: manageiq
+      app: "${APP_NAME}"
   stringData:
     dbname: "${DATABASE_NAME}"
     hostname: "${DATABASE_HOSTNAME}"
     password: "${DATABASE_PASSWORD}"
     username: "${DATABASE_USER}"
 parameters:
+- name: APP_NAME
+  value: manageiq
 - name: DATABASE_HOSTNAME
   value: postgresql
 - name: DATABASE_NAME

--- a/templates/app/postgresql.yaml
+++ b/templates/app/postgresql.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: manageiq-postgresql
+  name: "${APP_NAME}-postgresql"
 objects:
 - apiVersion: v1
   kind: ConfigMap
   metadata:
     name: postgresql-configs
     labels:
-      app: manageiq
+      app: "${APP_NAME}"
   data:
     01_miq_overrides.conf: |
       #------------------------------------------------------------------------------
@@ -82,7 +82,7 @@ objects:
   metadata:
     name: postgresql
     labels:
-      app: manageiq
+      app: "${APP_NAME}"
   spec:
     accessModes:
     - ReadWriteOnce
@@ -94,7 +94,7 @@ objects:
   metadata:
     name: postgresql
     labels:
-      app: manageiq
+      app: "${APP_NAME}"
   spec:
     ports:
     - name: postgresql
@@ -106,7 +106,7 @@ objects:
   metadata:
     name: postgresql
     labels:
-      app: manageiq
+      app: "${APP_NAME}"
   spec:
     strategy:
       type: Recreate
@@ -168,6 +168,8 @@ objects:
             limits:
               memory: "${POSTGRESQL_MEM_LIMIT}"
 parameters:
+- name: APP_NAME
+  value: manageiq
 - name: POSTGRESQL_MAX_CONNECTIONS
   value: '1000'
 - name: POSTGRESQL_SHARED_BUFFERS

--- a/templates/app/rbac.yaml
+++ b/templates/app/rbac.yaml
@@ -1,18 +1,20 @@
 apiVersion: v1
-kind: List
-items:
+kind: Template
+metadata:
+  name: rbac
+objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
-    name: miq-orchestrator
+    name: "${APP_NAME}-orchestrator"
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
-    name: miq-anyuid
+    name: "${APP_NAME}-anyuid"
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
-    name: miq-httpd
+    name: "${APP_NAME}-httpd"
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
@@ -23,7 +25,7 @@ items:
     apiGroup: rbac.authorization.k8s.io
   subjects:
   - kind: ServiceAccount
-    name: miq-orchestrator
+    name: "${APP_NAME}-orchestrator"
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
@@ -34,4 +36,7 @@ items:
     apiGroup: rbac.authorization.k8s.io
   subjects:
   - kind: ServiceAccount
-    name: miq-orchestrator
+    name: "${APP_NAME}-orchestrator"
+parameters:
+- name: APP_NAME
+  value: manageiq


### PR DESCRIPTION
This PR adds a new parameter (`APP_NAME`) to the templates which allows for changing the name of the deployed application.

This solves part of https://github.com/ManageIQ/manageiq-pods/issues/360