### PR TITLE
Remove external auth from the template-based deployment

### DIFF
--- a/bin/teardown
+++ b/bin/teardown
@@ -10,11 +10,9 @@ oc delete secret -l app=$APP_NAME
 oc delete secret tls-secret
 
 oc delete serviceaccount $APP_NAME-orchestrator
-oc delete serviceaccount $APP_NAME-httpd
 
 oc delete cm postgresql-configs
 oc delete cm httpd-configs
-oc delete cm httpd-auth-configs
 
 oc delete role $APP_NAME-orchestrator
 oc delete rolebinding $APP_NAME-orchestrator

--- a/templates/app/httpd.yaml
+++ b/templates/app/httpd.yaml
@@ -34,9 +34,6 @@ objects:
         # For httpd, some ErrorDocuments must by served by the httpd pod
         RewriteCond %{REQUEST_URI} !^/proxy_pages
 
-        # For SAML /saml2 is only served by mod_auth_mellon in the httpd pod
-        RewriteCond %{REQUEST_URI} !^/saml2
-
         # For OpenID-Connect /openid-connect is only served by mod_auth_openidc
         RewriteCond %{REQUEST_URI} !^/openid-connect
 
@@ -50,183 +47,6 @@ objects:
         ErrorLog  "| /usr/bin/tee /proc/1/fd/2 /var/log/httpd/error_log"
         CustomLog "| /usr/bin/tee /proc/1/fd/1 /var/log/httpd/access_log" common
       </VirtualHost>
-    authentication.conf: |
-      # Load appropriate authentication configuration files
-      #
-      Include "conf.d/configuration-${HTTPD_AUTH_TYPE}-auth"
-    configuration-internal-auth: |
-      # Internal authentication
-      #
-    configuration-external-auth: |
-      Include "conf.d/external-auth-load-modules-conf"
-
-      <Location /dashboard/kerberos_authenticate>
-        AuthType           GSSAPI
-        AuthName           "GSSAPI Single Sign On Login"
-        GssapiCredStore    keytab:/etc/http.keytab
-        GssapiLocalName    on
-        Require            pam-account httpd-auth
-
-        ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js
-      </Location>
-
-      Include "conf.d/external-auth-login-form-conf"
-      Include "conf.d/external-auth-application-api-conf"
-      Include "conf.d/external-auth-lookup-user-details-conf"
-      Include "conf.d/external-auth-remote-user-conf"
-    configuration-active-directory-auth: |
-      Include "conf.d/external-auth-load-modules-conf"
-
-      <Location /dashboard/kerberos_authenticate>
-        AuthType           GSSAPI
-        AuthName           "GSSAPI Single Sign On Login"
-        GssapiCredStore    keytab:/etc/krb5.keytab
-        GssapiLocalName    on
-        Require            pam-account httpd-auth
-
-        ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js
-      </Location>
-
-      Include "conf.d/external-auth-login-form-conf"
-      Include "conf.d/external-auth-application-api-conf"
-      Include "conf.d/external-auth-lookup-user-details-conf"
-      Include "conf.d/external-auth-remote-user-conf"
-    configuration-saml-auth: |
-      LoadModule auth_mellon_module modules/mod_auth_mellon.so
-
-      <Location />
-        MellonEnable               "info"
-
-        MellonIdPMetadataFile      "/etc/httpd/saml2/idp-metadata.xml"
-
-        MellonSPPrivateKeyFile     "/etc/httpd/saml2/sp-key.key"
-        MellonSPCertFile           "/etc/httpd/saml2/sp-cert.cert"
-        MellonSPMetadataFile       "/etc/httpd/saml2/sp-metadata.xml"
-
-        MellonVariable             "sp-cookie"
-        MellonSecureCookie         On
-        MellonCookiePath           "/"
-
-        MellonIdP                  "IDP"
-
-        MellonEndpointPath         "/saml2"
-
-        MellonUser                 username
-        MellonMergeEnvVars         On
-
-        MellonSetEnvNoPrefix       "REMOTE_USER"            username
-        MellonSetEnvNoPrefix       "REMOTE_USER_EMAIL"      email
-        MellonSetEnvNoPrefix       "REMOTE_USER_FIRSTNAME"  firstname
-        MellonSetEnvNoPrefix       "REMOTE_USER_LASTNAME"   lastname
-        MellonSetEnvNoPrefix       "REMOTE_USER_FULLNAME"   fullname
-        MellonSetEnvNoPrefix       "REMOTE_USER_GROUPS"     groups
-      </Location>
-
-      <Location /saml_login>
-        AuthType                   "Mellon"
-        MellonEnable               "auth"
-        Require                    valid-user
-      </Location>
-
-      Include "conf.d/external-auth-remote-user-conf"
-    configuration-openid-connect-auth: |
-      LoadModule auth_openidc_module modules/mod_auth_openidc.so
-
-      OIDCProviderMetadataURL      ${HTTPD_AUTH_OIDC_PROVIDER_METADATA_URL}
-      OIDCClientID                 ${HTTPD_AUTH_OIDC_CLIENT_ID}
-      OIDCClientSecret             ${HTTPD_AUTH_OIDC_CLIENT_SECRET}
-
-      OIDCRedirectURI              "https://${APPLICATION_DOMAIN}/oidc_login/redirect_uri"
-      OIDCOAuthRemoteUserClaim     username
-
-      OIDCCryptoPassphrase         sp-secret
-
-      <Location /oidc_login>
-        AuthType                   openid-connect
-        Require                    valid-user
-      </Location>
-
-      Include "conf.d/external-auth-openid-connect-remote-user-conf"
-    external-auth-load-modules-conf: |
-      LoadModule authnz_pam_module            modules/mod_authnz_pam.so
-      LoadModule intercept_form_submit_module modules/mod_intercept_form_submit.so
-      LoadModule lookup_identity_module       modules/mod_lookup_identity.so
-      LoadModule auth_kerb_module             modules/mod_auth_kerb.so
-    external-auth-login-form-conf: |
-      <Location /dashboard/external_authenticate>
-        InterceptFormPAMService    httpd-auth
-        InterceptFormLogin         user_name
-        InterceptFormPassword      user_password
-        InterceptFormLoginSkip     admin
-        InterceptFormClearRemoteUserForSkipped on
-      </Location>
-    external-auth-application-api-conf: |
-      <LocationMatch ^/api>
-        SetEnvIf Authorization     '^Basic +YWRtaW46' let_admin_in
-        SetEnvIf X-Auth-Token      '^.+$'             let_api_token_in
-        SetEnvIf X-MIQ-Token       '^.+$'             let_sys_token_in
-
-        AuthType                   Basic
-        AuthName                   "External Authentication (httpd) for API"
-        AuthBasicProvider          PAM
-
-        AuthPAMService             httpd-auth
-        Require                    valid-user
-        Order                      Allow,Deny
-        Allow from                 env=let_admin_in
-        Allow from                 env=let_api_token_in
-        Allow from                 env=let_sys_token_in
-        Satisfy                    Any
-      </LocationMatch>
-    external-auth-lookup-user-details-conf: |
-      <LocationMatch ^/dashboard/external_authenticate$|^/dashboard/kerberos_authenticate$|^/api>
-        LookupUserAttr mail        REMOTE_USER_EMAIL
-        LookupUserAttr givenname   REMOTE_USER_FIRSTNAME
-        LookupUserAttr sn          REMOTE_USER_LASTNAME
-        LookupUserAttr displayname REMOTE_USER_FULLNAME
-        LookupUserAttr domainname  REMOTE_USER_DOMAIN
-
-        LookupUserGroups           REMOTE_USER_GROUPS ":"
-        LookupDbusTimeout          5000
-      </LocationMatch>
-    external-auth-remote-user-conf: |
-      RequestHeader unset X_REMOTE_USER
-
-      RequestHeader set X_REMOTE_USER           %{REMOTE_USER}e           env=REMOTE_USER
-      RequestHeader set X_EXTERNAL_AUTH_ERROR   %{EXTERNAL_AUTH_ERROR}e   env=EXTERNAL_AUTH_ERROR
-      RequestHeader set X_REMOTE_USER_EMAIL     %{REMOTE_USER_EMAIL}e     env=REMOTE_USER_EMAIL
-      RequestHeader set X_REMOTE_USER_FIRSTNAME %{REMOTE_USER_FIRSTNAME}e env=REMOTE_USER_FIRSTNAME
-      RequestHeader set X_REMOTE_USER_LASTNAME  %{REMOTE_USER_LASTNAME}e  env=REMOTE_USER_LASTNAME
-      RequestHeader set X_REMOTE_USER_FULLNAME  %{REMOTE_USER_FULLNAME}e  env=REMOTE_USER_FULLNAME
-      RequestHeader set X_REMOTE_USER_GROUPS    %{REMOTE_USER_GROUPS}e    env=REMOTE_USER_GROUPS
-      RequestHeader set X_REMOTE_USER_DOMAIN    %{REMOTE_USER_DOMAIN}e    env=REMOTE_USER_DOMAIN
-    external-auth-openid-connect-remote-user-conf: |
-      RequestHeader unset X_REMOTE_USER
-
-      RequestHeader set X_REMOTE_USER           %{OIDC_CLAIM_PREFERRED_USERNAME}e env=OIDC_CLAIM_PREFERRED_USERNAME
-      RequestHeader set X_EXTERNAL_AUTH_ERROR   %{EXTERNAL_AUTH_ERROR}e           env=EXTERNAL_AUTH_ERROR
-      RequestHeader set X_REMOTE_USER_EMAIL     %{OIDC_CLAIM_EMAIL}e              env=OIDC_CLAIM_EMAIL
-      RequestHeader set X_REMOTE_USER_FIRSTNAME %{OIDC_CLAIM_GIVEN_NAME}e         env=OIDC_CLAIM_GIVEN_NAME
-      RequestHeader set X_REMOTE_USER_LASTNAME  %{OIDC_CLAIM_FAMILY_NAME}e        env=OIDC_CLAIM_FAMILY_NAME
-      RequestHeader set X_REMOTE_USER_FULLNAME  %{OIDC_CLAIM_NAME}e               env=OIDC_CLAIM_NAME
-      RequestHeader set X_REMOTE_USER_GROUPS    %{OIDC_CLAIM_GROUPS}e             env=OIDC_CLAIM_GROUPS
-      RequestHeader set X_REMOTE_USER_DOMAIN    %{OIDC_CLAIM_DOMAIN}e             env=OIDC_CLAIM_DOMAIN
-- apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    name: httpd-auth-configs
-    labels:
-      app: "${APP_NAME}"
-  data:
-    auth-type: internal
-    auth-kerberos-realms: undefined
-    auth-oidc-provider-metadata-url: undefined
-    auth-oidc-client-id: undefined
-    auth-oidc-client-secret: undefined
-    auth-configuration.conf: |
-      # External Authentication Configuration File
-      #
-      # For details on usage please see https://github.com/ManageIQ/manageiq-pods/blob/master/README.md#configuring-external-authentication
 - apiVersion: v1
   kind: Service
   metadata:
@@ -275,18 +95,6 @@ objects:
       port: 8080
     selector:
       name: httpd
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: httpd-dbus-api
-    labels:
-      app: "${APP_NAME}"
-  spec:
-    ports:
-    - name: http-dbus-api
-      port: 8081
-    selector:
-      name: httpd
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -308,24 +116,12 @@ objects:
         - name: httpd-config
           configMap:
             name: httpd-configs
-        - name: httpd-auth-config
-          configMap:
-            name: httpd-auth-configs
         containers:
         - name: httpd
           image: "${HTTPD_IMAGE_NAME}:${HTTPD_IMAGE_TAG}"
           ports:
           - containerPort: 8080
             protocol: TCP
-          - containerPort: 8081
-            protocol: TCP
-          livenessProbe:
-            exec:
-              command:
-              - pidof
-              - httpd
-            initialDelaySeconds: 15
-            timeoutSeconds: 3
           readinessProbe:
             tcpSocket:
               port: 8080
@@ -334,51 +130,12 @@ objects:
           volumeMounts:
           - name: httpd-config
             mountPath: "/etc/httpd/conf.d"
-          - name: httpd-auth-config
-            mountPath: "/etc/httpd/auth-conf.d"
           resources:
             requests:
               memory: "${HTTPD_MEM_REQ}"
               cpu: "${HTTPD_CPU_REQ}"
             limits:
               memory: "${HTTPD_MEM_LIMIT}"
-          env:
-          - name: APPLICATION_DOMAIN
-            value: "${APPLICATION_DOMAIN}"
-          - name: HTTPD_AUTH_TYPE
-            valueFrom:
-              configMapKeyRef:
-                name: httpd-auth-configs
-                key: auth-type
-          - name: HTTPD_AUTH_KERBEROS_REALMS
-            valueFrom:
-              configMapKeyRef:
-                name: httpd-auth-configs
-                key: auth-kerberos-realms
-          - name: HTTPD_AUTH_OIDC_PROVIDER_METADATA_URL
-            valueFrom:
-              configMapKeyRef:
-                name: httpd-auth-configs
-                key: auth-oidc-provider-metadata-url
-                optional: true
-          - name: HTTPD_AUTH_OIDC_CLIENT_ID
-            valueFrom:
-              configMapKeyRef:
-                name: httpd-auth-configs
-                key: auth-oidc-client-id
-                optional: true
-          - name: HTTPD_AUTH_OIDC_CLIENT_SECRET
-            valueFrom:
-              configMapKeyRef:
-                name: httpd-auth-configs
-                key: auth-oidc-client-secret
-                optional: true
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                - "/usr/bin/save-container-environment"
-        serviceAccountName: "${APP_NAME}-httpd"
 - apiVersion: extensions/v1beta1
   kind: Ingress
   metadata:


### PR DESCRIPTION
We're now using a separate image to implement external auth. In the operator we can switch between these two images based on the parameters provided in the CR, but the templates don't give us that kind of flexibility.

I think it's a better user-experience to be able to deploy the templates out-of-the-box without needing admin privileges rather than having the full suite of external auth available.