### PR TITLE
Clear the app logs directory after all UI worker steps

### DIFF
--- a/images/manageiq-ui-worker/Dockerfile
+++ b/images/manageiq-ui-worker/Dockerfile
@@ -41,7 +41,8 @@ RUN source /etc/default/evm && \
     sed -i '/phantomjs/d' package.json && \
     yarn install && \
     yarn run available-languages && \
-    yarn run build
+    yarn run build && \
+    rm -vf ${APP_ROOT}/log/*.log
 
 RUN source /etc/default/evm && \
     yarn cache clean && \
@@ -49,7 +50,9 @@ RUN source /etc/default/evm && \
     if [ ! -z "${NPM_REGISTRY_OVERRIDE}" ]; then \
       /tmp/npm_registry/npm_yarn_registry_cleanup.sh; \
     fi && \
-    rm -rf /tmp/npm_registry
+    rm -rf /tmp/npm_registry && \
+    rm -vf ${APP_ROOT}/log/*.log
+
 
 # Configure httpd to run without root privileges
 RUN chgrp root /var/run/httpd && chmod g+rwx /var/run/httpd && \


### PR DESCRIPTION
Before this change, the image had some logs left over from the build
which did not have the group permissions we need to write to them
at runtime.

This lead to failures in the UI pod:
```
/usr/share/ruby/logger.rb:744:in `initialize': Permission denied @ rb_sysopen - /var/www/miq/vmdb/log/audit.log (Errno::EACCES)
```