### PR TITLE
Add the pod name as an env var to the orchestrator

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
@@ -149,6 +149,12 @@ func NewOrchestratorDeployment(cr *miqv1alpha1.Manageiq) *appsv1.Deployment {
 									Value: "",
 								},
 								corev1.EnvVar{
+									Name: "POD_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+									},
+								},
+								corev1.EnvVar{
 									Name: "POD_UID",
 									ValueFrom: &corev1.EnvVarSource{
 										FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.uid"},

--- a/templates/app/orchestrator.yaml
+++ b/templates/app/orchestrator.yaml
@@ -99,6 +99,10 @@ objects:
               secretKeyRef:
                 name: kafka-secrets
                 key: username
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           - name: POD_UID
             valueFrom:
               fieldRef:


### PR DESCRIPTION
This is also needed to set the owner reference on the worker
deployments.

Forgot to add this in #434

Part of #428