### PR TITLE
Add IMAGE_PULL_SECRET parameter

### DIFF
--- a/parameters
+++ b/parameters
@@ -38,6 +38,9 @@ HTTPD_IMAGE_TAG=latest
 HTTPD_MEM_LIMIT=8192Mi
 HTTPD_MEM_REQ=512Mi
 
+# Image pull secret to use for the orchestrator and worker images
+#IMAGE_PULL_SECRET=
+
 # memcached pod deployment information
 MEMCACHED_CPU_REQ=200m
 MEMCACHED_IMAGE_NAME=manageiq/memcached

--- a/templates/app/orchestrator.yaml
+++ b/templates/app/orchestrator.yaml
@@ -75,12 +75,16 @@ objects:
                 key: encryption-key
           - name: CONTAINER_IMAGE_NAMESPACE
             value: "${ORCHESTRATOR_IMAGE_NAMESPACE}"
+          - name: IMAGE_PULL_SECRET
+            value: "${IMAGE_PULL_SECRET}"
           resources:
             requests:
               memory: "${ORCHESTRATOR_MEM_REQ}"
               cpu: "${ORCHESTRATOR_CPU_REQ}"
             limits:
               memory: "${ORCHESTRATOR_MEM_LIMIT}"
+        imagePullSecrets:
+        - name: "${IMAGE_PULL_SECRET}"
         serviceAccountName: "${APP_NAME}-orchestrator"
         terminationGracePeriodSeconds: 90
 parameters:
@@ -93,6 +97,8 @@ parameters:
 - name: GUID
   from: "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
   generate: expression
+- name: IMAGE_PULL_SECRET
+  value: ''
 - name: ORCHESTRATOR_IMAGE_NAMESPACE
   value: manageiq
 - name: ORCHESTRATOR_IMAGE_NAME

--- a/templates/app/orchestrator.yaml
+++ b/templates/app/orchestrator.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: "${APP_NAME}-orchestrator"
+  name: orchestrator
 objects:
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
-    name: "${APP_NAME}-orchestrator"
+    name: orchestrator
     labels:
       app: "${APP_NAME}"
   spec:
@@ -15,15 +15,15 @@ objects:
     replicas: 1
     selector:
       matchLabels:
-        name: "${APP_NAME}-orchestrator"
+        name: orchestrator
     template:
       metadata:
-        name: "${APP_NAME}-orchestrator"
+        name: orchestrator
         labels:
-          name: "${APP_NAME}-orchestrator"
+          name: orchestrator
       spec:
         containers:
-        - name: "${APP_NAME}-orchestrator"
+        - name: orchestrator
           image: "${ORCHESTRATOR_IMAGE_NAMESPACE}/${ORCHESTRATOR_IMAGE_NAME}:${ORCHESTRATOR_IMAGE_TAG}"
           livenessProbe:
             exec:


### PR DESCRIPTION
This PR adds a parameter for a secret name to be used for the orchestrator and worker images.

This secret should be pre-created and contain the credentials for the registry specified in the `ORCHESTRATOR_IMAGE_NAMESPACE` parameter.

Additionally it removes the app name prefix for the orchestrator deployment.

https://github.com/ManageIQ/manageiq/issues/19699