### PR TITLE
Add the pod UID to the orchestrator

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
@@ -148,6 +148,12 @@ func NewOrchestratorDeployment(cr *miqv1alpha1.Manageiq) *appsv1.Deployment {
 									Name:  "IMAGE_PULL_SECRET",
 									Value: "",
 								},
+								corev1.EnvVar{
+									Name: "POD_UID",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.uid"},
+									},
+								},
 							},
 
 							Resources: corev1.ResourceRequirements{

--- a/templates/app/orchestrator.yaml
+++ b/templates/app/orchestrator.yaml
@@ -99,6 +99,10 @@ objects:
               secretKeyRef:
                 name: kafka-secrets
                 key: username
+          - name: POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
           resources:
             requests:
               memory: "${ORCHESTRATOR_MEM_REQ}"


### PR DESCRIPTION
We will use this to set up a controller reference for all of the
worker deployments this orchestrator pod creates. This will ensure
that the worker deployments are removed even if the orchestrator
is brought down abruptly.

Part of #428