### PR TITLE
add app_name parameter to teardown script

### DIFF
--- a/bin/teardown
+++ b/bin/teardown
@@ -1,15 +1,17 @@
 #!/bin/bash
 
-oc delete all -l app=manageiq
+APP_NAME=${APP_NAME:-manageiq}
+
+oc delete all -l app=$APP_NAME
 
 oc get pvc -o name |xargs oc delete
 
-oc delete secret -l app=manageiq
+oc delete secret -l app=$APP_NAME
 oc delete secret tls-secret
 
-oc delete serviceaccount manageiq-anyuid
-oc delete serviceaccount manageiq-orchestrator
-oc delete serviceaccount manageiq-httpd
+oc delete serviceaccount $APP_NAME-anyuid
+oc delete serviceaccount $APP_NAME-orchestrator
+oc delete serviceaccount $APP_NAME-httpd
 
 oc delete cm postgresql-configs
 oc delete cm httpd-configs

--- a/bin/teardown
+++ b/bin/teardown
@@ -17,7 +17,7 @@ oc delete cm postgresql-configs
 oc delete cm httpd-configs
 oc delete cm httpd-auth-configs
 
-oc delete role manageiq-orchestrator
-oc delete rolebinding manageiq-orchestrator
+oc delete role $APP_NAME-orchestrator
+oc delete rolebinding $APP_NAME-orchestrator
 
 oc delete ingress httpd


### PR DESCRIPTION
Setting an APP_NAME parameter in the teardown script that defaults to `manageiq`. Deployments using a non-default APP_NAME in the parameters file will be able to use teardown without editing it. 

Requesting that this change goes into jansa as well. 


