### PR TITLE
Support for local RPMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ build.log
 manageiq-operator/build/_output/*
 parameters
 manageiq-operator/vendor/*
+images/manageiq-base/rpms
 
 *.swp

--- a/bin/build
+++ b/bin/build
@@ -15,14 +15,19 @@ HOOKS_SCRIPT_URL=${HOOKS_SCRIPT_URL:-""}
 
 OPERATOR_DIR=${OPERATOR_DIR:-manageiq-operator}
 
-while getopts "t:d:r:nhp" opt; do
+RPM_BUILD_OPTIONS=${RPM_BUILD_OPTIONS:-""}
+RPM_BUILD_IMAGE=${RPM_BUILD_IMAGE:-"manageiq/rpm_build"}
+
+while getopts "t:d:r:bnhlp" opt; do
   case $opt in
+    b) REBUILD_RPM="true" ;;
     d) IMAGE_DIR=$OPTARG ;;
+    l) LOCAL_RPM="true" ;;
     n) NO_CACHE="true" ;;
     p) PUSH="true" ;;
     r) REPO=$OPTARG ;;
     t) TAG=$OPTARG ;;
-    h) echo "Usage: $0 -d IMAGE_DIR -r IMAGE_REPOSITORY [-hnp] [ -t IMAGE_TAG ]"; exit 1
+    h) echo "Usage: $0 -d IMAGE_DIR -r IMAGE_REPOSITORY [-hblnp] [ -t IMAGE_TAG ]"; exit 1
   esac
 done
 
@@ -36,7 +41,25 @@ if [ -z "$REPO" ]; then
   exit 1
 fi
 
+if [ -n "$LOCAL_RPM" ] && [ -n "$REBUILD_RPM" ]; then
+  echo "Local rpm (-l) and rebuild rpm (-b) options can't be used together"
+  exit 1
+fi
+
 set -e
+
+if [ -n "$REBUILD_RPM" ]; then
+  rpm_dir=$IMAGE_DIR/manageiq-base/rpms
+  rm -rf $rpm_dir/*
+  options="-v $PWD/$rpm_dir:/root/BUILD/rpms"
+  if [ -n "$RPM_BUILD_OPTIONS" ]; then
+    options+=" -v $PWD/$RPM_BUILD_OPTIONS:/root/OPTIONS"
+  fi
+  docker pull $RPM_BUILD_IMAGE
+  cmd="docker run -it --rm $options $RPM_BUILD_IMAGE build"
+  echo "Building RPMs locally: $cmd"
+  $cmd
+fi
 
 pushd $IMAGE_DIR
   cmd="docker build --tag $REPO/manageiq-base:$TAG \
@@ -51,6 +74,10 @@ pushd $IMAGE_DIR
 
   if [ -n "$NO_CACHE" ]; then
     cmd+=" --no-cache"
+  fi
+
+  if [ -n "$LOCAL_RPM" ] || [ -n "$REBUILD_RPM" ]; then
+    cmd+=" --build-arg LOCAL_RPM=true"
   fi
 
   echo "Building manageiq-base: $cmd"

--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -22,6 +22,7 @@ FROM registry.access.redhat.com/ubi8/ubi:8.1
 MAINTAINER ManageIQ https://manageiq.org
 
 ARG ARCH=x86_64
+ARG LOCAL_RPM
 
 ENV TERM=xterm \
     CONTAINER=true \
@@ -36,6 +37,9 @@ LABEL name="manageiq-base" \
       io.k8s.description="ManageIQ is a management and automation platform for virtual, private, and hybrid cloud infrastructures." \
       io.openshift.tags="ManageIQ,miq,manageiq"
 
+COPY rpms/* /tmp/rpms/
+COPY container-assets/create_local_yum_repo.sh /
+
 RUN curl -L https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo > /etc/yum.repos.d/ansible-runner.repo
 
 RUN dnf -y --disableplugin=subscription-manager install \
@@ -48,6 +52,7 @@ RUN dnf -y --disableplugin=subscription-manager install \
     dnf -y --disableplugin=subscription-manager module enable ruby:2.6 && \
     dnf config-manager --enable manageiq-11-kasparov-nightly && \
     dnf config-manager --setopt=ubi-8-appstream.exclude=*net-snmp* --setopt=ubi-8-baseos.exclude=*net-snmp* --setopt=ubi-8-codeready-builder.exclude=*net-snmp* --save && \
+    if [[ "$LOCAL_RPM" = "true" ]]; then /create_local_yum_repo.sh; fi && \
     dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
       manageiq-pods               \
       python3-devel               \

--- a/images/manageiq-base/container-assets/create_local_yum_repo.sh
+++ b/images/manageiq-base/container-assets/create_local_yum_repo.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+yum -y install createrepo_c
+createrepo /tmp/rpms
+yum -y remove createrepo_c
+
+cat > /etc/yum.repos.d/local_rpm.repo << EOF
+[local-rpm]
+baseurl=file:///tmp/rpms/$basearch
+name=Local yum repo
+enabled=1
+gpgcheck=0
+EOF
+
+dnf config-manager --setopt=copr:copr.fedorainfracloud.org:simaishi:test.exclude=manageiq-* --save

--- a/images/manageiq-base/container-assets/create_local_yum_repo.sh
+++ b/images/manageiq-base/container-assets/create_local_yum_repo.sh
@@ -12,4 +12,4 @@ enabled=1
 gpgcheck=0
 EOF
 
-dnf config-manager --setopt=copr:copr.fedorainfracloud.org:simaishi:test.exclude=manageiq-* --save
+dnf config-manager --setopt=manageiq-11-kasparov*.exclude=manageiq-* --save

--- a/images/manageiq-ui-worker/Dockerfile
+++ b/images/manageiq-ui-worker/Dockerfile
@@ -18,3 +18,5 @@ RUN chgrp root /var/run/httpd && chmod g+rwx /var/run/httpd && \
 RUN sed -i '/^Listen 80/d' /etc/httpd/conf/httpd.conf
 
 COPY container-assets/manageiq-http.conf /etc/httpd/conf.d
+
+RUN rm -rf /tmp/rpms /create_local_yum_repo.sh /etc/yum.repos.d/local_rpm.repo


### PR DESCRIPTION
Built on top of #485.

Adding 2 options to bin/build:
- `-b` builds RPMs from scratch
- `-l` uses RPMs that exist locally (the expected directory structure is what `-b` produces: manageiq-base/rpms/\<arch\>/*rpm

Also, 2 env can be set for rpm build:
- `RPM_BUILD_OPTIONS` overrides [default rpm build options](https://github.com/ManageIQ/manageiq-rpm_build/blob/master/config/options.yml) (repo, branches, etc.) - this is the path to the directory where override options.yml is.
- `RPM_BUILD_IMAGE` sets rpm build container image name (default: manageiq/rpm_build)

Notes:
- Running with `-b` will remove previously built RPMs.
- Considering this is a "developer" mode, I skipped cleanup (removing RPMs) in manageiq-base and only added cleanup to manageiq-ui-worker, to avoid having duplicate code in manageiq-ui-worker build. If that's a problem, I will change.

Tested with https://github.com/ManageIQ/manageiq-rpm_build/pull/40

~~TODO: replace my copr yum repo with manageiq.~~.