### PR TITLE
Use defaults for missing cr values

### DIFF
--- a/manageiq-operator/README.md
+++ b/manageiq-operator/README.md
@@ -50,7 +50,7 @@ $ oc create -f deploy/operator.yaml
 ### Create the CR to deploy ManageIQ
 
 ```bash
-$ oc create -f deploy/crds/manageiq_v1alpha1_manageiq_cr.yaml
+$ oc create -f deploy/crds/manageiq.org_v1alpha1_manageiq_cr.yaml
 ```
 
 **ManageIQ Instance Example**

--- a/manageiq-operator/README.md
+++ b/manageiq-operator/README.md
@@ -55,7 +55,9 @@ $ oc create -f deploy/crds/manageiq_v1alpha1_manageiq_cr.yaml
 
 **ManageIQ Instance Example**
 
-> Deployments' resource requests here are tailered to make them fit into a crc cluster, change them according to your cluster's resource capacity*
+> The domain here will work for a Code Ready Containers cluster. Change it to one that will work for your environment.
+
+> Additional parameters are available and documented in the Custom Resource Definition
 
 ```yaml
 apiVersion: manageiq.org/v1alpha1
@@ -63,45 +65,5 @@ kind: ManageIQ
 metadata:
   name: miq
 spec:
-  appName:  "manageiq"
-  applicationAdminPassword: "smartvm"
   applicationDomain: "miqproject.apps-crc.testing"
-
-  databaseSecret: postgresql-secrets
-  databaseRegion: "0"
-  databaseVolumeCapacity: 15Gi
-
-  httpdCpuRequest: 100m
-  httpdImageName: manageiq/httpd
-  httpdImageTag: latest
-  httpdMemoryLimit: 200Mi
-  httpdMemoryRequest: 100Mi
-
-  memcachedCpuRequest: 200m
-  memcachedImageName: manageiq/memcached
-  memcachedImageTag: latest
-  memcachedMaxConnection: "1024"
-  memcachedMaxMemory: "64"
-  memcachedMemoryLimit: 256Mi
-  memcachedMemoryRequest: 64Mi
-  memcachedSlabPageSize: 1m
-
-  orchestratorCpuRequest: 100m
-  orchestratorImageName: manageiq-orchestrator
-  orchestratorImageNamespace: manageiq
-  orchestratorImageTag: latest
-  orchestratorMemoryLimit: 16Gi
-  orchestratorMemoryRequest: 150Mi
-
-  postgresqlCpuRequest: 100m
-  postgresqlImageName: docker.io/manageiq/postgresql
-  postgresqlImageTag: latest
-  postgresqlMaxConnections: "1000"
-  postgresqlMemoryLimit: 8Gi
-  postgresqlMemoryRequest: 200Mi
-  postgresqlSharedBuffers: 1GB
-
-  kafkaSecret: kafka-secrets
-  kafkaVolumeCapacity: 1Gi
-  zookeeperVolumeCapacity: 1Gi
 ```

--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -96,7 +96,7 @@ spec:
               description: 'Memcached deployment memory request (default: no limit)'
               type: string
             memcachedSlabPageSize:
-              description: 'Memcached max item size (default: 1mb, min: 1k, max: 1024m)'
+              description: 'Memcached max item size (default: 1m, min: 1k, max: 1024m)'
               type: string
             orchestratorCpuRequest:
               description: 'Orchestrator deployment CPU request (default: no request)'

--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -32,124 +32,124 @@ spec:
           description: ManageIQSpec defines the desired state of ManageIQ
           properties:
             appName:
-              description: 'Important: Run "operator-sdk generate k8s" to regenerate
-                code after modifying this file Application name used for deployed
-                objects'
+              description: 'Application name used for deployed objects (default: manageiq)'
               type: string
             applicationAdminPassword:
-              description: admin user initial password
+              description: 'Initial password for "admin" user (default: smartvm)'
               type: string
             applicationDomain:
-              description: Domain name for the external route Used for external authentication
+              description: Domain name for the external route. Used for external authentication
                 configuration
               type: string
             databaseRegion:
-              description: Application region number
+              description: 'Database region number (default: 0)'
               type: string
             databaseSecret:
+              description: 'Secret containing the database access information, content
+                generated if not provided (default: postgresql-secrets)'
               type: string
             databaseVolumeCapacity:
-              description: Containerized database volume size
-              type: string
-            encryptionKey:
+              description: 'Database volume size (default: 15Gi)'
               type: string
             httpdCpuRequest:
+              description: 'Httpd deployment CPU request (default: no request)'
               type: string
             httpdImageName:
+              description: 'Image used for the httpd deployment (default: manageiq/httpd)'
               type: string
             httpdImageTag:
+              description: 'Image tag used for the httpd deployment (default: latest)'
               type: string
             httpdMemoryLimit:
+              description: 'Httpd deployment memory limit (default: no limit)'
               type: string
             httpdMemoryRequest:
+              description: 'Httpd deployment memory request (default: no limit)'
               type: string
             kafkaSecret:
+              description: 'Secret containing the kafka access information, content
+                generated if not provided (default: kafka-secrets)'
               type: string
             kafkaVolumeCapacity:
+              description: 'Kafka volume size (default: 1Gi)'
               type: string
             memcachedCpuRequest:
+              description: 'Memcached deployment CPU request (default: no request)'
               type: string
             memcachedImageName:
+              description: 'Image used for the memcached deployment (default: manageiq/memcached)'
               type: string
             memcachedImageTag:
+              description: 'Image tag used for the memcached deployment (default:
+                latest)'
               type: string
             memcachedMaxConnection:
+              description: 'Memcached max simultaneous connections (default: 1024)'
               type: string
             memcachedMaxMemory:
+              description: 'Memcached item memory in megabytes (default: 64)'
               type: string
             memcachedMemoryLimit:
+              description: 'Memcached deployment memory limit (default: no limit)'
               type: string
             memcachedMemoryRequest:
+              description: 'Memcached deployment memory request (default: no limit)'
               type: string
             memcachedSlabPageSize:
+              description: 'Memcached max item size (default: 1mb, min: 1k, max: 1024m)'
               type: string
             orchestratorCpuRequest:
+              description: 'Orchestrator deployment CPU request (default: no request)'
               type: string
             orchestratorImageName:
+              description: 'Image name used for the orchestrator deployment (default:
+                manageiq-orchestrator)'
               type: string
             orchestratorImageNamespace:
+              description: 'Image namespace used for the orchestrator and worker deployments
+                (default: manageiq)'
               type: string
             orchestratorImageTag:
+              description: 'Image tag used for the orchestrator and worker deployments
+                (default: latest)'
               type: string
             orchestratorMemoryLimit:
+              description: 'Orchestrator deployment memory limit (default: no limit)'
               type: string
             orchestratorMemoryRequest:
+              description: 'Orchestrator deployment memory request (default: no limit)'
               type: string
             postgresqlCpuRequest:
+              description: 'PostgreSQL deployment CPU request (default: no request)'
               type: string
             postgresqlImageName:
+              description: 'Image used for the postgresql deployment (Default: docker.io/manageiq/postgresql)'
               type: string
             postgresqlImageTag:
+              description: 'Image tag used for the postgresql deployment (Default:
+                10)'
               type: string
             postgresqlMaxConnections:
+              description: 'PostgreSQL maximum connection setting (default: 1000)'
               type: string
             postgresqlMemoryLimit:
+              description: 'PostgreSQL deployment memory limit (default: no limit)'
               type: string
             postgresqlMemoryRequest:
+              description: 'PostgreSQL deployment memory request (default: no limit)'
               type: string
             postgresqlSharedBuffers:
+              description: 'PostgreSQL shared buffers setting (default: 1GB)'
               type: string
             tlsSecret:
-              description: Secret containing the tls cert and key for the ingress
+              description: 'Secret containing the tls cert and key for the ingress,
+                content generated if not provided (default: tls-secret)'
               type: string
             zookeeperVolumeCapacity:
+              description: 'Zookeeper volume size (default: 1Gi)'
               type: string
           required:
-          - appName
-          - applicationAdminPassword
           - applicationDomain
-          - databaseRegion
-          - databaseVolumeCapacity
-          - encryptionKey
-          - httpdCpuRequest
-          - httpdImageName
-          - httpdImageTag
-          - httpdMemoryLimit
-          - httpdMemoryRequest
-          - kafkaVolumeCapacity
-          - memcachedCpuRequest
-          - memcachedImageName
-          - memcachedImageTag
-          - memcachedMaxConnection
-          - memcachedMaxMemory
-          - memcachedMemoryLimit
-          - memcachedMemoryRequest
-          - memcachedSlabPageSize
-          - orchestratorCpuRequest
-          - orchestratorImageName
-          - orchestratorImageNamespace
-          - orchestratorImageTag
-          - orchestratorMemoryLimit
-          - orchestratorMemoryRequest
-          - postgresqlCpuRequest
-          - postgresqlImageName
-          - postgresqlImageTag
-          - postgresqlMaxConnections
-          - postgresqlMemoryLimit
-          - postgresqlMemoryRequest
-          - postgresqlSharedBuffers
-          - tlsSecret
-          - zookeeperVolumeCapacity
           type: object
         status:
           description: ManageIQStatus defines the observed state of ManageIQ

--- a/manageiq-operator/deploy/crds/manageiq.org_v1alpha1_manageiq_cr.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_v1alpha1_manageiq_cr.yaml
@@ -3,46 +3,4 @@ kind: ManageIQ
 metadata:
   name: miq
 spec:
-  # Add fields here
-  appName: # e.g. "manageiq"
-  applicationAdminPassword: # e.g. "smartvm"
-  applicationDomain: # e.g. "miqproject.example.com"
-
-  databaseSecret: postgresql-secrets
-  databaseRegion: # e.g. "0"
-  databaseVolumeCapacity: # e.g. 15Gi
-
-  httpdCpuRequest: # e.g. 100m
-  httpdImageName: # e.g. manageiq/httpd
-  httpdImageTag: # e.g. latest
-  httpdMemoryLimit: # e.g. 200Mi
-  httpdMemoryRequest: # e.g. 100Mi
-
-  memcachedCpuRequest: # e.g. 200m
-  memcachedImageName: # e.g. manageiq/memcached
-  memcachedImageTag: # e.g. latest
-
-  memcachedMaxConnection: # e.g. "1024"
-  memcachedMaxMemory: # e.g. "64"
-  memcachedMemoryLimit: # e.g. 256Mi
-  memcachedMemoryRequest: # e.g. 64Mi
-  memcachedSlabPageSize: # e.g. 1m
-
-  orchestratorCpuRequest: # e.g. 100m
-  orchestratorImageName: # e.g. manageiq-orchestrator
-  orchestratorImageNamespace: # e.g. manageiq
-  orchestratorImageTag: # e.g. latest
-  orchestratorMemoryLimit: # e.g. 16Gi
-  orchestratorMemoryRequest: # e.g. 150Mi
-
-  postgresqlCpuRequest: # e.g. 100m
-  postgresqlImageName: # e.g. docker.io/manageiq/postgresql
-  postgresqlImageTag: # e.g. latest
-  postgresqlMaxConnections: # e.g. "1000"
-  postgresqlMemoryLimit: # e.g. 8Gi
-  postgresqlMemoryRequest: # e.g. 200Mi
-  postgresqlSharedBuffers: # e.g. 1GB
-
-  kafkaSecret: kafka-secrets
-  kafkaVolumeCapacity: 1Gi
-  zookeeperVolumeCapacity: 1Gi
+  applicationDomain: miqproject.apps-crc.testing

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq-operator.v0.0.1.clusterserviceversion.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq-operator.v0.0.1.clusterserviceversion.yaml
@@ -11,41 +11,7 @@ metadata:
             "name": "miq"
           },
           "spec": {
-            "appName": null,
-            "applicationAdminPassword": null,
-            "applicationDomain": null,
-            "databaseRegion": null,
-            "databaseSecret": "postgresql-secrets",
-            "databaseVolumeCapacity": null,
-            "httpdCpuRequest": null,
-            "httpdImageName": null,
-            "httpdImageTag": null,
-            "httpdMemoryLimit": null,
-            "httpdMemoryRequest": null,
-            "kafkaSecret": "kafka-secrets",
-            "kafkaVolumeCapacity": "1Gi",
-            "memcachedCpuRequest": null,
-            "memcachedImageName": null,
-            "memcachedImageTag": null,
-            "memcachedMaxConnection": null,
-            "memcachedMaxMemory": null,
-            "memcachedMemoryLimit": null,
-            "memcachedMemoryRequest": null,
-            "memcachedSlabPageSize": null,
-            "orchestratorCpuRequest": null,
-            "orchestratorImageName": null,
-            "orchestratorImageNamespace": null,
-            "orchestratorImageTag": null,
-            "orchestratorMemoryLimit": null,
-            "orchestratorMemoryRequest": null,
-            "postgresqlCpuRequest": null,
-            "postgresqlImageName": null,
-            "postgresqlImageTag": null,
-            "postgresqlMaxConnections": null,
-            "postgresqlMemoryLimit": null,
-            "postgresqlMemoryRequest": null,
-            "postgresqlSharedBuffers": null,
-            "zookeeperVolumeCapacity": "1Gi"
+            "applicationDomain": "miqproject.apps-crc.testing"
           }
         }
       ]

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -96,7 +96,7 @@ spec:
               description: 'Memcached deployment memory request (default: no limit)'
               type: string
             memcachedSlabPageSize:
-              description: 'Memcached max item size (default: 1mb, min: 1k, max: 1024m)'
+              description: 'Memcached max item size (default: 1m, min: 1k, max: 1024m)'
               type: string
             orchestratorCpuRequest:
               description: 'Orchestrator deployment CPU request (default: no request)'

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -32,124 +32,124 @@ spec:
           description: ManageIQSpec defines the desired state of ManageIQ
           properties:
             appName:
-              description: 'Important: Run "operator-sdk generate k8s" to regenerate
-                code after modifying this file Application name used for deployed
-                objects'
+              description: 'Application name used for deployed objects (default: manageiq)'
               type: string
             applicationAdminPassword:
-              description: admin user initial password
+              description: 'Initial password for "admin" user (default: smartvm)'
               type: string
             applicationDomain:
-              description: Domain name for the external route Used for external authentication
+              description: Domain name for the external route. Used for external authentication
                 configuration
               type: string
             databaseRegion:
-              description: Application region number
+              description: 'Database region number (default: 0)'
               type: string
             databaseSecret:
+              description: 'Secret containing the database access information, content
+                generated if not provided (default: postgresql-secrets)'
               type: string
             databaseVolumeCapacity:
-              description: Containerized database volume size
-              type: string
-            encryptionKey:
+              description: 'Database volume size (default: 15Gi)'
               type: string
             httpdCpuRequest:
+              description: 'Httpd deployment CPU request (default: no request)'
               type: string
             httpdImageName:
+              description: 'Image used for the httpd deployment (default: manageiq/httpd)'
               type: string
             httpdImageTag:
+              description: 'Image tag used for the httpd deployment (default: latest)'
               type: string
             httpdMemoryLimit:
+              description: 'Httpd deployment memory limit (default: no limit)'
               type: string
             httpdMemoryRequest:
+              description: 'Httpd deployment memory request (default: no limit)'
               type: string
             kafkaSecret:
+              description: 'Secret containing the kafka access information, content
+                generated if not provided (default: kafka-secrets)'
               type: string
             kafkaVolumeCapacity:
+              description: 'Kafka volume size (default: 1Gi)'
               type: string
             memcachedCpuRequest:
+              description: 'Memcached deployment CPU request (default: no request)'
               type: string
             memcachedImageName:
+              description: 'Image used for the memcached deployment (default: manageiq/memcached)'
               type: string
             memcachedImageTag:
+              description: 'Image tag used for the memcached deployment (default:
+                latest)'
               type: string
             memcachedMaxConnection:
+              description: 'Memcached max simultaneous connections (default: 1024)'
               type: string
             memcachedMaxMemory:
+              description: 'Memcached item memory in megabytes (default: 64)'
               type: string
             memcachedMemoryLimit:
+              description: 'Memcached deployment memory limit (default: no limit)'
               type: string
             memcachedMemoryRequest:
+              description: 'Memcached deployment memory request (default: no limit)'
               type: string
             memcachedSlabPageSize:
+              description: 'Memcached max item size (default: 1mb, min: 1k, max: 1024m)'
               type: string
             orchestratorCpuRequest:
+              description: 'Orchestrator deployment CPU request (default: no request)'
               type: string
             orchestratorImageName:
+              description: 'Image name used for the orchestrator deployment (default:
+                manageiq-orchestrator)'
               type: string
             orchestratorImageNamespace:
+              description: 'Image namespace used for the orchestrator and worker deployments
+                (default: manageiq)'
               type: string
             orchestratorImageTag:
+              description: 'Image tag used for the orchestrator and worker deployments
+                (default: latest)'
               type: string
             orchestratorMemoryLimit:
+              description: 'Orchestrator deployment memory limit (default: no limit)'
               type: string
             orchestratorMemoryRequest:
+              description: 'Orchestrator deployment memory request (default: no limit)'
               type: string
             postgresqlCpuRequest:
+              description: 'PostgreSQL deployment CPU request (default: no request)'
               type: string
             postgresqlImageName:
+              description: 'Image used for the postgresql deployment (Default: docker.io/manageiq/postgresql)'
               type: string
             postgresqlImageTag:
+              description: 'Image tag used for the postgresql deployment (Default:
+                10)'
               type: string
             postgresqlMaxConnections:
+              description: 'PostgreSQL maximum connection setting (default: 1000)'
               type: string
             postgresqlMemoryLimit:
+              description: 'PostgreSQL deployment memory limit (default: no limit)'
               type: string
             postgresqlMemoryRequest:
+              description: 'PostgreSQL deployment memory request (default: no limit)'
               type: string
             postgresqlSharedBuffers:
+              description: 'PostgreSQL shared buffers setting (default: 1GB)'
               type: string
             tlsSecret:
-              description: Secret containing the tls cert and key for the ingress
+              description: 'Secret containing the tls cert and key for the ingress,
+                content generated if not provided (default: tls-secret)'
               type: string
             zookeeperVolumeCapacity:
+              description: 'Zookeeper volume size (default: 1Gi)'
               type: string
           required:
-          - appName
-          - applicationAdminPassword
           - applicationDomain
-          - databaseRegion
-          - databaseVolumeCapacity
-          - encryptionKey
-          - httpdCpuRequest
-          - httpdImageName
-          - httpdImageTag
-          - httpdMemoryLimit
-          - httpdMemoryRequest
-          - kafkaVolumeCapacity
-          - memcachedCpuRequest
-          - memcachedImageName
-          - memcachedImageTag
-          - memcachedMaxConnection
-          - memcachedMaxMemory
-          - memcachedMemoryLimit
-          - memcachedMemoryRequest
-          - memcachedSlabPageSize
-          - orchestratorCpuRequest
-          - orchestratorImageName
-          - orchestratorImageNamespace
-          - orchestratorImageTag
-          - orchestratorMemoryLimit
-          - orchestratorMemoryRequest
-          - postgresqlCpuRequest
-          - postgresqlImageName
-          - postgresqlImageTag
-          - postgresqlMaxConnections
-          - postgresqlMemoryLimit
-          - postgresqlMemoryRequest
-          - postgresqlSharedBuffers
-          - tlsSecret
-          - zookeeperVolumeCapacity
           type: object
         status:
           description: ManageIQStatus defines the observed state of ManageIQ

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -75,7 +75,7 @@ type ManageIQSpec struct {
 	// Memcached item memory in megabytes (default: 64)
 	// +optional
 	MemcachedMaxMemory string `json:"memcachedMaxMemory"`
-	// Memcached max item size (default: 1mb, min: 1k, max: 1024m)
+	// Memcached max item size (default: 1m, min: 1k, max: 1024m)
 	// +optional
 	MemcachedSlabPageSize string `json:"memcachedSlabPageSize"`
 
@@ -211,7 +211,7 @@ func (m *ManageIQ) Initialize() {
 	}
 
 	if spec.MemcachedSlabPageSize == "" {
-		spec.MemcachedSlabPageSize = "1mb"
+		spec.MemcachedSlabPageSize = "1m"
 	}
 
 	if spec.OrchestratorImageName == "" {

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -7,62 +7,131 @@ import (
 // ManageIQSpec defines the desired state of ManageIQ
 type ManageIQSpec struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// Application name used for deployed objects
+
+	// Application name used for deployed objects (default: manageiq)
+	// +optional
 	AppName string `json:"appName"`
 
-	// admin user initial password
+	// Initial password for "admin" user (default: smartvm)
+	// +optional
 	ApplicationAdminPassword string `json:"applicationAdminPassword"`
 
-	// Domain name for the external route
-	// Used for external authentication configuration
+	// Domain name for the external route. Used for external authentication configuration
 	ApplicationDomain string `json:"applicationDomain"`
 
-	// Application region number
+	// Database region number (default: 0)
+	// +optional
 	DatabaseRegion string `json:"databaseRegion"`
-	// Containerized database volume size
+
+	// Database volume size (default: 15Gi)
+	// +optional
 	DatabaseVolumeCapacity string `json:"databaseVolumeCapacity"`
+
+	// Secret containing the database access information, content generated if not provided (default: postgresql-secrets)
 	// +optional
 	DatabaseSecret string `json:"databaseSecret"`
 
-	// Secret containing the tls cert and key for the ingress
+	// Secret containing the tls cert and key for the ingress, content generated if not provided (default: tls-secret)
+	// +optional
 	TLSSecret string `json:"tlsSecret"`
 
-	HttpdCpuRequest    string `json:"httpdCpuRequest"`
-	HttpdImageName     string `json:"httpdImageName"`
-	HttpdImageTag      string `json:"httpdImageTag"`
-	HttpdMemoryLimit   string `json:"httpdMemoryLimit"`
+	// Image used for the httpd deployment (default: manageiq/httpd)
+	// +optional
+	HttpdImageName string `json:"httpdImageName"`
+	// Image tag used for the httpd deployment (default: latest)
+	// +optional
+	HttpdImageTag string `json:"httpdImageTag"`
+
+	// Httpd deployment CPU request (default: no request)
+	// +optional
+	HttpdCpuRequest string `json:"httpdCpuRequest"`
+	// Httpd deployment memory limit (default: no limit)
+	// +optional
+	HttpdMemoryLimit string `json:"httpdMemoryLimit"`
+	// Httpd deployment memory request (default: no limit)
+	// +optional
 	HttpdMemoryRequest string `json:"httpdMemoryRequest"`
 
-	MemcachedCpuRequest    string `json:"memcachedCpuRequest"`
-	MemcachedImageName     string `json:"memcachedImageName"`
-	MemcachedImageTag      string `json:"memcachedImageTag"`
-	MemcachedMaxConnection string `json:"memcachedMaxConnection"`
-	MemcachedMaxMemory     string `json:"memcachedMaxMemory"`
-	MemcachedMemoryLimit   string `json:"memcachedMemoryLimit"`
+	// Image used for the memcached deployment (default: manageiq/memcached)
+	// +optional
+	MemcachedImageName string `json:"memcachedImageName"`
+	// Image tag used for the memcached deployment (default: latest)
+	// +optional
+	MemcachedImageTag string `json:"memcachedImageTag"`
+
+	// Memcached deployment CPU request (default: no request)
+	// +optional
+	MemcachedCpuRequest string `json:"memcachedCpuRequest"`
+	// Memcached deployment memory limit (default: no limit)
+	// +optional
+	MemcachedMemoryLimit string `json:"memcachedMemoryLimit"`
+	// Memcached deployment memory request (default: no limit)
+	// +optional
 	MemcachedMemoryRequest string `json:"memcachedMemoryRequest"`
-	MemcachedSlabPageSize  string `json:"memcachedSlabPageSize"`
 
-	OrchestratorCpuRequest     string `json:"orchestratorCpuRequest"`
-	OrchestratorImageName      string `json:"orchestratorImageName"`
+	// Memcached max simultaneous connections (default: 1024)
+	// +optional
+	MemcachedMaxConnection string `json:"memcachedMaxConnection"`
+	// Memcached item memory in megabytes (default: 64)
+	// +optional
+	MemcachedMaxMemory string `json:"memcachedMaxMemory"`
+	// Memcached max item size (default: 1mb, min: 1k, max: 1024m)
+	// +optional
+	MemcachedSlabPageSize string `json:"memcachedSlabPageSize"`
+
+	// Image name used for the orchestrator deployment (default: manageiq-orchestrator)
+	// +optional
+	OrchestratorImageName string `json:"orchestratorImageName"`
+	// Image namespace used for the orchestrator and worker deployments (default: manageiq)
+	// +optional
 	OrchestratorImageNamespace string `json:"orchestratorImageNamespace"`
-	OrchestratorImageTag       string `json:"orchestratorImageTag"`
-	OrchestratorMemoryLimit    string `json:"orchestratorMemoryLimit"`
-	OrchestratorMemoryRequest  string `json:"orchestratorMemoryRequest"`
+	// Image tag used for the orchestrator and worker deployments (default: latest)
+	// +optional
+	OrchestratorImageTag string `json:"orchestratorImageTag"`
 
-	PostgresqlCpuRequest     string `json:"postgresqlCpuRequest"`
-	PostgresqlImageName      string `json:"postgresqlImageName"`
-	PostgresqlImageTag       string `json:"postgresqlImageTag"`
+	// Orchestrator deployment CPU request (default: no request)
+	// +optional
+	OrchestratorCpuRequest string `json:"orchestratorCpuRequest"`
+	// Orchestrator deployment memory limit (default: no limit)
+	// +optional
+	OrchestratorMemoryLimit string `json:"orchestratorMemoryLimit"`
+	// Orchestrator deployment memory request (default: no limit)
+	// +optional
+	OrchestratorMemoryRequest string `json:"orchestratorMemoryRequest"`
+
+	// Image used for the postgresql deployment (Default: docker.io/manageiq/postgresql)
+	// +optional
+	PostgresqlImageName string `json:"postgresqlImageName"`
+	// Image tag used for the postgresql deployment (Default: 10)
+	// +optional
+	PostgresqlImageTag string `json:"postgresqlImageTag"`
+
+	// PostgreSQL deployment CPU request (default: no request)
+	// +optional
+	PostgresqlCpuRequest string `json:"postgresqlCpuRequest"`
+	// PostgreSQL deployment memory limit (default: no limit)
+	// +optional
+	PostgresqlMemoryLimit string `json:"postgresqlMemoryLimit"`
+	// PostgreSQL deployment memory request (default: no limit)
+	// +optional
+	PostgresqlMemoryRequest string `json:"postgresqlMemoryRequest"`
+
+	// PostgreSQL maximum connection setting (default: 1000)
+	// +optional
 	PostgresqlMaxConnections string `json:"postgresqlMaxConnections"`
-	PostgresqlMemoryLimit    string `json:"postgresqlMemoryLimit"`
-	PostgresqlMemoryRequest  string `json:"postgresqlMemoryRequest"`
-	PostgresqlSharedBuffers  string `json:"postgresqlSharedBuffers"`
+	// PostgreSQL shared buffers setting (default: 1GB)
+	// +optional
+	PostgresqlSharedBuffers string `json:"postgresqlSharedBuffers"`
 
-	KafkaVolumeCapacity     string `json:"kafkaVolumeCapacity"`
+	// Kafka volume size (default: 1Gi)
+	// +optional
+	KafkaVolumeCapacity string `json:"kafkaVolumeCapacity"`
+	// Zookeeper volume size (default: 1Gi)
+	// +optional
 	ZookeeperVolumeCapacity string `json:"zookeeperVolumeCapacity"`
+	// Secret containing the kafka access information, content generated if not provided (default: kafka-secrets)
 	// +optional
 	KafkaSecret string `json:"kafkaSecret"`
-
-	EncryptionKey string `json:"encryptionKey"`
 }
 
 // ManageIQStatus defines the observed state of ManageIQ
@@ -96,4 +165,88 @@ type ManageIQList struct {
 
 func init() {
 	SchemeBuilder.Register(&ManageIQ{}, &ManageIQList{})
+}
+
+func (m *ManageIQ) Initialize() {
+	spec := &m.Spec
+
+	if spec.AppName == "" {
+		spec.AppName = "manageiq"
+	}
+
+	if spec.ApplicationAdminPassword == "" {
+		spec.ApplicationAdminPassword = "smartvm"
+	}
+
+	if spec.DatabaseRegion == "" {
+		spec.DatabaseRegion = "0"
+	}
+
+	if spec.DatabaseVolumeCapacity == "" {
+		spec.DatabaseVolumeCapacity = "15Gi"
+	}
+
+	if spec.HttpdImageName == "" {
+		spec.HttpdImageName = "manageiq/httpd"
+	}
+
+	if spec.HttpdImageTag == "" {
+		spec.HttpdImageTag = "latest"
+	}
+
+	if spec.MemcachedImageName == "" {
+		spec.MemcachedImageName = "manageiq/memcached"
+	}
+
+	if spec.MemcachedImageTag == "" {
+		spec.MemcachedImageTag = "latest"
+	}
+
+	if spec.MemcachedMaxConnection == "" {
+		spec.MemcachedMaxConnection = "1024"
+	}
+
+	if spec.MemcachedMaxMemory == "" {
+		spec.MemcachedMaxMemory = "64"
+	}
+
+	if spec.MemcachedSlabPageSize == "" {
+		spec.MemcachedSlabPageSize = "1mb"
+	}
+
+	if spec.OrchestratorImageName == "" {
+		spec.OrchestratorImageName = "manageiq-orchestrator"
+	}
+
+	if spec.OrchestratorImageNamespace == "" {
+		spec.OrchestratorImageNamespace = "manageiq"
+	}
+
+	if spec.OrchestratorImageTag == "" {
+		spec.OrchestratorImageTag = "latest"
+	}
+
+	if spec.PostgresqlImageName == "" {
+		spec.PostgresqlImageName = "docker.io/manageiq/postgresql"
+	}
+
+	if spec.PostgresqlImageTag == "" {
+		spec.PostgresqlImageTag = "10"
+	}
+
+	if spec.PostgresqlMaxConnections == "" {
+		spec.PostgresqlMaxConnections = "1000"
+	}
+
+	if spec.PostgresqlSharedBuffers == "" {
+		spec.PostgresqlSharedBuffers = "1GB"
+	}
+
+	if spec.KafkaVolumeCapacity == "" {
+		spec.KafkaVolumeCapacity = "1Gi"
+	}
+
+	if spec.ZookeeperVolumeCapacity == "" {
+		spec.ZookeeperVolumeCapacity = "1Gi"
+	}
 }

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -172,7 +172,10 @@ func (r *ReconcileManageIQ) generateHttpdResources(cr *miqv1alpha1.ManageIQ) err
 		return err
 	}
 
-	httpdDeployment := miqtool.NewHttpdDeployment(cr)
+	httpdDeployment, err := miqtool.NewHttpdDeployment(cr)
+	if err != nil {
+		return err
+	}
 	if err := r.createk8sResIfNotExist(cr, httpdDeployment, &appsv1.Deployment{}); err != nil {
 		return err
 	}
@@ -186,7 +189,10 @@ func (r *ReconcileManageIQ) generateHttpdResources(cr *miqv1alpha1.ManageIQ) err
 }
 
 func (r *ReconcileManageIQ) generateMemcachedResources(cr *miqv1alpha1.ManageIQ) error {
-	memcachedDeployment := miqtool.NewMemcachedDeployment(cr)
+	memcachedDeployment, err := miqtool.NewMemcachedDeployment(cr)
+	if err != nil {
+		return err
+	}
 	if err := r.createk8sResIfNotExist(cr, memcachedDeployment, &appsv1.Deployment{}); err != nil {
 		return err
 	}
@@ -220,7 +226,10 @@ func (r *ReconcileManageIQ) generatePostgresqlResources(cr *miqv1alpha1.ManageIQ
 		return err
 	}
 
-	postgresqlDeployment := miqtool.NewPostgresqlDeployment(cr)
+	postgresqlDeployment, err := miqtool.NewPostgresqlDeployment(cr)
+	if err != nil {
+		return err
+	}
 	if err := r.createk8sResIfNotExist(cr, postgresqlDeployment, &appsv1.Deployment{}); err != nil {
 		return err
 	}
@@ -283,7 +292,10 @@ func (r *ReconcileManageIQ) generateOrchestratorResources(cr *miqv1alpha1.Manage
 		return err
 	}
 
-	orchestratorDeployment := miqtool.NewOrchestratorDeployment(cr)
+	orchestratorDeployment, err := miqtool.NewOrchestratorDeployment(cr)
+	if err != nil {
+		return err
+	}
 	if err := r.createk8sResIfNotExist(cr, orchestratorDeployment, &appsv1.Deployment{}); err != nil {
 		return err
 	}

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -105,6 +105,7 @@ func (r *ReconcileManageIQ) Reconcile(request reconcile.Request) (reconcile.Resu
 	// Fetch the ManageIQ instance
 	miqInstance := &miqv1alpha1.ManageIQ{}
 	err := r.client.Get(context.TODO(), request.NamespacedName, miqInstance)
+	miqInstance.Initialize()
 
 	if errors.IsNotFound(err) {
 		return reconcile.Result{}, nil

--- a/manageiq-operator/pkg/helpers/miq-components/memcached.go
+++ b/manageiq-operator/pkg/helpers/miq-components/memcached.go
@@ -4,27 +4,67 @@ import (
 	miqv1alpha1 "github.com/ManageIQ/manageiq-pods/manageiq-operator/pkg/apis/manageiq/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func NewMemcachedDeployment(cr *miqv1alpha1.ManageIQ) *appsv1.Deployment {
+func NewMemcachedDeployment(cr *miqv1alpha1.ManageIQ) (*appsv1.Deployment, error) {
+	container := corev1.Container{
+		Name:  "memcached",
+		Image: cr.Spec.MemcachedImageName + ":" + cr.Spec.MemcachedImageTag,
+
+		Ports: []corev1.ContainerPort{
+			corev1.ContainerPort{
+				ContainerPort: 11211,
+				Protocol:      "TCP",
+			},
+		},
+
+		LivenessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt(11211),
+				},
+			},
+		},
+		ReadinessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt(11211),
+				},
+			},
+		},
+		Env: []corev1.EnvVar{
+			corev1.EnvVar{
+				Name:  "MEMCACHED_MAX_MEMORY",
+				Value: cr.Spec.MemcachedMaxMemory,
+			},
+			corev1.EnvVar{
+				Name:  "MEMCACHED_MAX_CONNECTIONS",
+				Value: cr.Spec.MemcachedMaxConnection,
+			},
+			corev1.EnvVar{
+				Name:  "MEMCACHED_SLAB_PAGE_SIZE",
+				Value: cr.Spec.MemcachedSlabPageSize,
+			},
+		},
+	}
+
+	err := addResourceReqs(cr.Spec.MemcachedMemoryLimit, cr.Spec.MemcachedMemoryRequest, cr.Spec.MemcachedCpuRequest, &container)
+	if err != nil {
+		return nil, err
+	}
+
 	deploymentLabels := map[string]string{
 		"app": cr.Spec.AppName,
 	}
-
 	podLabels := map[string]string{
 		"name": "memcached",
 		"app":  cr.Spec.AppName,
 	}
-
 	var repNum int32 = 1
-	memLimit, _ := resource.ParseQuantity(cr.Spec.MemcachedMemoryLimit)
-	memReq, _ := resource.ParseQuantity(cr.Spec.MemcachedMemoryRequest)
-	cpuReq, _ := resource.ParseQuantity(cr.Spec.MemcachedCpuRequest)
 
-	return &appsv1.Deployment{
+	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "memcached",
 			Namespace: cr.ObjectMeta.Namespace,
@@ -41,61 +81,13 @@ func NewMemcachedDeployment(cr *miqv1alpha1.ManageIQ) *appsv1.Deployment {
 					Labels: podLabels,
 				},
 				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						corev1.Container{
-							Name:  "memcached",
-							Image: cr.Spec.MemcachedImageName + ":" + cr.Spec.MemcachedImageTag,
-
-							Ports: []corev1.ContainerPort{
-								corev1.ContainerPort{
-									ContainerPort: 11211,
-									Protocol:      "TCP",
-								},
-							},
-
-							LivenessProbe: &corev1.Probe{
-								Handler: corev1.Handler{
-									TCPSocket: &corev1.TCPSocketAction{
-										Port: intstr.FromInt(11211),
-									},
-								},
-							},
-							ReadinessProbe: &corev1.Probe{
-								Handler: corev1.Handler{
-									TCPSocket: &corev1.TCPSocketAction{
-										Port: intstr.FromInt(11211),
-									},
-								},
-							},
-							Env: []corev1.EnvVar{
-								corev1.EnvVar{
-									Name:  "MEMCACHED_MAX_MEMORY",
-									Value: cr.Spec.MemcachedMaxMemory,
-								},
-								corev1.EnvVar{
-									Name:  "MEMCACHED_MAX_CONNECTION",
-									Value: cr.Spec.MemcachedMaxConnection,
-								},
-								corev1.EnvVar{
-									Name:  "MEMCACHED_SLAB_PAGE_SIZE",
-									Value: cr.Spec.MemcachedSlabPageSize,
-								},
-							},
-							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									"memory": memLimit,
-								},
-								Requests: corev1.ResourceList{
-									"memory": memReq,
-									"cpu":    cpuReq,
-								},
-							},
-						},
-					},
+					Containers: []corev1.Container{container},
 				},
 			},
 		},
 	}
+
+	return deployment, nil
 }
 
 func NewMemcachedService(cr *miqv1alpha1.ManageIQ) *corev1.Service {

--- a/manageiq-operator/pkg/helpers/miq-components/util.go
+++ b/manageiq-operator/pkg/helpers/miq-components/util.go
@@ -1,0 +1,42 @@
+package miqtools
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func addResourceReqs(memLimit string, memReq string, cpuReq string, c *corev1.Container) error {
+	if memLimit == "" && memReq == "" && cpuReq == "" {
+		return nil
+	}
+
+	if memLimit != "" {
+		limit, err := resource.ParseQuantity(memLimit)
+		if err != nil {
+			return err
+		}
+		c.Resources.Limits = corev1.ResourceList{"memory": limit}
+	}
+
+	if memReq != "" || cpuReq != "" {
+		c.Resources.Requests = make(map[corev1.ResourceName]resource.Quantity)
+	}
+
+	if memReq != "" {
+		req, err := resource.ParseQuantity(memReq)
+		if err != nil {
+			return err
+		}
+		c.Resources.Requests["memory"] = req
+	}
+
+	if cpuReq != "" {
+		req, err := resource.ParseQuantity(cpuReq)
+		if err != nil {
+			return err
+		}
+		c.Resources.Requests["cpu"] = req
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows some sensible defaults to be used for nearly all of the parameters in the manageiq CR. By doing this it also allows manageiq to be deployed more easily in resource constrained environments like Code Ready Containers. Specifically the defaults for the resource limits and requirements are to not set any limits or requirements. If any of the values are set they will be properly reflected in the deployment.

This also makes manageiq much easier to deploy. A valid CR is now just:
```yaml
apiVersion: manageiq.org/v1alpha1
kind: ManageIQ
metadata:
  name: miq
spec:
  applicationDomain: "miqproject.apps-crc.testing"
```

This prevents the user from needing to know about things like image location, and tags, while allowing them to continue to customize PV sizes and tuning parameters as needed.

I got very aggressive with this, but I would be okay with adding back some parameters like the PV sizes if we think those should be more visible.

Fixes #443