### PR TITLE
Use 8080 for httpd and 8081 for dbus api

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -41,7 +41,7 @@ func NewIngress(cr *miqv1alpha1.ManageIQ) *extensionsv1beta1.Ingress {
 									Path: "/",
 									Backend: extensionsv1beta1.IngressBackend{
 										ServiceName: "httpd",
-										ServicePort: intstr.FromInt(80),
+										ServicePort: intstr.FromInt(8080),
 									},
 								},
 							},
@@ -114,11 +114,11 @@ func NewHttpdDeployment(cr *miqv1alpha1.ManageIQ) (*appsv1.Deployment, error) {
 		Image: cr.Spec.HttpdImageName + ":" + cr.Spec.HttpdImageTag,
 		Ports: []corev1.ContainerPort{
 			corev1.ContainerPort{
-				ContainerPort: 80,
+				ContainerPort: 8080,
 				Protocol:      "TCP",
 			},
 			corev1.ContainerPort{
-				ContainerPort: 8080,
+				ContainerPort: 8081,
 				Protocol:      "TCP",
 			},
 		},
@@ -134,7 +134,7 @@ func NewHttpdDeployment(cr *miqv1alpha1.ManageIQ) (*appsv1.Deployment, error) {
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				TCPSocket: &corev1.TCPSocketAction{
-					Port: intstr.FromInt(80),
+					Port: intstr.FromInt(8080),
 				},
 			},
 			InitialDelaySeconds: 10,
@@ -326,7 +326,7 @@ func NewHttpdService(cr *miqv1alpha1.ManageIQ) *corev1.Service {
 			Ports: []corev1.ServicePort{
 				corev1.ServicePort{
 					Name: "http",
-					Port: 80,
+					Port: 8080,
 				},
 			},
 			Selector: selector,
@@ -353,7 +353,7 @@ func NewHttpdDbusAPIService(cr *miqv1alpha1.ManageIQ) *corev1.Service {
 			Ports: []corev1.ServicePort{
 				corev1.ServicePort{
 					Name: "http-dbus-api",
-					Port: 8080,
+					Port: 8081,
 				},
 			},
 			Selector: selector,

--- a/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
@@ -12,13 +12,14 @@ func httpdAuthConfigurationConf() string {
 // application.conf
 func httpdApplicationConf() string {
 	return `
+Listen 8080
 # Timeout: The number of seconds before receives and sends time out.
 Timeout 120
 
 RewriteEngine On
 Options SymLinksIfOwnerMatch
 
-<VirtualHost *:80>
+<VirtualHost *:8080>
   KeepAlive on
   # Without ServerName mod_auth_mellon compares against http:// and not https:// from the IdP
   ServerName https://%{REQUEST_HOST}

--- a/templates/app/httpd.yaml
+++ b/templates/app/httpd.yaml
@@ -11,13 +11,14 @@ objects:
       app: "${APP_NAME}"
   data:
     application.conf: |
+      Listen 8080
       # Timeout: The number of seconds before receives and sends time out.
       Timeout 120
 
       RewriteEngine On
       Options SymLinksIfOwnerMatch
 
-      <VirtualHost *:80>
+      <VirtualHost *:8080>
         KeepAlive on
         # Without ServerName mod_auth_mellon compares against http:// and not https:// from the IdP
         ServerName https://%{REQUEST_HOST}
@@ -271,7 +272,7 @@ objects:
   spec:
     ports:
     - name: http
-      port: 80
+      port: 8080
     selector:
       name: httpd
 - apiVersion: v1
@@ -283,7 +284,7 @@ objects:
   spec:
     ports:
     - name: http-dbus-api
-      port: 8080
+      port: 8081
     selector:
       name: httpd
 - apiVersion: apps/v1
@@ -314,9 +315,9 @@ objects:
         - name: httpd
           image: "${HTTPD_IMAGE_NAME}:${HTTPD_IMAGE_TAG}"
           ports:
-          - containerPort: 80
-            protocol: TCP
           - containerPort: 8080
+            protocol: TCP
+          - containerPort: 8081
             protocol: TCP
           livenessProbe:
             exec:
@@ -327,7 +328,7 @@ objects:
             timeoutSeconds: 3
           readinessProbe:
             tcpSocket:
-              port: 80
+              port: 8080
             initialDelaySeconds: 10
             timeoutSeconds: 3
           volumeMounts:
@@ -396,7 +397,7 @@ objects:
         - path: "/"
           backend:
             serviceName: httpd
-            servicePort: 80
+            servicePort: 8080
 parameters:
 - name: APP_NAME
   value: manageiq


### PR DESCRIPTION
This will make switching in an httpd pod without root privileges
easier as it won't be able to bind to port 80

Requires https://github.com/ManageIQ/container-httpd/pull/45

Related to https://github.com/ManageIQ/manageiq-pods/issues/467