### PR TITLE
Remove extra sha256 sum when generating the encryption key

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/generators.go
+++ b/manageiq-operator/pkg/helpers/miq-components/generators.go
@@ -2,7 +2,6 @@ package miqtools
 
 import (
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 )
@@ -17,8 +16,7 @@ func randomBytes(n int) []byte {
 }
 
 func generateEncryptionKey() string {
-	sum := sha256.Sum256(randomBytes(32))
-	return base64.StdEncoding.EncodeToString(sum[:])
+	return base64.StdEncoding.EncodeToString(randomBytes(32))
 }
 
 func generatePassword() string {


### PR DESCRIPTION
This was present in the [original implementation]
(https://github.com/ManageIQ/manageiq-password/blob/f85e888fe60433390d0a1d5145889edc67437fdf/lib/manageiq/password.rb#L210-L213)
but was only needed because that code allowed for user-provided
passwords to be used as the encryption key. In our implementation
we are only using random bytes as the input so an extra sha sum
doesn't do anything to improve security.

Additionally this was triggering an issue in some static security
analysis tools.