### PR TITLE
Use StdEncoding rather than URLEncoding for creating the encryption key

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/generators.go
+++ b/manageiq-operator/pkg/helpers/miq-components/generators.go
@@ -17,12 +17,8 @@ func randomBytes(n int) []byte {
 }
 
 func generateEncryptionKey() string {
-	buf := randomBytes(32)
-
-	h := sha256.New()
-	h.Write(buf)
-
-	return base64.URLEncoding.EncodeToString(h.Sum(nil))
+	sum := sha256.Sum256(randomBytes(32))
+	return base64.StdEncoding.EncodeToString(sum[:])
 }
 
 func generateDatabasePassword() string {


### PR DESCRIPTION
With the URLEncoding, we would get an error from our ruby code
complaining that the key was not 32 bytes. It seems the difference
in encoding was causing the issue.