### PR TITLE
Add the actual steps for using the operator to the README

### DIFF
--- a/manageiq-operator/README.md
+++ b/manageiq-operator/README.md
@@ -4,6 +4,12 @@ This operator manages the lifecycle of ManageIQ application on a OCP4 cluster.
 
 ## Run Operator
 
+Deploy the ManageIQ CRD
+
+```bash
+$ oc create -f deploy/crds/manageiq_v1alpha1_manageiq_crd.yaml
+```
+
 ### Option A: Run Locally(outside of cluster)
 
 In project root directory, run
@@ -14,18 +20,36 @@ $ operator-sdk up local --namespace=<yournamespace>
 
 ### Option B: Run Inside Cluster
 
-Please refer to *"4. Build and run the Operator"* in [this guide](https://docs.openshift.com/container-platform/4.1/applications/operator_sdk/osdk-getting-started.html) for remaining steps
-
-
-#### Deploy CRD resources
+1. Build the operator image:
 
 ```bash
-$ oc create -f deploy/crds/manageiq_v1alpha1_manageiq_crd.yaml
+$ operator-sdk build docker.io/example/manageiq-operator:latest
 ```
 
-#### Create ManageIQ Custom Resource
+2. Update the operator deployment with the new image:
+
+```bash
+$ sed -i 's|docker.io/manageiq/manageiq-operator:v0.0.1|docker.io/example/manageiq-operator:latest|g' deploy/operator.yaml
+```
+
+3. Push the new image to the registry:
+
+```bash
+$ docker push docker.io/example/manageiq-operator:latest
+```
+
+### Setup RBAC and deploy the operator
 
 ```bash 
+$ oc create -f deploy/role.yaml
+$ oc create -f deploy/role_binding.yaml
+$ oc create -f deploy/service_account.yaml
+$ oc create -f deploy/operator.yaml
+```
+
+### Create the CR to deploy ManageIQ
+
+```bash
 $ oc create -f deploy/crds/manageiq_v1alpha1_manageiq_cr.yaml
 ```
 

--- a/manageiq-operator/deploy/operator.yaml
+++ b/manageiq-operator/deploy/operator.yaml
@@ -15,7 +15,6 @@ spec:
       serviceAccountName: manageiq-operator
       containers:
         - name: manageiq-operator
-          # Replace this with the built image name
           image: docker.io/manageiq/manageiq-operator:v0.0.1
           command:
           - manageiq-operator


### PR DESCRIPTION
This puts the steps to build and run the operator in the README
instead of referencing the OpenShift documentation.

Additionally it reorders some of the sections to ensure that the
deployment works properly. Specifically, the CRD needs to be created
before the operator is deployed to the cluster. This also needs to be
done whether you are running locally or deploying the operator as
a pod in the cluster.

This is what I was looking for in https://github.com/ManageIQ/manageiq-pods/pull/402#discussion_r400887590

cc @gyliu513 