### PR TITLE
Only check for the httpd process in the privileged image

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -150,14 +150,16 @@ func assignHttpdPorts(privileged bool, c *corev1.Container) {
 func initializeHttpdContainer(spec *miqv1alpha1.ManageIQSpec, privileged bool, c *corev1.Container) error {
 	c.Name = "httpd"
 	c.Image = httpdImage(spec.HttpdImageNamespace, spec.HttpdImageTag, privileged)
-	c.LivenessProbe = &corev1.Probe{
-		Handler: corev1.Handler{
-			Exec: &corev1.ExecAction{
-				Command: []string{"pidof", "httpd"},
+	if privileged {
+		c.LivenessProbe = &corev1.Probe{
+			Handler: corev1.Handler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"pidof", "httpd"},
+				},
 			},
-		},
-		InitialDelaySeconds: 10,
-		TimeoutSeconds:      3,
+			InitialDelaySeconds: 10,
+			TimeoutSeconds:      3,
+		}
 	}
 	c.ReadinessProbe = &corev1.Probe{
 		Handler: corev1.Handler{


### PR DESCRIPTION
In the non-privileged image httpd will be running as pid 1 so
the container will exit if the process comes down, making the
liveness check redundant.

Fixes #475
