### PR TITLE
Make the admin password required in the CR

### DIFF
--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -35,7 +35,7 @@ spec:
               description: 'Application name used for deployed objects (default: manageiq)'
               type: string
             applicationAdminPassword:
-              description: 'Initial password for "admin" user (default: smartvm)'
+              description: Initial password for "admin" user
               type: string
             applicationDomain:
               description: Domain name for the external route. Used for external authentication
@@ -184,6 +184,7 @@ spec:
               description: 'Zookeeper volume size (default: 1Gi)'
               type: string
           required:
+          - applicationAdminPassword
           - applicationDomain
           type: object
         status:

--- a/manageiq-operator/deploy/crds/manageiq.org_v1alpha1_manageiq_cr.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_v1alpha1_manageiq_cr.yaml
@@ -3,4 +3,5 @@ kind: ManageIQ
 metadata:
   name: miq
 spec:
+  applicationAdminPassword: smartvm
   applicationDomain: miqproject.apps-crc.testing

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -35,7 +35,7 @@ spec:
               description: 'Application name used for deployed objects (default: manageiq)'
               type: string
             applicationAdminPassword:
-              description: 'Initial password for "admin" user (default: smartvm)'
+              description: Initial password for "admin" user
               type: string
             applicationDomain:
               description: Domain name for the external route. Used for external authentication
@@ -184,6 +184,7 @@ spec:
               description: 'Zookeeper volume size (default: 1Gi)'
               type: string
           required:
+          - applicationAdminPassword
           - applicationDomain
           type: object
         status:

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -15,8 +15,7 @@ type ManageIQSpec struct {
 	// +optional
 	AppName string `json:"appName"`
 
-	// Initial password for "admin" user (default: smartvm)
-	// +optional
+	// Initial password for "admin" user
 	ApplicationAdminPassword string `json:"applicationAdminPassword"`
 
 	// Domain name for the external route. Used for external authentication configuration
@@ -207,10 +206,6 @@ func (m *ManageIQ) Initialize() {
 
 	if spec.AppName == "" {
 		spec.AppName = "manageiq"
-	}
-
-	if spec.ApplicationAdminPassword == "" {
-		spec.ApplicationAdminPassword = "smartvm"
 	}
 
 	if spec.DatabaseRegion == "" {


### PR DESCRIPTION
This makes the user choose a better password than "smartvm"
without generating one that will be difficult to communicate back
to the user