### PR TITLE
Don't run the app as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,25 +48,6 @@ _**Note:**_ This section assumes you have a basic user.
 $ oc new-project <project_name>
 ```
 
-### Add the anyuid and orchestrator service accounts to the anyuid security context
-
-_**Note:**_ The current MIQ images require the root user.
-
-These service accounts for your namespace (project) must be added to the anyuid SCC before pods using the service accounts can run as root.
-
-_**As admin**_
-
-```bash
-$ oc adm policy add-scc-to-user anyuid system:serviceaccount:<your-namespace>:<app-name>-anyuid
-$ oc adm policy add-scc-to-user anyuid system:serviceaccount:<your-namespace>:<app-name>-orchestrator
-```
-
-Verify that the service accounts are now included in the anyuid scc
-```
-$ oc describe scc anyuid | grep Users
-Users:					system:serviceaccount:<your-namespace>:miq-anyuid,system:serviceaccount:<your-namespace>:miq-orchestrator
-```
-
 ### Set up the httpd service account
 
 #### If running without OCI systemd hooks (Minishift)
@@ -214,7 +195,7 @@ $ oc describe pods | egrep "^Name:|openshift.io/scc"
 Name:               httpd-754985464b-4dzzx
 Annotations:        openshift.io/scc=anyuid
 Name:               manageiq-orchestrator-5997776478-vx4v9
-Annotations:        openshift.io/scc=anyuid
+Annotations:        openshift.io/scc=restricted
 Name:               memcached-696479b955-67fs6
 Annotations:        openshift.io/scc=restricted
 Name:               postgresql-5f954fdbd5-tnlmf

--- a/bin/deploy_on_minishift
+++ b/bin/deploy_on_minishift
@@ -30,20 +30,6 @@ then
 	$(oc new-project $project >/dev/null)
 fi
 
-$(oc describe scc anyuid | grep Users | awk '{print $2}' | grep -q $project:miq-anyuid)
-if [ $? -ne 0 ];
-then
-	echo "Assigning SCC anyuid to miq-anyuid Service Account..."
-	$(oc adm policy add-scc-to-user anyuid system:serviceaccount:$project:miq-anyuid >/dev/null)
-fi
-
-$(oc describe scc anyuid | grep Users | awk '{print $2}' | grep -q miq-orchestrator)
-if [ $? -ne 0 ];
-then
-	echo "Assigning SCC anyuid to miq-orchestrator Service Account..."
-	$(oc adm policy add-scc-to-user anyuid system:serviceaccount:$project:miq-orchestrator >/dev/null)
-fi
-
 $(oc get scc miq-sysadmin >/dev/null 2>&1)
 if [ $? -ne 0 ];
 then

--- a/bin/teardown
+++ b/bin/teardown
@@ -9,7 +9,6 @@ oc get pvc -o name |xargs oc delete
 oc delete secret -l app=$APP_NAME
 oc delete secret tls-secret
 
-oc delete serviceaccount $APP_NAME-anyuid
 oc delete serviceaccount $APP_NAME-orchestrator
 oc delete serviceaccount $APP_NAME-httpd
 

--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -154,6 +154,9 @@ RUN source /etc/default/evm && \
     rm -rvf ${APP_ROOT}/tmp/cache/assets && \
     rm -vf ${APP_ROOT}/log/*.log
 
+RUN chgrp -R 0 $APP_ROOT && \
+    chmod -R g=u $APP_ROOT
+
 ADD container-assets/container_env ${APP_ROOT}
 
 RUN wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_${ARCH} && \

--- a/images/manageiq-ui-worker/Dockerfile
+++ b/images/manageiq-ui-worker/Dockerfile
@@ -51,4 +51,9 @@ RUN source /etc/default/evm && \
     fi && \
     rm -rf /tmp/npm_registry
 
+# Configure httpd to run without root privileges
+RUN chgrp root /var/run/httpd && chmod g+rwx /var/run/httpd && \
+    chgrp root /var/log/httpd && chmod g+rwx /var/log/httpd
+RUN sed -i '/^Listen 80/d' /etc/httpd/conf/httpd.conf
+
 COPY container-assets/manageiq-http.conf /etc/httpd/conf.d

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -327,11 +327,6 @@ func (r *ReconcileManageIQ) generateRbacResources(cr *miqv1alpha1.ManageIQ) erro
 		return err
 	}
 
-	anyuidServiceAccount := miqtool.AnyuidServiceAccount(cr)
-	if err := r.createk8sResIfNotExist(cr, anyuidServiceAccount, &corev1.ServiceAccount{}); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/manageiq-operator/pkg/helpers/miq-components/rbac.go
+++ b/manageiq-operator/pkg/helpers/miq-components/rbac.go
@@ -25,15 +25,6 @@ func OrchestratorServiceAccount(cr *miqv1alpha1.ManageIQ) *corev1.ServiceAccount
 	}
 }
 
-func AnyuidServiceAccount(cr *miqv1alpha1.ManageIQ) *corev1.ServiceAccount {
-	return &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Spec.AppName + "-anyuid",
-			Namespace: cr.ObjectMeta.Namespace,
-		},
-	}
-}
-
 func OrchestratorRole(cr *miqv1alpha1.ManageIQ) *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{

--- a/templates/app/rbac.yaml
+++ b/templates/app/rbac.yaml
@@ -10,10 +10,6 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
-    name: "${APP_NAME}-anyuid"
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
     name: "${APP_NAME}-httpd"
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes the orchestrator and work pods run in the restricted scc rather than anyuid

A bunch of certifications require us not to run as root
in containers. Additionally the vast majority of the application
should run fine without root and the parts that need root are
typically things we can't do in containers anyway.

Specifically this changes the permissions of some directories to
allow the root group access which is what we'll be running as when
using the restricted scc in OpenShift

Related to https://github.com/ManageIQ/manageiq-pods/issues/442

**Special notes for your reviewer**:

Merge with https://github.com/ManageIQ/manageiq/pull/20095