### PR TITLE
Define and use a role for the orchestrator

### DIFF
--- a/bin/teardown
+++ b/bin/teardown
@@ -7,15 +7,15 @@ oc get pvc -o name |xargs oc delete
 oc delete secret -l app=manageiq
 oc delete secret tls-secret
 
-oc delete serviceaccount miq-anyuid
-oc delete serviceaccount miq-orchestrator
-oc delete serviceaccount miq-httpd
+oc delete serviceaccount manageiq-anyuid
+oc delete serviceaccount manageiq-orchestrator
+oc delete serviceaccount manageiq-httpd
 
 oc delete cm postgresql-configs
 oc delete cm httpd-configs
 oc delete cm httpd-auth-configs
 
-oc delete rolebinding edit
-oc delete rolebinding view
+oc delete role manageiq-orchestrator
+oc delete rolebinding manageiq-orchestrator
 
 oc delete ingress httpd

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -248,6 +248,21 @@ func (r *ReconcileManageiq) generateKafkaResources(cr *miqv1alpha1.Manageiq) err
 }
 
 func (r *ReconcileManageiq) generateOrchestratorResources(cr *miqv1alpha1.Manageiq) error {
+	orchestratorServiceAccount := miqtool.OrchestratorServiceAccount(cr)
+	if err := r.createk8sResIfNotExist(cr, orchestratorServiceAccount, &corev1.ServiceAccount{}); err != nil {
+		return err
+	}
+
+	orchestratorRole := miqtool.OrchestratorRole(cr)
+	if err := r.createk8sResIfNotExist(cr, orchestratorRole, &rbacv1.Role{}); err != nil {
+		return err
+	}
+
+	orchestratorRoleBinding := miqtool.OrchestratorRoleBinding(cr)
+	if err := r.createk8sResIfNotExist(cr, orchestratorRoleBinding, &rbacv1.RoleBinding{}); err != nil {
+		return err
+	}
+
 	orchestratorDeployment := miqtool.NewOrchestratorDeployment(cr)
 	if err := r.createk8sResIfNotExist(cr, orchestratorDeployment, &appsv1.Deployment{}); err != nil {
 		return err
@@ -280,23 +295,8 @@ func (r *ReconcileManageiq) generateRbacResources(cr *miqv1alpha1.Manageiq) erro
 		return err
 	}
 
-	orchestratorServiceAccount := miqtool.OrchestratorServiceAccount(cr)
-	if err := r.createk8sResIfNotExist(cr, orchestratorServiceAccount, &corev1.ServiceAccount{}); err != nil {
-		return err
-	}
-
 	anyuidServiceAccount := miqtool.AnyuidServiceAccount(cr)
 	if err := r.createk8sResIfNotExist(cr, anyuidServiceAccount, &corev1.ServiceAccount{}); err != nil {
-		return err
-	}
-
-	orchestratorViewRoleBinding := miqtool.OrchestratorViewRoleBinding(cr)
-	if err := r.createk8sResIfNotExist(cr, orchestratorViewRoleBinding, &rbacv1.RoleBinding{}); err != nil {
-		return err
-	}
-
-	orchestratorEditRoleBinding := miqtool.OrchestratorEditRoleBinding(cr)
-	if err := r.createk8sResIfNotExist(cr, orchestratorEditRoleBinding, &rbacv1.RoleBinding{}); err != nil {
 		return err
 	}
 

--- a/manageiq-operator/pkg/helpers/miq-components/rbac.go
+++ b/manageiq-operator/pkg/helpers/miq-components/rbac.go
@@ -19,7 +19,7 @@ func HttpdServiceAccount(cr *miqv1alpha1.Manageiq) *corev1.ServiceAccount {
 func OrchestratorServiceAccount(cr *miqv1alpha1.Manageiq) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Spec.AppName + "-orchestrator",
+			Name:      orchestratorObjectName(cr),
 			Namespace: cr.ObjectMeta.Namespace,
 		},
 	}
@@ -34,42 +34,52 @@ func AnyuidServiceAccount(cr *miqv1alpha1.Manageiq) *corev1.ServiceAccount {
 	}
 }
 
-func OrchestratorViewRoleBinding(cr *miqv1alpha1.Manageiq) *rbacv1.RoleBinding {
-	return &rbacv1.RoleBinding{
+func OrchestratorRole(cr *miqv1alpha1.Manageiq) *rbacv1.Role {
+	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "view",
+			Name:      orchestratorObjectName(cr),
 			Namespace: cr.ObjectMeta.Namespace,
 		},
-		RoleRef: rbacv1.RoleRef{
-			Kind:     "ClusterRole",
-			Name:     "view",
-			APIGroup: "rbac.authorization.k8s.io",
-		},
-		Subjects: []rbacv1.Subject{
-			rbacv1.Subject{
-				Kind: "ServiceAccount",
-				Name: cr.Spec.AppName + "-orchestrator",
+		Rules: []rbacv1.PolicyRule{
+			rbacv1.PolicyRule{
+				APIGroups: []string{""},
+				Resources: []string{"pods", "pods/finalizers"},
+				Verbs:     []string{"*"},
+			},
+			rbacv1.PolicyRule{
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments", "deployments/scale"},
+				Verbs:     []string{"*"},
+			},
+			rbacv1.PolicyRule{
+				APIGroups: []string{"extensions"},
+				Resources: []string{"deployments", "deployments/scale"},
+				Verbs:     []string{"*"},
 			},
 		},
 	}
 }
 
-func OrchestratorEditRoleBinding(cr *miqv1alpha1.Manageiq) *rbacv1.RoleBinding {
+func OrchestratorRoleBinding(cr *miqv1alpha1.Manageiq) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "edit",
+			Name:      orchestratorObjectName(cr),
 			Namespace: cr.ObjectMeta.Namespace,
 		},
 		RoleRef: rbacv1.RoleRef{
-			Kind:     "ClusterRole",
-			Name:     "edit",
+			Kind:     "Role",
+			Name:     orchestratorObjectName(cr),
 			APIGroup: "rbac.authorization.k8s.io",
 		},
 		Subjects: []rbacv1.Subject{
 			rbacv1.Subject{
 				Kind: "ServiceAccount",
-				Name: cr.Spec.AppName + "-orchestrator",
+				Name: orchestratorObjectName(cr),
 			},
 		},
 	}
+}
+
+func orchestratorObjectName(cr *miqv1alpha1.Manageiq) string {
+	return cr.Spec.AppName + "-orchestrator"
 }

--- a/templates/app/rbac.yaml
+++ b/templates/app/rbac.yaml
@@ -16,23 +16,38 @@ objects:
   metadata:
     name: "${APP_NAME}-httpd"
 - apiVersion: rbac.authorization.k8s.io/v1
-  kind: RoleBinding
+  kind: Role
   metadata:
-    name: view
-  roleRef:
-    kind: ClusterRole
-    name: view
-    apiGroup: rbac.authorization.k8s.io
-  subjects:
-  - kind: ServiceAccount
     name: "${APP_NAME}-orchestrator"
+  rules:
+  - apiGroups:
+    - ''
+    resources:
+    - pods
+    - pods/finalizers
+    verbs:
+    - "*"
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    - deployments/scale
+    verbs:
+    - "*"
+  - apiGroups:
+    - extensions
+    resources:
+    - deployments
+    - deployments/scale
+    verbs:
+    - "*"
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
-    name: edit
+    name: "${APP_NAME}-orchestrator"
   roleRef:
-    kind: ClusterRole
-    name: edit
+    kind: Role
+    name: "${APP_NAME}-orchestrator"
     apiGroup: rbac.authorization.k8s.io
   subjects:
   - kind: ServiceAccount


### PR DESCRIPTION
This is more like how an operator works and allows us to control
the individual permissions given to the orchestrator.

Specifically the "edit" cluster role didn't include the ability to
set finalizers on pods. This was preventing us from using kubernetes
garbage collection to ensure that the worker deployments were cleaned
up whenever the orchestrator pod is brought down.

Part of #428