### PR TITLE
Add a hooks url for build-time customization

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -18,6 +18,8 @@ CORE_REPO_NAME=${CORE_REPO_NAME:-manageiq}
 GIT_HOST=${GIT_HOST:-github.com}
 GIT_AUTH=${GIT_AUTH:-""}
 
+HOOKS_SCRIPT_URL=${HOOKS_SCRIPT_URL:-""}
+
 NPM_REGISTRY_OVERRIDE=${NPM_REGISTRY_OVERRIDE:-""}
 
 while getopts "t:d:r:nhp" opt; do
@@ -56,6 +58,7 @@ pushd $IMAGE_DIR
                     --build-arg BUILD_ORG=$BUILD_ORG \
                     --build-arg GIT_AUTH=$GIT_AUTH \
                     --build-arg GIT_HOST=$GIT_HOST \
+                    --build-arg HOOKS_SCRIPT_URL=$HOOKS_SCRIPT_URL \
                     --build-arg CORE_REPO_NAME=$CORE_REPO_NAME \
                     --build-arg ARCH=$ARCH"
 

--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -15,6 +15,8 @@ ARG CORE_REPO_NAME=manageiq
 ARG GIT_HOST=github.com
 ARG GIT_AUTH
 
+ARG HOOKS_SCRIPT_URL
+
 RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install git
 
 RUN mkdir appliance && \
@@ -29,6 +31,9 @@ RUN mkdir app && \
 
 RUN mkdir build && \
     if [[ -n "$GIT_AUTH" ]]; then GIT_HOST=${GIT_AUTH}@${GIT_HOST}; fi && curl -L https://${GIT_HOST}/${BUILD_ORG}/${CORE_REPO_NAME}-appliance-build/tarball/${BUILD_REF} | tar vxz -C build --strip 1
+
+# Hooks should make modifications to the source in the appliance, sui, and/or app directories
+RUN if [[ -n "$HOOKS_SCRIPT_URL" ]]; then curl -L ${HOOKS_SCRIPT_URL} | bash; fi
 
 FROM registry.access.redhat.com/ubi8/ubi
 MAINTAINER ManageIQ https://manageiq.org


### PR DESCRIPTION
The idea here is that anything that needs to be overlayed onto
the source directories will be handled by this one script.
It should assume that it's running locally to the "build",
"app", "sui", and "appliance" directories and add whatever it
wants to those, knowing that they will be copied over to the final
image in the next stage.

Fixes #360