### PR TITLE
Only use httpd with systemd when necessary

### DIFF
--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -51,11 +51,19 @@ spec:
             databaseVolumeCapacity:
               description: 'Database volume size (default: 15Gi)'
               type: string
+            httpdAuthenticationType:
+              description: 'Type of httpd authentication (default: internal) Options:
+                internal, external, active-directory, saml, openid-connect Note: external,
+                active-directory, and saml require an httpd container with elevated
+                privileges'
+              type: string
             httpdCpuRequest:
               description: 'Httpd deployment CPU request (default: no request)'
               type: string
-            httpdImageName:
-              description: 'Image used for the httpd deployment (default: manageiq/httpd)'
+            httpdImageNamespace:
+              description: 'Image namespace used for the httpd deployment (default:
+                manageiq) Note: the exact image will be determined by the authentication
+                method selected'
               type: string
             httpdImageTag:
               description: 'Image tag used for the httpd deployment (default: latest)'

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -51,11 +51,19 @@ spec:
             databaseVolumeCapacity:
               description: 'Database volume size (default: 15Gi)'
               type: string
+            httpdAuthenticationType:
+              description: 'Type of httpd authentication (default: internal) Options:
+                internal, external, active-directory, saml, openid-connect Note: external,
+                active-directory, and saml require an httpd container with elevated
+                privileges'
+              type: string
             httpdCpuRequest:
               description: 'Httpd deployment CPU request (default: no request)'
               type: string
-            httpdImageName:
-              description: 'Image used for the httpd deployment (default: manageiq/httpd)'
+            httpdImageNamespace:
+              description: 'Image namespace used for the httpd deployment (default:
+                manageiq) Note: the exact image will be determined by the authentication
+                method selected'
               type: string
             httpdImageTag:
               description: 'Image tag used for the httpd deployment (default: latest)'

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -35,12 +35,19 @@ type ManageIQSpec struct {
 	// +optional
 	TLSSecret string `json:"tlsSecret"`
 
-	// Image used for the httpd deployment (default: manageiq/httpd)
+	// Image namespace used for the httpd deployment (default: manageiq)
+	// Note: the exact image will be determined by the authentication method selected
 	// +optional
-	HttpdImageName string `json:"httpdImageName"`
+	HttpdImageNamespace string `json:"httpdImageNamespace"`
 	// Image tag used for the httpd deployment (default: latest)
 	// +optional
 	HttpdImageTag string `json:"httpdImageTag"`
+
+	// Type of httpd authentication (default: internal)
+	// Options: internal, external, active-directory, saml, openid-connect
+	// Note: external, active-directory, and saml require an httpd container with elevated privileges
+	// +optional
+	HttpdAuthenticationType string `json:"httpdAuthenticationType"`
 
 	// Httpd deployment CPU request (default: no request)
 	// +optional
@@ -189,12 +196,16 @@ func (m *ManageIQ) Initialize() {
 		spec.DatabaseVolumeCapacity = "15Gi"
 	}
 
-	if spec.HttpdImageName == "" {
-		spec.HttpdImageName = "manageiq/httpd"
+	if spec.HttpdImageNamespace == "" {
+		spec.HttpdImageNamespace = "manageiq"
 	}
 
 	if spec.HttpdImageTag == "" {
 		spec.HttpdImageTag = "latest"
+	}
+
+	if spec.HttpdAuthenticationType == "" {
+		spec.HttpdAuthenticationType = "internal"
 	}
 
 	if spec.MemcachedImageName == "" {


### PR DESCRIPTION
This PR changes the operator to deploy an httpd image which requires fewer privileges and does not run `systemd` when we don't need it. It also adds the image to this repo (which we may or may not want to move forward with).

When the `HttpdAuthenticationType` parameter is either `internal` or `openid-connect`, we will deploy the image without systemd and will not require the httpd sa to have anyuid or privileged scc access.

This handles the first two bullets of https://github.com/ManageIQ/manageiq-pods/issues/467
I'll open a separate patch to configure oidc using the operator.

My only open issues with this PR are the name of the new image and its location. I would prefer this image be the un-qualified `manageiq/httpd` image as it's the less complicated of the two and change the name of the original image to `manageiq/httpd-init` or something. Additionally I'm not sure if we want it to live in this repo, the container-httpd repo, or somewhere else.