### PR TITLE
Add kafka for messaging

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -28,6 +28,7 @@ function create_tls_secret() {
 # password with a newly generated one.
 (parameter_provided "DATABASE_PASSWORD" || secret_missing "postgresql-secrets") && apply_template "postgresql-secrets.yaml"
 (parameter_provided "ENCRYPTION_KEY" || secret_missing "app-secrets") && apply_template "app-secrets.yaml"
+(parameter_provided "MESSAGING_PASSWORD" || secret_missing "kafka-secrets") && apply_template "kafka-secrets.yaml"
 secret_missing "tls-secret" && create_tls_secret
 
 # Orchestrator RBAC
@@ -35,6 +36,7 @@ apply_template "rbac.yaml"
 
 # Only deploy the database if the user didn't specify an external database host
 parameter_provided "DATABASE_HOSTNAME" || apply_template "postgresql.yaml"
+parameter_provided "MESSAGING_HOSTNAME" || apply_template "kafka.yaml"
 
 apply_template "httpd.yaml"
 apply_template "memcached.yaml"

--- a/parameters
+++ b/parameters
@@ -17,6 +17,15 @@ DATABASE_PORT=5432
 DATABASE_USER=root
 #DATABASE_PASSWORD=
 
+# Kafka connection information
+# Containerized kafka pod will be deployed if hostname is not provided
+# Password will be generated ([a-zA-Z0-9]{8}) if not provided
+MESSAGING_TYPE=kafka
+#MESSAGING_HOSTNAME=kafka
+MESSAGING_PORT=9092
+MESSAGING_USERNAME=root
+#MESSAGING_PASSWORD=
+
 # Application region number
 DATABASE_REGION=0
 
@@ -67,3 +76,7 @@ POSTGRESQL_MAX_CONNECTIONS=1000
 POSTGRESQL_MEM_LIMIT=8Gi
 POSTGRESQL_MEM_REQ=4Gi
 POSTGRESQL_SHARED_BUFFERS=1GB
+
+# Kafka deployment information
+KAFKA_VOLUME_CAPACITY=1Gi
+ZOOKEEPER_VOLUME_CAPACITY=1Gi

--- a/templates/app/kafka-secrets.yaml
+++ b/templates/app/kafka-secrets.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: kafka-secrets
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: kafka-secrets
+    labels:
+      app: "${APP_NAME}"
+  stringData:
+    hostname: "${MESSAGING_HOSTNAME}"
+    password: "${MESSAGING_PASSWORD}"
+    username: "${MESSAGING_USERNAME}"
+parameters:
+- name: APP_NAME
+  value: manageiq
+- name: MESSAGING_HOSTNAME
+  value: kafka
+- name: MESSAGING_PASSWORD
+  from: "[a-zA-Z0-9]{8}"
+  generate: expression
+- name: MESSAGING_USERNAME
+  value: root

--- a/templates/app/kafka.yaml
+++ b/templates/app/kafka.yaml
@@ -1,0 +1,140 @@
+apiVersion: v1
+kind: Template
+objects:
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: kafka-data
+    labels:
+      app: "${APP_NAME}"
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: "${KAFKA_VOLUME_CAPACITY}"
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: zookeeper-data
+    labels:
+      app: "${APP_NAME}"
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: "${ZOOKEEPER_VOLUME_CAPACITY}"
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: "${APP_NAME}"
+    name: kafka
+  spec:
+    ports:
+    - name: kafka
+      port: 9092
+    selector:
+      name: kafka
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: "${APP_NAME}"
+    name: zookeeper
+  spec:
+    ports:
+    - name: zookeeper
+      port: 2181
+    selector:
+      name: zookeeper
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: kafka
+    labels:
+      app: "${APP_NAME}"
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate
+    selector:
+      matchLabels:
+        name: kafka
+    template:
+      metadata:
+        name: kafka
+        labels:
+          name: kafka
+      spec:
+        containers:
+        - name: kafka
+          image: docker.io/bitnami/kafka:latest
+          env:
+          - name: KAFKA_BROKER_USER
+            valueFrom:
+              secretKeyRef:
+                name: kafka-secrets
+                key: username
+          - name: KAFKA_BROKER_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: kafka-secrets
+                key: password
+          - name: KAFKA_ZOOKEEPER_CONNECT
+            value: zookeeper:2181
+          - name: ALLOW_PLAINTEXT_LISTENER
+            value: 'yes'
+          ports:
+          - containerPort: 9092
+          volumeMounts:
+          - name: kafka-data
+            mountPath: "/bitnami/kafka"
+        terminationGracePeriodSeconds: 10
+        volumes:
+        - name: kafka-data
+          persistentVolumeClaim:
+            claimName: kafka-data
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: zookeeper
+    labels:
+      app: "${APP_NAME}"
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate
+    selector:
+      matchLabels:
+        name: zookeeper
+    template:
+      metadata:
+        name: zookeeper
+        labels:
+          name: zookeeper
+      spec:
+        containers:
+        - image: bitnami/zookeeper:latest
+          name: zookeeper
+          env:
+          - name: ALLOW_ANONYMOUS_LOGIN
+            value: 'yes'
+          ports:
+          - containerPort: 2181
+          volumeMounts:
+          - mountPath: "/bitnami/zookeeper"
+            name: zookeeper-data
+        restartPolicy: Always
+        volumes:
+        - name: zookeeper-data
+          persistentVolumeClaim:
+            claimName: zookeeper-data
+parameters:
+- name: APP_NAME
+  value: manageiq
+- name: KAFKA_VOLUME_CAPACITY
+  value: 1Gi
+- name: ZOOKEEPER_VOLUME_CAPACITY
+  value: 1Gi

--- a/templates/app/orchestrator.yaml
+++ b/templates/app/orchestrator.yaml
@@ -77,6 +77,25 @@ objects:
             value: "${ORCHESTRATOR_IMAGE_NAMESPACE}"
           - name: IMAGE_PULL_SECRET
             value: "${IMAGE_PULL_SECRET}"
+          - name: MESSAGING_HOSTNAME
+            valueFrom:
+              secretKeyRef:
+                name: kafka-secrets
+                key: hostname
+          - name: MESSAGING_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: kafka-secrets
+                key: password
+          - name: MESSAGING_PORT
+            value: "${MESSAGING_PORT}"
+          - name: MESSAGING_TYPE
+            value: "${MESSAGING_TYPE}"
+          - name: MESSAGING_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: kafka-secrets
+                key: username
           resources:
             requests:
               memory: "${ORCHESTRATOR_MEM_REQ}"
@@ -111,3 +130,5 @@ parameters:
   value: 6144Mi
 - name: ORCHESTRATOR_MEM_LIMIT
   value: 16384Mi
+- name: MESSAGING_TYPE
+  value: kafka


### PR DESCRIPTION
This adds deployments for kafka and zookeeper as well as the related
services, volume claims, and secrets.

The kafka pod is not scaleable as there is configuration that needs
to be done for multiple brokers.

Fixes https://github.com/ManageIQ/manageiq/issues/20007

cc @agrare 