### PR TITLE
Remove ability to set the admin user password

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Examine output and point your web browser to the reported URL/HOST.
 
 ### Logging In
 
-Per the ManageIQ project [basic configuration](http://manageiq.org/docs/get-started/basic-configuration) documentation, you can now login to the MIQ web interface using the default username (`admin`) and either the default password (`smartvm`) of the password configured using the `APPLICATION_ADMIN_PASSWORD` parameter.
+Per the ManageIQ project [basic configuration](http://manageiq.org/docs/get-started/basic-configuration) documentation, you can now login to the MIQ web interface using the default username and password (`admin`/`smartvm`).
 
 ## Backup and restore of the MIQ database
 

--- a/images/manageiq-orchestrator/container-assets/entrypoint
+++ b/images/manageiq-orchestrator/container-assets/entrypoint
@@ -67,9 +67,6 @@ case $? in
       set -e
       REGION=${DATABASE_REGION} bin/rake db:migrate
       REGION=${DATABASE_REGION} bin/rails runner "MiqDatabase.seed; MiqRegion.seed"
-
-      echo "== Setting admin password =="
-      bin/rails runner "EvmDatabase.seed_primordial; user = User.lookup_by_userid('admin').update_attributes!(:password => ENV['APPLICATION_ADMIN_PASSWORD'])"
     popd
   ;;
   4) # new_replica

--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -34,9 +34,6 @@ spec:
             appName:
               description: 'Application name used for deployed objects (default: manageiq)'
               type: string
-            applicationAdminPassword:
-              description: Initial password for "admin" user
-              type: string
             applicationDomain:
               description: Domain name for the external route. Used for external authentication
                 configuration
@@ -188,7 +185,6 @@ spec:
               description: 'Zookeeper volume size (default: 1Gi)'
               type: string
           required:
-          - applicationAdminPassword
           - applicationDomain
           type: object
         status:

--- a/manageiq-operator/deploy/crds/manageiq.org_v1alpha1_manageiq_cr.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_v1alpha1_manageiq_cr.yaml
@@ -3,5 +3,4 @@ kind: ManageIQ
 metadata:
   name: miq
 spec:
-  applicationAdminPassword: smartvm
   applicationDomain: miqproject.apps-crc.testing

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq-operator.v0.0.1.clusterserviceversion.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq-operator.v0.0.1.clusterserviceversion.yaml
@@ -11,7 +11,6 @@ metadata:
             "name": "miq"
           },
           "spec": {
-            "applicationAdminPassword": "smartvm",
             "applicationDomain": "miqproject.apps-crc.testing"
           }
         }

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -34,9 +34,6 @@ spec:
             appName:
               description: 'Application name used for deployed objects (default: manageiq)'
               type: string
-            applicationAdminPassword:
-              description: Initial password for "admin" user
-              type: string
             applicationDomain:
               description: Domain name for the external route. Used for external authentication
                 configuration
@@ -188,7 +185,6 @@ spec:
               description: 'Zookeeper volume size (default: 1Gi)'
               type: string
           required:
-          - applicationAdminPassword
           - applicationDomain
           type: object
         status:

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -15,9 +15,6 @@ type ManageIQSpec struct {
 	// +optional
 	AppName string `json:"appName"`
 
-	// Initial password for "admin" user
-	ApplicationAdminPassword string `json:"applicationAdminPassword"`
-
 	// Domain name for the external route. Used for external authentication configuration
 	ApplicationDomain string `json:"applicationDomain"`
 

--- a/manageiq-operator/pkg/helpers/miq-components/app-secret.go
+++ b/manageiq-operator/pkg/helpers/miq-components/app-secret.go
@@ -12,7 +12,6 @@ func AppSecret(cr *miqv1alpha1.ManageIQ) *corev1.Secret {
 		"app": cr.Spec.AppName,
 	}
 	secret := map[string]string{
-		"admin-password": cr.Spec.ApplicationAdminPassword,
 		"encryption-key": generateEncryptionKey(),
 	}
 	return &corev1.Secret{

--- a/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
@@ -38,15 +38,6 @@ func NewOrchestratorDeployment(cr *miqv1alpha1.ManageIQ) (*appsv1.Deployment, er
 				Value: cr.Spec.AppName,
 			},
 			corev1.EnvVar{
-				Name: "APPLICATION_ADMIN_PASSWORD",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: "app-secrets"},
-						Key:                  "admin-password",
-					},
-				},
-			},
-			corev1.EnvVar{
 				Name:  "AUTH_TYPE",
 				Value: cr.Spec.HttpdAuthenticationType,
 			},

--- a/parameters
+++ b/parameters
@@ -1,9 +1,6 @@
 # Application name used for deployed objects
 APP_NAME=manageiq
 
-# admin user initial password
-APPLICATION_ADMIN_PASSWORD=smartvm
-
 # Domain name for the external route
 # Used for external authentication configuration
 APPLICATION_DOMAIN=

--- a/templates/app/app-secrets.yaml
+++ b/templates/app/app-secrets.yaml
@@ -10,13 +10,10 @@ objects:
     labels:
       app: "${APP_NAME}"
   stringData:
-    admin-password: "${APPLICATION_ADMIN_PASSWORD}"
     encryption-key: "${ENCRYPTION_KEY}"
 parameters:
 - name: APP_NAME
   value: manageiq
-- name: APPLICATION_ADMIN_PASSWORD
-  value: smartvm
 - name: ENCRYPTION_KEY
   from: "[a-zA-Z0-9]{43}"
   generate: expression

--- a/templates/app/orchestrator.yaml
+++ b/templates/app/orchestrator.yaml
@@ -37,11 +37,6 @@ objects:
             value: 'true'
           - name: APP_NAME
             value: "${APP_NAME}"
-          - name: APPLICATION_ADMIN_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: admin-password
           - name: GUID
             value: "${GUID}"
           - name: DATABASE_REGION


### PR DESCRIPTION
The application has logic to configure the initial user and
also allows for changing that user's password. The ability to set
the password from multiple places is error-prone and confusing

Fixes #499
