### PR TITLE
Allow user to provide tls secret

### DIFF
--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -26,6 +26,9 @@ type ManageiqSpec struct {
 	// Containerized database volume size
 	DatabaseVolumeCapacity string `json:"databaseVolumeCapacity"`
 
+	// Secret containing the tls cert and key for the ingress
+	TLSSecret string `json:"tlsSecret"`
+
 	HttpdCpuRequest    string `json:"httpdCpuRequest"`
 	HttpdImageName     string `json:"httpdImageName"`
 	HttpdImageTag      string `json:"httpdImageTag"`

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -262,7 +262,11 @@ func (r *ReconcileManageiq) generateSecrets(cr *miqv1alpha1.Manageiq) error {
 		return err
 	}
 
-	tlsSecret := miqtool.TLSSecret(cr)
+	tlsSecret, err := miqtool.TLSSecret(cr)
+	if err != nil {
+		return err
+	}
+
 	if err := r.createk8sResIfNotExist(cr, tlsSecret, &corev1.Secret{}); err != nil {
 		return err
 	}

--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -31,7 +31,7 @@ func NewIngress(cr *miqv1alpha1.Manageiq) *extensionsv1beta1.Ingress {
 					Hosts: []string{
 						cr.Spec.ApplicationDomain,
 					},
-					SecretName: "tls-secret",
+					SecretName: tlsSecretName(cr),
 				},
 			},
 			Rules: []extensionsv1beta1.IngressRule{
@@ -407,7 +407,7 @@ func TLSSecret(cr *miqv1alpha1.Manageiq) (*corev1.Secret, error) {
 	}
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tls-secret",
+			Name:      tlsSecretName(cr),
 			Namespace: cr.ObjectMeta.Namespace,
 			Labels:    labels,
 		},
@@ -415,4 +415,13 @@ func TLSSecret(cr *miqv1alpha1.Manageiq) (*corev1.Secret, error) {
 		Type:       "kubernetes.io/tls",
 	}
 	return secret, nil
+}
+
+func tlsSecretName(cr *miqv1alpha1.Manageiq) string {
+	secretName := "tls-secret"
+	if cr.Spec.TLSSecret != "" {
+		secretName = cr.Spec.TLSSecret
+	}
+
+	return secretName
 }

--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -391,23 +391,28 @@ func NewHttpdDbusAPIService(cr *miqv1alpha1.Manageiq) *corev1.Service {
 	}
 }
 
-func TLSSecret(cr *miqv1alpha1.Manageiq) *corev1.Secret {
+func TLSSecret(cr *miqv1alpha1.Manageiq) (*corev1.Secret, error) {
 	labels := map[string]string{
 		"app": cr.Spec.AppName,
 	}
 
-	crt, key := tlstools.GenerateCrt("server")
-	secret := map[string]string{
+	crt, key, err := tlstools.GenerateCrt("server")
+	if err != nil {
+		return nil, err
+	}
+
+	data := map[string]string{
 		"tls.crt": string(crt),
 		"tls.key": string(key),
 	}
-	return &corev1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "tls-secret",
 			Namespace: cr.ObjectMeta.Namespace,
 			Labels:    labels,
 		},
-		StringData: secret,
+		StringData: data,
 		Type:       "kubernetes.io/tls",
 	}
+	return secret, nil
 }

--- a/manageiq-operator/pkg/helpers/tlstools/generate_crt.go
+++ b/manageiq-operator/pkg/helpers/tlstools/generate_crt.go
@@ -6,36 +6,19 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"flag"
-	"log"
 	"math/big"
 	"time"
 )
 
-var (
-	host      = flag.String("host", "", "Comma-separated hostnames and IPs to generate a certificate for")
-	validFrom = flag.String("start-date", "", "Creation date formatted as Jan 1 15:04:05 2020")
-	validFor  = flag.Duration("duration", 365*24*time.Hour, "Duration that certificate is valid for")
-	isCA      = flag.Bool("ca", true, "whether this cert should be its own Certificate Authority")
-	rsaBits   = flag.Int("rsa-bits", 2048, "Size of RSA key to generate. Ignored if --ecdsa-curve is set")
-)
-
-func GenerateCrt(CN string) (crt []byte, key []byte) {
-
-	priv, err := rsa.GenerateKey(rand.Reader, *rsaBits)
-
-	if err != nil {
-		log.Fatalf("Failed to generate private key: %v", err)
-	}
-
-	var notBefore time.Time
-	notBefore = time.Now()
-	notAfter := notBefore.Add(*validFor)
+func GenerateCrt(CN string) (crt []byte, key []byte, err error) {
+	notBefore := time.Now()
+	// One year from now
+	notAfter := notBefore.AddDate(1, 0, 0)
 
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
-		log.Fatalf("Failed to generate serial number: %v", err)
+		return nil, nil, err
 	}
 
 	template := x509.Certificate{
@@ -51,16 +34,19 @@ func GenerateCrt(CN string) (crt []byte, key []byte) {
 		BasicConstraintsValid: true,
 	}
 
-	if *isCA {
-		template.IsCA = true
-		template.KeyUsage |= x509.KeyUsageCertSign
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
 	privBytes := x509.MarshalPKCS1PrivateKey(priv)
 
 	newcrt := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
 	newkey := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: privBytes})
 
-	return newcrt, newkey
+	return newcrt, newkey, nil
 }


### PR DESCRIPTION
This PR sdds a field to the manageiq spec for the tls secret name to allow the user to provide a pre-created secret.

This will behave just like the postgres secret:

If it is not provided a new secret called "tls-secret" will be created.
That secret will be removed when the CR is removed.

If the name is provided, but the secret does not exist when the
app is deployed a new secret will be created with the provided
name and used. This secret will also be removed with the CR.

If the name of an existing secret is provided, it will be used
and will not be removed when the CR is removed.

Fixes #409

Additionally this PR cleans up the GenerateCrt function a bit.