### PR TITLE
Pin the base image to ubi 8.1 and don't install net-snmp from ubi repos

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi:8.1
 
 ARG MIQ_REF=master
 ARG SUI_REF=master
@@ -36,7 +36,7 @@ RUN mkdir build && \
 # Hooks should make modifications to the source in the appliance, sui, and/or app directories
 RUN if [[ -n "$HOOKS_SCRIPT_URL" ]]; then curl -L ${HOOKS_SCRIPT_URL} | bash; fi
 
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi:8.1
 MAINTAINER ManageIQ https://manageiq.org
 
 ARG ARCH=x86_64
@@ -62,6 +62,7 @@ RUN curl -L https://copr.fedorainfracloud.org/coprs/manageiq/ManageIQ-Master/rep
 RUN dnf -y --disableplugin=subscription-manager install http://mirror.centos.org/centos/8/BaseOS/${ARCH}/os/Packages/centos-repos-8.1-1.1911.0.8.el8.${ARCH}.rpm http://mirror.centos.org/centos/8/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8.1-1.1911.0.8.el8.noarch.rpm https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     dnf -y --disableplugin=subscription-manager module enable nodejs:12 && \
     dnf -y --disableplugin=subscription-manager module enable ruby:2.6 && \
+    dnf config-manager --setopt=ubi-8-appstream.exclude=*net-snmp* --setopt=ubi-8-baseos.exclude=*net-snmp* --setopt=ubi-8-codeready-builder.exclude=*net-snmp* --save && \
     dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
       ansible                     \
       ansible-runner              \


### PR DESCRIPTION
The ubi repos are not versioned by minor version so we were pulling
in a later version from there which was incompatible with the earlier
version that we had available for the other net-snmp-* packages
from the CentOS repos.

This lead to errors such as:
```
Error:
 Problem: package net-snmp-utils-1:5.8-12.el8_1.1.x86_64 requires net-snmp-libs(x86-64) = 1:5.8-12.el8_1.1, but none of the providers can be installed
  - cannot install both net-snmp-libs-1:5.8-14.el8.x86_64 and net-snmp-libs-1:5.8-12.el8_1.1.x86_64
  - cannot install the best candidate for the job
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```