### PR TITLE
Allow operator to deploy orchestrator role

### DIFF
--- a/manageiq-operator/deploy/role.yaml
+++ b/manageiq-operator/deploy/role.yaml
@@ -8,6 +8,7 @@ rules:
   - ""
   resources:
   - pods
+  - pods/finalizers
   - services
   - services/finalizers
   - persistentvolumeclaims
@@ -19,6 +20,8 @@ rules:
 - apiGroups:
   - extensions
   resources:
+  - deployments
+  - deployments/scale
   - ingresses
   verbs:
   - '*'
@@ -26,15 +29,14 @@ rules:
   - "rbac.authorization.k8s.io"
   resources:
   - rolebindings
-  - clusterroles
   - roles
   verbs:
-  - escalate
   - '*'
 - apiGroups:
   - apps
   resources:
   - deployments
+  - deployments/scale
   - replicasets
   verbs:
   - '*'


### PR DESCRIPTION
**What this PR does / why we need it**:

Before this change we were getting a permissions error because the
orchestrator was asking for more permissions than the operator had.
This commit makes the operator roles a superset of the orchestrator's
and removes the escalate verb from the operator role

ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping