### PR TITLE
Clean up controller

### DIFF
--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -96,33 +96,23 @@ func (r *ReconcileManageiq) Reconcile(request reconcile.Request) (reconcile.Resu
 
 	currentAppName = miqInstance.Spec.AppName
 
-	err = GenerateRbacResources(miqInstance, r)
-	if err != nil {
-		return reconcile.Result{}, err
+	if e := GenerateRbacResources(miqInstance, r); e != nil {
+		return reconcile.Result{}, e
 	}
-	err = GenerateSecrets(miqInstance, r)
-	if err != nil {
-		return reconcile.Result{}, err
+	if e := GenerateSecrets(miqInstance, r); e != nil {
+		return reconcile.Result{}, e
 	}
-
-	err = GeneratePostgresqlResources(miqInstance, r)
-	if err != nil {
-		return reconcile.Result{}, err
+	if e := GeneratePostgresqlResources(miqInstance, r); e != nil {
+		return reconcile.Result{}, e
 	}
-
-	err = GenerateHttpdResources(miqInstance, r)
-	if err != nil {
-		return reconcile.Result{}, err
+	if e := GenerateHttpdResources(miqInstance, r); e != nil {
+		return reconcile.Result{}, e
 	}
-
-	err = GenerateMemcachedResources(miqInstance, r)
-	if err != nil {
-		return reconcile.Result{}, err
+	if e := GenerateMemcachedResources(miqInstance, r); e != nil {
+		return reconcile.Result{}, e
 	}
-
-	err = GenerateOrchestratorResources(miqInstance, r)
-	if err != nil {
-		return reconcile.Result{}, err
+	if e := GenerateOrchestratorResources(miqInstance, r); e != nil {
+		return reconcile.Result{}, e
 	}
 
 	return reconcile.Result{}, nil

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -96,29 +96,29 @@ func (r *ReconcileManageiq) Reconcile(request reconcile.Request) (reconcile.Resu
 
 	currentAppName = miqInstance.Spec.AppName
 
-	if e := GenerateRbacResources(miqInstance, r); e != nil {
+	if e := r.generateRbacResources(miqInstance); e != nil {
 		return reconcile.Result{}, e
 	}
-	if e := GenerateSecrets(miqInstance, r); e != nil {
+	if e := r.generateSecrets(miqInstance); e != nil {
 		return reconcile.Result{}, e
 	}
-	if e := GeneratePostgresqlResources(miqInstance, r); e != nil {
+	if e := r.generatePostgresqlResources(miqInstance); e != nil {
 		return reconcile.Result{}, e
 	}
-	if e := GenerateHttpdResources(miqInstance, r); e != nil {
+	if e := r.generateHttpdResources(miqInstance); e != nil {
 		return reconcile.Result{}, e
 	}
-	if e := GenerateMemcachedResources(miqInstance, r); e != nil {
+	if e := r.generateMemcachedResources(miqInstance); e != nil {
 		return reconcile.Result{}, e
 	}
-	if e := GenerateOrchestratorResources(miqInstance, r); e != nil {
+	if e := r.generateOrchestratorResources(miqInstance); e != nil {
 		return reconcile.Result{}, e
 	}
 
 	return reconcile.Result{}, nil
 }
 
-func GenerateHttpdResources(cr *miqv1alpha1.Manageiq, r *ReconcileManageiq) error {
+func (r *ReconcileManageiq) generateHttpdResources(cr *miqv1alpha1.Manageiq) error {
 	HttpdIngress := miqtool.NewIngress(cr)
 	HttpdConfigMap := miqtool.NewHttpdConfigMap(cr)
 	HttpdAuthConfigMap := miqtool.NewHttpdAuthConfigMap(cr)
@@ -174,7 +174,7 @@ func GenerateHttpdResources(cr *miqv1alpha1.Manageiq, r *ReconcileManageiq) erro
 	return nil
 }
 
-func GenerateMemcachedResources(cr *miqv1alpha1.Manageiq, r *ReconcileManageiq) error {
+func (r *ReconcileManageiq) generateMemcachedResources(cr *miqv1alpha1.Manageiq) error {
 	MemcachedDeployment := miqtool.NewMemcachedDeployment(cr)
 	MemcachedService := miqtool.NewMemcachedService(cr)
 	err := Createk8sResIfNotExist(cr, MemcachedDeployment, &appsv1.Deployment{}, r)
@@ -188,7 +188,7 @@ func GenerateMemcachedResources(cr *miqv1alpha1.Manageiq, r *ReconcileManageiq) 
 	return nil
 }
 
-func GeneratePostgresqlResources(cr *miqv1alpha1.Manageiq, r *ReconcileManageiq) error {
+func (r *ReconcileManageiq) generatePostgresqlResources(cr *miqv1alpha1.Manageiq) error {
 	PostgresqlService := miqtool.NewPostgresqlService(cr)
 	PostgresqlPVC := miqtool.NewPostgresqlPVC(cr)
 	PostgresqlConfigsConfigMap := miqtool.NewPostgresqlConfigsConfigMap(cr)
@@ -217,7 +217,7 @@ func GeneratePostgresqlResources(cr *miqv1alpha1.Manageiq, r *ReconcileManageiq)
 	return nil
 }
 
-func GenerateOrchestratorResources(cr *miqv1alpha1.Manageiq, r *ReconcileManageiq) error {
+func (r *ReconcileManageiq) generateOrchestratorResources(cr *miqv1alpha1.Manageiq) error {
 	OrchestratorDeployment := miqtool.NewOrchestratorDeployment(cr)
 	err := Createk8sResIfNotExist(cr, OrchestratorDeployment, &appsv1.Deployment{}, r)
 	if err != nil {
@@ -227,7 +227,7 @@ func GenerateOrchestratorResources(cr *miqv1alpha1.Manageiq, r *ReconcileManagei
 	return nil
 }
 
-func GenerateSecrets(cr *miqv1alpha1.Manageiq, r *ReconcileManageiq) error {
+func (r *ReconcileManageiq) generateSecrets(cr *miqv1alpha1.Manageiq) error {
 
 	PostgresqlSecret := miqtool.NewPostgresqlSecret(cr)
 	AppSecret := miqtool.AppSecret(cr)
@@ -251,7 +251,7 @@ func GenerateSecrets(cr *miqv1alpha1.Manageiq, r *ReconcileManageiq) error {
 	return nil
 }
 
-func GenerateRbacResources(cr *miqv1alpha1.Manageiq, r *ReconcileManageiq) error {
+func (r *ReconcileManageiq) generateRbacResources(cr *miqv1alpha1.Manageiq) error {
 
 	HttpdServiceAccount := miqtool.HttpdServiceAccount(cr)
 	OrchestratorServiceAccount := miqtool.OrchestratorServiceAccount(cr)

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -116,55 +116,48 @@ func (r *ReconcileManageiq) Reconcile(request reconcile.Request) (reconcile.Resu
 }
 
 func (r *ReconcileManageiq) generateHttpdResources(cr *miqv1alpha1.Manageiq) error {
-	HttpdIngress := miqtool.NewIngress(cr)
 	HttpdConfigMap := miqtool.NewHttpdConfigMap(cr)
+	if err := r.createk8sResIfNotExist(cr, HttpdConfigMap, &corev1.ConfigMap{}); err != nil {
+		return err
+	}
+
 	HttpdAuthConfigMap := miqtool.NewHttpdAuthConfigMap(cr)
-	HttpdService := miqtool.NewHttpdService(cr)
-	HttpdDbusAPIService := miqtool.NewHttpdDbusAPIService(cr)
-	HttpdDeployment := miqtool.NewHttpdDeployment(cr)
+	if err := r.createk8sResIfNotExist(cr, HttpdAuthConfigMap, &corev1.ConfigMap{}); err != nil {
+		return err
+	}
 
 	UIService := miqtool.NewUIService(cr)
+	if err := r.createk8sResIfNotExist(cr, UIService, &corev1.Service{}); err != nil {
+		return err
+	}
+
 	WebService := miqtool.NewWebService(cr)
+	if err := r.createk8sResIfNotExist(cr, WebService, &corev1.Service{}); err != nil {
+		return err
+	}
+
 	RemoteConsoleService := miqtool.NewRemoteConsoleService(cr)
-
-	err := Createk8sResIfNotExist(cr, HttpdConfigMap, &corev1.ConfigMap{}, r)
-	if err != nil {
-		return err
-	}
-	err = Createk8sResIfNotExist(cr, HttpdAuthConfigMap, &corev1.ConfigMap{}, r)
-	if err != nil {
-		return err
-	}
-	err = Createk8sResIfNotExist(cr, UIService, &corev1.Service{}, r)
-	if err != nil {
-		return err
-	}
-	err = Createk8sResIfNotExist(cr, WebService, &corev1.Service{}, r)
-	if err != nil {
-		return err
-	}
-	err = Createk8sResIfNotExist(cr, RemoteConsoleService, &corev1.Service{}, r)
-	if err != nil {
+	if err := r.createk8sResIfNotExist(cr, RemoteConsoleService, &corev1.Service{}); err != nil {
 		return err
 	}
 
-	err = Createk8sResIfNotExist(cr, HttpdService, &corev1.Service{}, r)
-	if err != nil {
+	HttpdService := miqtool.NewHttpdService(cr)
+	if err := r.createk8sResIfNotExist(cr, HttpdService, &corev1.Service{}); err != nil {
 		return err
 	}
 
-	err = Createk8sResIfNotExist(cr, HttpdDbusAPIService, &corev1.Service{}, r)
-	if err != nil {
+	HttpdDbusAPIService := miqtool.NewHttpdDbusAPIService(cr)
+	if err := r.createk8sResIfNotExist(cr, HttpdDbusAPIService, &corev1.Service{}); err != nil {
 		return err
 	}
 
-	err = Createk8sResIfNotExist(cr, HttpdDeployment, &appsv1.Deployment{}, r)
-	if err != nil {
+	HttpdDeployment := miqtool.NewHttpdDeployment(cr)
+	if err := r.createk8sResIfNotExist(cr, HttpdDeployment, &appsv1.Deployment{}); err != nil {
 		return err
 	}
 
-	err = Createk8sResIfNotExist(cr, HttpdIngress, &extenv1beta1.Ingress{}, r)
-	if err != nil {
+	HttpdIngress := miqtool.NewIngress(cr)
+	if err := r.createk8sResIfNotExist(cr, HttpdIngress, &extenv1beta1.Ingress{}); err != nil {
 		return err
 	}
 
@@ -173,41 +166,36 @@ func (r *ReconcileManageiq) generateHttpdResources(cr *miqv1alpha1.Manageiq) err
 
 func (r *ReconcileManageiq) generateMemcachedResources(cr *miqv1alpha1.Manageiq) error {
 	MemcachedDeployment := miqtool.NewMemcachedDeployment(cr)
+	if err := r.createk8sResIfNotExist(cr, MemcachedDeployment, &appsv1.Deployment{}); err != nil {
+		return err
+	}
+
 	MemcachedService := miqtool.NewMemcachedService(cr)
-	err := Createk8sResIfNotExist(cr, MemcachedDeployment, &appsv1.Deployment{}, r)
-	if err != nil {
+	if err := r.createk8sResIfNotExist(cr, MemcachedService, &corev1.Service{}); err != nil {
 		return err
 	}
-	err = Createk8sResIfNotExist(cr, MemcachedService, &corev1.Service{}, r)
-	if err != nil {
-		return err
-	}
+
 	return nil
 }
 
 func (r *ReconcileManageiq) generatePostgresqlResources(cr *miqv1alpha1.Manageiq) error {
-	PostgresqlService := miqtool.NewPostgresqlService(cr)
-	PostgresqlPVC := miqtool.NewPostgresqlPVC(cr)
 	PostgresqlConfigsConfigMap := miqtool.NewPostgresqlConfigsConfigMap(cr)
+	if err := r.createk8sResIfNotExist(cr, PostgresqlConfigsConfigMap, &corev1.ConfigMap{}); err != nil {
+		return err
+	}
+
+	PostgresqlPVC := miqtool.NewPostgresqlPVC(cr)
+	if err := r.createk8sResIfNotExist(cr, PostgresqlPVC, &corev1.PersistentVolumeClaim{}); err != nil {
+		return err
+	}
+
+	PostgresqlService := miqtool.NewPostgresqlService(cr)
+	if err := r.createk8sResIfNotExist(cr, PostgresqlService, &corev1.Service{}); err != nil {
+		return err
+	}
+
 	PostgresqlDeployment := miqtool.NewPostgresqlDeployment(cr)
-
-	err := Createk8sResIfNotExist(cr, PostgresqlConfigsConfigMap, &corev1.ConfigMap{}, r)
-	if err != nil {
-		return err
-	}
-
-	err = Createk8sResIfNotExist(cr, PostgresqlPVC, &corev1.PersistentVolumeClaim{}, r)
-	if err != nil {
-		return err
-	}
-
-	err = Createk8sResIfNotExist(cr, PostgresqlService, &corev1.Service{}, r)
-	if err != nil {
-		return err
-	}
-
-	err = Createk8sResIfNotExist(cr, PostgresqlDeployment, &appsv1.Deployment{}, r)
-	if err != nil {
+	if err := r.createk8sResIfNotExist(cr, PostgresqlDeployment, &appsv1.Deployment{}); err != nil {
 		return err
 	}
 
@@ -216,8 +204,7 @@ func (r *ReconcileManageiq) generatePostgresqlResources(cr *miqv1alpha1.Manageiq
 
 func (r *ReconcileManageiq) generateOrchestratorResources(cr *miqv1alpha1.Manageiq) error {
 	OrchestratorDeployment := miqtool.NewOrchestratorDeployment(cr)
-	err := Createk8sResIfNotExist(cr, OrchestratorDeployment, &appsv1.Deployment{}, r)
-	if err != nil {
+	if err := r.createk8sResIfNotExist(cr, OrchestratorDeployment, &appsv1.Deployment{}); err != nil {
 		return err
 	}
 
@@ -225,23 +212,18 @@ func (r *ReconcileManageiq) generateOrchestratorResources(cr *miqv1alpha1.Manage
 }
 
 func (r *ReconcileManageiq) generateSecrets(cr *miqv1alpha1.Manageiq) error {
+	AppSecret := miqtool.AppSecret(cr)
+	if err := r.createk8sResIfNotExist(cr, AppSecret, &corev1.Secret{}); err != nil {
+		return err
+	}
+
+	TLSSecret := miqtool.TLSSecret(cr)
+	if err := r.createk8sResIfNotExist(cr, TLSSecret, &corev1.Secret{}); err != nil {
+		return err
+	}
 
 	PostgresqlSecret := miqtool.NewPostgresqlSecret(cr)
-	AppSecret := miqtool.AppSecret(cr)
-	TLSSecret := miqtool.TLSSecret(cr)
-
-	err := Createk8sResIfNotExist(cr, AppSecret, &corev1.Secret{}, r)
-	if err != nil {
-		return err
-	}
-
-	err = Createk8sResIfNotExist(cr, TLSSecret, &corev1.Secret{}, r)
-	if err != nil {
-		return err
-	}
-
-	err = Createk8sResIfNotExist(cr, PostgresqlSecret, &corev1.Secret{}, r)
-	if err != nil {
+	if err := r.createk8sResIfNotExist(cr, PostgresqlSecret, &corev1.Secret{}); err != nil {
 		return err
 	}
 
@@ -249,39 +231,35 @@ func (r *ReconcileManageiq) generateSecrets(cr *miqv1alpha1.Manageiq) error {
 }
 
 func (r *ReconcileManageiq) generateRbacResources(cr *miqv1alpha1.Manageiq) error {
-
 	HttpdServiceAccount := miqtool.HttpdServiceAccount(cr)
-	OrchestratorServiceAccount := miqtool.OrchestratorServiceAccount(cr)
-	AnyuidServiceAccount := miqtool.AnyuidServiceAccount(cr)
-	OrchestratorViewRoleBinding := miqtool.OrchestratorViewRoleBinding(cr)
-	OrchestratorEditRoleBinding := miqtool.OrchestratorEditRoleBinding(cr)
+	if err := r.createk8sResIfNotExist(cr, HttpdServiceAccount, &corev1.ServiceAccount{}); err != nil {
+		return err
+	}
 
-	err := Createk8sResIfNotExist(cr, HttpdServiceAccount, &corev1.ServiceAccount{}, r)
-	if err != nil {
+	OrchestratorServiceAccount := miqtool.OrchestratorServiceAccount(cr)
+	if err := r.createk8sResIfNotExist(cr, OrchestratorServiceAccount, &corev1.ServiceAccount{}); err != nil {
 		return err
 	}
-	err = Createk8sResIfNotExist(cr, OrchestratorServiceAccount, &corev1.ServiceAccount{}, r)
-	if err != nil {
+
+	AnyuidServiceAccount := miqtool.AnyuidServiceAccount(cr)
+	if err := r.createk8sResIfNotExist(cr, AnyuidServiceAccount, &corev1.ServiceAccount{}); err != nil {
 		return err
 	}
-	err = Createk8sResIfNotExist(cr, AnyuidServiceAccount, &corev1.ServiceAccount{}, r)
-	if err != nil {
+
+	OrchestratorViewRoleBinding := miqtool.OrchestratorViewRoleBinding(cr)
+	if err := r.createk8sResIfNotExist(cr, OrchestratorViewRoleBinding, &rbacv1.RoleBinding{}); err != nil {
 		return err
 	}
-	err = Createk8sResIfNotExist(cr, OrchestratorViewRoleBinding, &rbacv1.RoleBinding{}, r)
-	if err != nil {
-		return err
-	}
-	err = Createk8sResIfNotExist(cr, OrchestratorEditRoleBinding, &rbacv1.RoleBinding{}, r)
-	if err != nil {
+
+	OrchestratorEditRoleBinding := miqtool.OrchestratorEditRoleBinding(cr)
+	if err := r.createk8sResIfNotExist(cr, OrchestratorEditRoleBinding, &rbacv1.RoleBinding{}); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func Createk8sResIfNotExist(cr *miqv1alpha1.Manageiq, res, restype metav1.Object, r *ReconcileManageiq) error {
-
+func (r *ReconcileManageiq) createk8sResIfNotExist(cr *miqv1alpha1.Manageiq, res, restype metav1.Object) error {
 	reqLogger := log.WithValues("task: ", "create resource")
 	if err := controllerutil.SetControllerReference(cr, res, r.scheme); err != nil {
 		return err


### PR DESCRIPTION
This is built on https://github.com/ManageIQ/manageiq-pods/pull/418, so merge that first.

This PR does some style cleanup and makes some functions into methods where it makes sense.
Additionally it removes the CleanUpOrchestratedDeployments function as it wasn't needed. All of the objects created by the operator are removed automatically.