### PR TITLE
Request only the permissions we need and make the operator work

### DIFF
--- a/manageiq-operator/deploy/role.yaml
+++ b/manageiq-operator/deploy/role.yaml
@@ -9,9 +9,7 @@ rules:
   resources:
   - pods
   - services
-  - endpoints
   - persistentvolumeclaims
-  - events
   - configmaps
   - secrets
   - serviceaccounts
@@ -36,18 +34,8 @@ rules:
   - apps
   resources:
   - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
   verbs:
   - '*'
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - create
 - apiGroups:
   - apps
   resourceNames:
@@ -60,19 +48,6 @@ rules:
   - manageiq.org
   resources:
   - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - cache.example.com
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - manageiq.org
-  resources:
-  - '*'
-  - manageiqs
   verbs:
   - '*'
 - apiGroups:

--- a/manageiq-operator/deploy/role.yaml
+++ b/manageiq-operator/deploy/role.yaml
@@ -14,7 +14,23 @@ rules:
   - events
   - configmaps
   - secrets
+  - serviceaccounts
   verbs:
+  - '*'
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - '*'
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - rolebindings
+  - clusterroles
+  - roles
+  verbs:
+  - escalate
   - '*'
 - apiGroups:
   - apps
@@ -41,7 +57,7 @@ rules:
   verbs:
   - update
 - apiGroups:
-  - manageiq.example.com
+  - manageiq.org
   resources:
   - '*'
   verbs:
@@ -57,5 +73,11 @@ rules:
   resources:
   - '*'
   - manageiqs
+  verbs:
+  - '*'
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
   verbs:
   - '*'

--- a/manageiq-operator/deploy/role.yaml
+++ b/manageiq-operator/deploy/role.yaml
@@ -53,7 +53,7 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - manageiq.example.com
+  - manageiq.org
   resources:
   - '*'
   - manageiqs


### PR DESCRIPTION
Currently we request a bunch of RBAC permissions that we don't need. Additionally the `role.yaml` does not contain the minimal permissions we need to create all the objects we attempt to create.

This PR adds what is missing and removes what isn't needed.

Fixes #407