### PR TITLE
Add glibc-langpack-en to solve locale issues

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -56,6 +56,7 @@ RUN dnf -y --disableplugin=subscription-manager install http://mirror.centos.org
       file              \
       gcc-c++           \
       git               \
+      glibc-langpack-en \
       hostname          \
       http-parser       \
       initscripts       \


### PR DESCRIPTION
Adding this package fixes warnings like these:

bash: warning: setlocale: LC_CTYPE: cannot change locale (en_US.UTF-8): No such file or directory
bash: warning: setlocale: LC_CTYPE: cannot change locale (en_US.UTF-8)

As well as allows the monolithic image to initdb properly:

/etc/default/evm: line 26: warning: setlocale: LC_CTYPE: cannot change locale (en_US.UTF-8): No such file or directory
/etc/default/evm: line 26: warning: setlocale: LC_CTYPE: cannot change locale (en_US.UTF-8)
== Checking MIQ database status ==
** DB has not been initialized
** Launching initdb
The files belonging to this database system will be owned by user "postgres".
This user must also own the server process.

initdb: invalid locale settings; check LANG and LC_* environment variables
!! Failed to initdb

ref: https://github.com/CentOS/sig-cloud-instance-images/issues/71