### PR TITLE
Allow more flexible external auth configuration

### DIFF
--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -51,6 +51,10 @@ spec:
             databaseVolumeCapacity:
               description: 'Database volume size (default: 15Gi)'
               type: string
+            httpdAuthConfig:
+              description: Secret containing the httpd configuration files Mutually
+                exclusive with the OIDCCliencSecret and OIDCProviderURL if using openid-connect
+              type: string
             httpdAuthenticationType:
               description: 'Type of httpd authentication (default: internal) Options:
                 internal, external, active-directory, saml, openid-connect Note: external,

--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -106,6 +106,14 @@ spec:
             memcachedSlabPageSize:
               description: 'Memcached max item size (default: 1m, min: 1k, max: 1024m)'
               type: string
+            oidcClientSecret:
+              description: Secret name containing the OIDC client id and secret Only
+                used with the openid-connect authentication type
+              type: string
+            oidcProviderURL:
+              description: URL for the OIDC provider Only used with the openid-connect
+                authentication type
+              type: string
             orchestratorCpuRequest:
               description: 'Orchestrator deployment CPU request (default: no request)'
               type: string

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -51,6 +51,10 @@ spec:
             databaseVolumeCapacity:
               description: 'Database volume size (default: 15Gi)'
               type: string
+            httpdAuthConfig:
+              description: Secret containing the httpd configuration files Mutually
+                exclusive with the OIDCCliencSecret and OIDCProviderURL if using openid-connect
+              type: string
             httpdAuthenticationType:
               description: 'Type of httpd authentication (default: internal) Options:
                 internal, external, active-directory, saml, openid-connect Note: external,

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -106,6 +106,14 @@ spec:
             memcachedSlabPageSize:
               description: 'Memcached max item size (default: 1m, min: 1k, max: 1024m)'
               type: string
+            oidcClientSecret:
+              description: Secret name containing the OIDC client id and secret Only
+                used with the openid-connect authentication type
+              type: string
+            oidcProviderURL:
+              description: URL for the OIDC provider Only used with the openid-connect
+                authentication type
+              type: string
             orchestratorCpuRequest:
               description: 'Orchestrator deployment CPU request (default: no request)'
               type: string

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -1,7 +1,10 @@
 package v1alpha1
 
 import (
+	"errors"
+	"fmt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
 )
 
 // ManageIQSpec defines the desired state of ManageIQ
@@ -56,6 +59,10 @@ type ManageIQSpec struct {
 	// Only used with the openid-connect authentication type
 	// +optional
 	OIDCClientSecret string `json:"oidcClientSecret"`
+	// Secret containing the httpd configuration files
+	// Mutually exclusive with the OIDCCliencSecret and OIDCProviderURL if using openid-connect
+	// +optional
+	HttpdAuthConfig string `json:"httpdAuthConfig"`
 
 	// Httpd deployment CPU request (default: no request)
 	// +optional
@@ -274,5 +281,35 @@ func (m *ManageIQ) Initialize() {
 
 	if spec.ZookeeperVolumeCapacity == "" {
 		spec.ZookeeperVolumeCapacity = "1Gi"
+	}
+}
+
+func (m *ManageIQ) Validate() error {
+	spec := m.Spec
+	errs := []string{}
+
+	if spec.HttpdAuthenticationType == "openid-connect" {
+		// Invalid if config and either secret or url is also provided
+		if spec.HttpdAuthConfig != "" && (spec.OIDCProviderURL != "" || spec.OIDCClientSecret != "") {
+			errs = append(errs, "OIDCProviderURL and OIDCClientSecret are invalid when HttpdAuthConfig is specified")
+			// Need to provide either the entire config or a secret and provider url
+		} else if spec.HttpdAuthConfig == "" && (spec.OIDCProviderURL == "" || spec.OIDCClientSecret == "") {
+			errs = append(errs, "HttpdAuthConfig or both OIDCProviderURL and OIDCClientSecret must be provided for openid-connect authentication")
+		}
+	} else {
+		if spec.OIDCProviderURL != "" {
+			errs = append(errs, fmt.Sprintf("OIDCProviderURL is not allowed for authentication type %s", spec.HttpdAuthenticationType))
+		}
+
+		if spec.OIDCClientSecret != "" {
+			errs = append(errs, fmt.Sprintf("OIDCClientSecret is not allowed for authentication type %s", spec.HttpdAuthenticationType))
+		}
+	}
+
+	if len(errs) > 0 {
+		err := fmt.Sprintf("validation failed for ManageIQ object: %s", strings.Join(errs, ", "))
+		return errors.New(err)
+	} else {
+		return nil
 	}
 }

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -48,6 +48,14 @@ type ManageIQSpec struct {
 	// Note: external, active-directory, and saml require an httpd container with elevated privileges
 	// +optional
 	HttpdAuthenticationType string `json:"httpdAuthenticationType"`
+	// URL for the OIDC provider
+	// Only used with the openid-connect authentication type
+	// +optional
+	OIDCProviderURL string `json:"oidcProviderURL"`
+	// Secret name containing the OIDC client id and secret
+	// Only used with the openid-connect authentication type
+	// +optional
+	OIDCClientSecret string `json:"oidcClientSecret"`
 
 	// Httpd deployment CPU request (default: no request)
 	// +optional

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -104,11 +104,16 @@ func (r *ReconcileManageIQ) Reconcile(request reconcile.Request) (reconcile.Resu
 
 	// Fetch the ManageIQ instance
 	miqInstance := &miqv1alpha1.ManageIQ{}
-	err := r.client.Get(context.TODO(), request.NamespacedName, miqInstance)
-	miqInstance.Initialize()
 
+	err := r.client.Get(context.TODO(), request.NamespacedName, miqInstance)
 	if errors.IsNotFound(err) {
 		return reconcile.Result{}, nil
+	}
+
+	miqInstance.Initialize()
+
+	if e := miqInstance.Validate(); e != nil {
+		return reconcile.Result{}, e
 	}
 
 	if e := r.generateSecrets(miqInstance); e != nil {

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -156,9 +156,11 @@ func (r *ReconcileManageIQ) generateHttpdResources(cr *miqv1alpha1.ManageIQ) err
 		return err
 	}
 
-	httpdAuthConfigMap := miqtool.NewHttpdAuthConfigMap(cr)
-	if err := r.createk8sResIfNotExist(cr, httpdAuthConfigMap, &corev1.ConfigMap{}); err != nil {
-		return err
+	if cr.Spec.HttpdAuthenticationType != "internal" && cr.Spec.HttpdAuthenticationType != "openid-connect" {
+		httpdAuthConfigMap := miqtool.NewHttpdAuthConfigMap(cr)
+		if err := r.createk8sResIfNotExist(cr, httpdAuthConfigMap, &corev1.ConfigMap{}); err != nil {
+			return err
+		}
 	}
 
 	uiService := miqtool.NewUIService(cr)

--- a/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
@@ -163,6 +163,12 @@ LoadModule auth_mellon_module modules/mod_auth_mellon.so
 }
 
 func httpdOIDCAuthConf(providerURL, applicationDomain string) string {
+	// If these are not provided, we should assume that the user provided a full config
+	// in a secret, so include the directory for that secret here
+	if providerURL == "" || applicationDomain == "" {
+		return "Include user-conf.d/*.conf"
+	}
+
 	s := `
 LoadModule auth_openidc_module modules/mod_auth_openidc.so
 

--- a/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
@@ -1,5 +1,10 @@
 package miqtools
 
+import (
+	"fmt"
+	miqv1alpha1 "github.com/ManageIQ/manageiq-pods/manageiq-operator/pkg/apis/manageiq/v1alpha1"
+)
+
 // auth-configuration.conf
 func httpdAuthConfigurationConf() string {
 	return `
@@ -55,26 +60,24 @@ Options SymLinksIfOwnerMatch
 }
 
 // authentication.conf
-func httpdAuthenticationConf() string {
-	return `
-# Load appropriate authentication configuration files
-#
-Include "conf.d/configuration-${HTTPD_AUTH_TYPE}-auth"
-`
+func httpdAuthenticationConf(spec *miqv1alpha1.ManageIQSpec) string {
+	switch spec.HttpdAuthenticationType {
+	case "openid-connect":
+		return httpdOIDCAuthConf(spec.OIDCProviderURL, spec.ApplicationDomain)
+	case "external":
+		return httpdExternalAuthConf()
+	case "active-directory":
+		return httpdADAuthConf()
+	case "saml":
+		return httpdSAMLAuthConf()
+	default:
+		return ""
+	}
 }
 
-// configuration-internal-auth
-func httpdInternalAuthConf() string {
-	return `
-# Internal authentication
-#
-`
-}
-
-// configuration-external-auth
 func httpdExternalAuthConf() string {
-	return `
-Include "conf.d/external-auth-load-modules-conf"
+	s := `
+%s
 
 <Location /dashboard/kerberos_authenticate>
   AuthType           GSSAPI
@@ -86,17 +89,17 @@ Include "conf.d/external-auth-load-modules-conf"
   ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js
 </Location>
 
-Include "conf.d/external-auth-login-form-conf"
-Include "conf.d/external-auth-application-api-conf"
-Include "conf.d/external-auth-lookup-user-details-conf"
-Include "conf.d/external-auth-remote-user-conf"
+%s
+%s
+%s
+%s
 `
+	return fmt.Sprintf(s, httpdAuthLoadModulesConf(), httpdAuthLoginFormConf(), httpdAuthApplicationAPIConf(), httpdAuthLookupUserDetailsConf(), httpdAuthRemoteUserConf())
 }
 
-// configuration-active-directory-auth
 func httpdADAuthConf() string {
-	return `
-Include "conf.d/external-auth-load-modules-conf"
+	s := `
+%s
 
 <Location /dashboard/kerberos_authenticate>
   AuthType           GSSAPI
@@ -108,16 +111,16 @@ Include "conf.d/external-auth-load-modules-conf"
   ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js
 </Location>
 
-Include "conf.d/external-auth-login-form-conf"
-Include "conf.d/external-auth-application-api-conf"
-Include "conf.d/external-auth-lookup-user-details-conf"
-Include "conf.d/external-auth-remote-user-conf"
+%s
+%s
+%s
+%s
 `
+	return fmt.Sprintf(s, httpdAuthLoadModulesConf(), httpdAuthLoginFormConf(), httpdAuthApplicationAPIConf(), httpdAuthLookupUserDetailsConf(), httpdAuthRemoteUserConf())
 }
 
-// configuration-saml-auth
 func httpdSAMLAuthConf() string {
-	return `
+	s := `
 LoadModule auth_mellon_module modules/mod_auth_mellon.so
 
 <Location />
@@ -154,20 +157,20 @@ LoadModule auth_mellon_module modules/mod_auth_mellon.so
   Require                    valid-user
 </Location>
 
-Include "conf.d/external-auth-remote-user-conf"
+%s
 `
+	return fmt.Sprintf(s, httpdAuthRemoteUserConf())
 }
 
-// configuration-openid-connect-auth
-func httpdOIDCAuthConf() string {
-	return `
+func httpdOIDCAuthConf(providerURL, applicationDomain string) string {
+	s := `
 LoadModule auth_openidc_module modules/mod_auth_openidc.so
 
-OIDCProviderMetadataURL      ${HTTPD_AUTH_OIDC_PROVIDER_METADATA_URL}
+OIDCProviderMetadataURL      %s
 OIDCClientID                 ${HTTPD_AUTH_OIDC_CLIENT_ID}
 OIDCClientSecret             ${HTTPD_AUTH_OIDC_CLIENT_SECRET}
 
-OIDCRedirectURI              "https://${APPLICATION_DOMAIN}/oidc_login/redirect_uri"
+OIDCRedirectURI              "https://%s/oidc_login/redirect_uri"
 OIDCOAuthRemoteUserClaim     username
 
 OIDCCryptoPassphrase         sp-secret
@@ -177,11 +180,20 @@ OIDCCryptoPassphrase         sp-secret
   Require                    valid-user
 </Location>
 
-Include "conf.d/external-auth-openid-connect-remote-user-conf"
+RequestHeader unset X_REMOTE_USER
+
+RequestHeader set X_REMOTE_USER           %%{OIDC_CLAIM_PREFERRED_USERNAME}e env=OIDC_CLAIM_PREFERRED_USERNAME
+RequestHeader set X_EXTERNAL_AUTH_ERROR   %%{EXTERNAL_AUTH_ERROR}e           env=EXTERNAL_AUTH_ERROR
+RequestHeader set X_REMOTE_USER_EMAIL     %%{OIDC_CLAIM_EMAIL}e              env=OIDC_CLAIM_EMAIL
+RequestHeader set X_REMOTE_USER_FIRSTNAME %%{OIDC_CLAIM_GIVEN_NAME}e         env=OIDC_CLAIM_GIVEN_NAME
+RequestHeader set X_REMOTE_USER_LASTNAME  %%{OIDC_CLAIM_FAMILY_NAME}e        env=OIDC_CLAIM_FAMILY_NAME
+RequestHeader set X_REMOTE_USER_FULLNAME  %%{OIDC_CLAIM_NAME}e               env=OIDC_CLAIM_NAME
+RequestHeader set X_REMOTE_USER_GROUPS    %%{OIDC_CLAIM_GROUPS}e             env=OIDC_CLAIM_GROUPS
+RequestHeader set X_REMOTE_USER_DOMAIN    %%{OIDC_CLAIM_DOMAIN}e             env=OIDC_CLAIM_DOMAIN
 `
+	return fmt.Sprintf(s, providerURL, applicationDomain)
 }
 
-// external-auth-load-modules-conf
 func httpdAuthLoadModulesConf() string {
 	return `
 LoadModule authnz_pam_module            modules/mod_authnz_pam.so
@@ -191,7 +203,6 @@ LoadModule auth_kerb_module             modules/mod_auth_kerb.so
 `
 }
 
-// external-auth-login-form-conf
 func httpdAuthLoginFormConf() string {
 	return `
 <Location /dashboard/external_authenticate>
@@ -204,7 +215,6 @@ func httpdAuthLoginFormConf() string {
 `
 }
 
-// external-auth-application-api-conf
 func httpdAuthApplicationAPIConf() string {
 	return `
 <LocationMatch ^/api>
@@ -227,7 +237,6 @@ func httpdAuthApplicationAPIConf() string {
 `
 }
 
-// external-auth-lookup-user-details-conf
 func httpdAuthLookupUserDetailsConf() string {
 	return `
 <LocationMatch ^/dashboard/external_authenticate$|^/dashboard/kerberos_authenticate$|^/api>
@@ -243,7 +252,6 @@ func httpdAuthLookupUserDetailsConf() string {
 `
 }
 
-// external-auth-remote-user-conf
 func httpdAuthRemoteUserConf() string {
 	return `
 RequestHeader unset X_REMOTE_USER
@@ -256,21 +264,5 @@ RequestHeader set X_REMOTE_USER_LASTNAME  %{REMOTE_USER_LASTNAME}e  env=REMOTE_U
 RequestHeader set X_REMOTE_USER_FULLNAME  %{REMOTE_USER_FULLNAME}e  env=REMOTE_USER_FULLNAME
 RequestHeader set X_REMOTE_USER_GROUPS    %{REMOTE_USER_GROUPS}e    env=REMOTE_USER_GROUPS
 RequestHeader set X_REMOTE_USER_DOMAIN    %{REMOTE_USER_DOMAIN}e    env=REMOTE_USER_DOMAIN
-`
-}
-
-// external-auth-openid-connect-remote-user-conf
-func httpdAuthOIDCRemoteUserConf() string {
-	return `
-RequestHeader unset X_REMOTE_USER
-
-RequestHeader set X_REMOTE_USER           %{OIDC_CLAIM_PREFERRED_USERNAME}e env=OIDC_CLAIM_PREFERRED_USERNAME
-RequestHeader set X_EXTERNAL_AUTH_ERROR   %{EXTERNAL_AUTH_ERROR}e           env=EXTERNAL_AUTH_ERROR
-RequestHeader set X_REMOTE_USER_EMAIL     %{OIDC_CLAIM_EMAIL}e              env=OIDC_CLAIM_EMAIL
-RequestHeader set X_REMOTE_USER_FIRSTNAME %{OIDC_CLAIM_GIVEN_NAME}e         env=OIDC_CLAIM_GIVEN_NAME
-RequestHeader set X_REMOTE_USER_LASTNAME  %{OIDC_CLAIM_FAMILY_NAME}e        env=OIDC_CLAIM_FAMILY_NAME
-RequestHeader set X_REMOTE_USER_FULLNAME  %{OIDC_CLAIM_NAME}e               env=OIDC_CLAIM_NAME
-RequestHeader set X_REMOTE_USER_GROUPS    %{OIDC_CLAIM_GROUPS}e             env=OIDC_CLAIM_GROUPS
-RequestHeader set X_REMOTE_USER_DOMAIN    %{OIDC_CLAIM_DOMAIN}e             env=OIDC_CLAIM_DOMAIN
 `
 }


### PR DESCRIPTION
This PR changes the way the operator deploys the external auth configuration for the httpd pod.
Now, we only deploy exactly what is required for the authentication type specified in the CR.
Additionally there are now two options for deploying OIDC authentication.

1. What we had before minus the [httpd_configmap_generator](https://github.com/ManageIQ/httpd_configmap_generator)
    - Previously a user would have to utilize the config map generator to translate their oidc url, client secret, and client id into a config map then overwrite the existing auth-configs created by the operator after the deployment finishes
    - Now the url can be supplied as `oidcProviderURL` in the CR and a secret should be created with the keys `CLIENT_ID` and `CLIENT_SECRET` and the name supplied as `oidcClientSecret` in the CR
2. Provide all the config files in a secret directly
    - In this case the operator takes the secret name from `httpdAuthConfig` and mounts all the files in that secret into `/etc/httpd/user-conf.d`
    - Any file named `*.conf` in that directory is included into the httpd config

Fixes #467 

cc @gyliu513 @jvlcek @abellotti 

This PR was mostly focused on OIDC, but in the future we should allow the other types to utilize the `httpdAuthConfig` parameter to provide the config files from the config map generator rather than creating a stub config map that then needs to be overwritten.

Longer term we could enhance the config map generator to actually create the configmaps in the cluster and have the operator run it as a job.

Another idea I had, but didn't pursue very far was that we could probably create a separate controller an CR just for auth, I'm not sure this would be worth the effort, but it feels like we'll end up with quite a lot of auth-related parameters in the manageiq CR if we try to move all the inputs to the generator into this CR. 