### PR TITLE
Pull latest ubi8 image for build

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -43,6 +43,7 @@ set -e
 
 pushd $IMAGE_DIR
   cmd="docker build --tag $REPO/manageiq-base:$TAG \
+                    --pull \
                     --build-arg MIQ_REF=$MIQ_REF \
                     --build-arg SUI_REF=$SUI_REF\
                     --build-arg APPLIANCE_REF=$APPLIANCE_REF \


### PR DESCRIPTION
Without `--pull`, it uses the image on local machine if exists, and doesn't check to see if a newer version is available.

I only added the option for manageiq-base build so it will pick up the latest ubi8 image.  For manageiq-* images, I thought you'd want to use local copy if exists, even if that's older than what's on Docker hub.