### PR TITLE
Add missing resource requests and limits

### DIFF
--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -65,6 +65,9 @@ spec:
                 active-directory, and saml require an httpd container with elevated
                 privileges'
               type: string
+            httpdCpuLimit:
+              description: 'Httpd deployment CPU limit (default: no limit)'
+              type: string
             httpdCpuRequest:
               description: 'Httpd deployment CPU request (default: no request)'
               type: string
@@ -105,6 +108,9 @@ spec:
             kafkaVolumeCapacity:
               description: 'Kafka volume size (default: 1Gi)'
               type: string
+            memcachedCpuLimit:
+              description: 'Memcached deployment CPU limit (default: no limit)'
+              type: string
             memcachedCpuRequest:
               description: 'Memcached deployment CPU request (default: no request)'
               type: string
@@ -142,6 +148,9 @@ spec:
               description: URL for the OIDC provider Only used with the openid-connect
                 authentication type
               type: string
+            orchestratorCpuLimit:
+              description: 'Orchestrator deployment CPU limit (default: no limit)'
+              type: string
             orchestratorCpuRequest:
               description: 'Orchestrator deployment CPU request (default: no request)'
               type: string
@@ -166,6 +175,9 @@ spec:
               type: string
             orchestratorMemoryRequest:
               description: 'Orchestrator deployment memory request (default: no limit)'
+              type: string
+            postgresqlCpuLimit:
+              description: 'PostgreSQL deployment CPU limit (default: no limit)'
               type: string
             postgresqlCpuRequest:
               description: 'PostgreSQL deployment CPU request (default: no request)'

--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -86,6 +86,18 @@ spec:
               description: Secret containing the image registry authentication information
                 needed for the manageiq images
               type: string
+            kafkaCpuRequest:
+              description: 'Kafka deployment CPU request (default: no request)'
+              type: string
+            kafkaCpulimit:
+              description: 'Kafka deployment CPU limit (default: no limit)'
+              type: string
+            kafkaMemoryLimit:
+              description: 'Kafka deployment memory limit (default: no limit)'
+              type: string
+            kafkaMemoryRequest:
+              description: 'Kafka deployment memory request (default: no limit)'
+              type: string
             kafkaSecret:
               description: 'Secret containing the kafka access information, content
                 generated if not provided (default: kafka-secrets)'
@@ -180,6 +192,18 @@ spec:
             tlsSecret:
               description: 'Secret containing the tls cert and key for the ingress,
                 content generated if not provided (default: tls-secret)'
+              type: string
+            zookeeperCpuRequest:
+              description: 'Zookeeper deployment CPU request (default: no request)'
+              type: string
+            zookeeperCpulimit:
+              description: 'Zookeeper deployment CPU limit (default: no limit)'
+              type: string
+            zookeeperMemoryLimit:
+              description: 'Zookeeper deployment memory limit (default: no limit)'
+              type: string
+            zookeeperMemoryRequest:
+              description: 'Zookeeper deployment memory request (default: no limit)'
               type: string
             zookeeperVolumeCapacity:
               description: 'Zookeeper volume size (default: 1Gi)'

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -65,6 +65,9 @@ spec:
                 active-directory, and saml require an httpd container with elevated
                 privileges'
               type: string
+            httpdCpuLimit:
+              description: 'Httpd deployment CPU limit (default: no limit)'
+              type: string
             httpdCpuRequest:
               description: 'Httpd deployment CPU request (default: no request)'
               type: string
@@ -105,6 +108,9 @@ spec:
             kafkaVolumeCapacity:
               description: 'Kafka volume size (default: 1Gi)'
               type: string
+            memcachedCpuLimit:
+              description: 'Memcached deployment CPU limit (default: no limit)'
+              type: string
             memcachedCpuRequest:
               description: 'Memcached deployment CPU request (default: no request)'
               type: string
@@ -142,6 +148,9 @@ spec:
               description: URL for the OIDC provider Only used with the openid-connect
                 authentication type
               type: string
+            orchestratorCpuLimit:
+              description: 'Orchestrator deployment CPU limit (default: no limit)'
+              type: string
             orchestratorCpuRequest:
               description: 'Orchestrator deployment CPU request (default: no request)'
               type: string
@@ -166,6 +175,9 @@ spec:
               type: string
             orchestratorMemoryRequest:
               description: 'Orchestrator deployment memory request (default: no limit)'
+              type: string
+            postgresqlCpuLimit:
+              description: 'PostgreSQL deployment CPU limit (default: no limit)'
               type: string
             postgresqlCpuRequest:
               description: 'PostgreSQL deployment CPU request (default: no request)'

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -86,6 +86,18 @@ spec:
               description: Secret containing the image registry authentication information
                 needed for the manageiq images
               type: string
+            kafkaCpuRequest:
+              description: 'Kafka deployment CPU request (default: no request)'
+              type: string
+            kafkaCpulimit:
+              description: 'Kafka deployment CPU limit (default: no limit)'
+              type: string
+            kafkaMemoryLimit:
+              description: 'Kafka deployment memory limit (default: no limit)'
+              type: string
+            kafkaMemoryRequest:
+              description: 'Kafka deployment memory request (default: no limit)'
+              type: string
             kafkaSecret:
               description: 'Secret containing the kafka access information, content
                 generated if not provided (default: kafka-secrets)'
@@ -180,6 +192,18 @@ spec:
             tlsSecret:
               description: 'Secret containing the tls cert and key for the ingress,
                 content generated if not provided (default: tls-secret)'
+              type: string
+            zookeeperCpuRequest:
+              description: 'Zookeeper deployment CPU request (default: no request)'
+              type: string
+            zookeeperCpulimit:
+              description: 'Zookeeper deployment CPU limit (default: no limit)'
+              type: string
+            zookeeperMemoryLimit:
+              description: 'Zookeeper deployment memory limit (default: no limit)'
+              type: string
+            zookeeperMemoryRequest:
+              description: 'Zookeeper deployment memory request (default: no limit)'
               type: string
             zookeeperVolumeCapacity:
               description: 'Zookeeper volume size (default: 1Gi)'

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -161,9 +161,35 @@ type ManageIQSpec struct {
 	// Kafka volume size (default: 1Gi)
 	// +optional
 	KafkaVolumeCapacity string `json:"kafkaVolumeCapacity"`
+	// Kafka deployment CPU limit (default: no limit)
+	// +optional
+	KafkaCpuLimit string `json:"kafkaCpulimit"`
+	// Kafka deployment CPU request (default: no request)
+	// +optional
+	KafkaCpuRequest string `json:"kafkaCpuRequest"`
+	// Kafka deployment memory limit (default: no limit)
+	// +optional
+	KafkaMemoryLimit string `json:"kafkaMemoryLimit"`
+	// Kafka deployment memory request (default: no limit)
+	// +optional
+	KafkaMemoryRequest string `json:"kafkaMemoryRequest"`
+
 	// Zookeeper volume size (default: 1Gi)
 	// +optional
 	ZookeeperVolumeCapacity string `json:"zookeeperVolumeCapacity"`
+	// Zookeeper deployment CPU limit (default: no limit)
+	// +optional
+	ZookeeperCpuLimit string `json:"zookeeperCpulimit"`
+	// Zookeeper deployment CPU request (default: no request)
+	// +optional
+	ZookeeperCpuRequest string `json:"zookeeperCpuRequest"`
+	// Zookeeper deployment memory limit (default: no limit)
+	// +optional
+	ZookeeperMemoryLimit string `json:"zookeeperMemoryLimit"`
+	// Zookeeper deployment memory request (default: no limit)
+	// +optional
+	ZookeeperMemoryRequest string `json:"zookeeperMemoryRequest"`
+
 	// Secret containing the kafka access information, content generated if not provided (default: kafka-secrets)
 	// +optional
 	KafkaSecret string `json:"kafkaSecret"`

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -74,6 +74,9 @@ type ManageIQSpec struct {
 	// +optional
 	EnableApplicationLocalLogin *bool `json:"enableApplicationLocalLogin"`
 
+	// Httpd deployment CPU limit (default: no limit)
+	// +optional
+	HttpdCpuLimit string `json:"httpdCpuLimit"`
 	// Httpd deployment CPU request (default: no request)
 	// +optional
 	HttpdCpuRequest string `json:"httpdCpuRequest"`
@@ -91,6 +94,9 @@ type ManageIQSpec struct {
 	// +optional
 	MemcachedImageTag string `json:"memcachedImageTag"`
 
+	// Memcached deployment CPU limit (default: no limit)
+	// +optional
+	MemcachedCpuLimit string `json:"memcachedCpuLimit"`
 	// Memcached deployment CPU request (default: no request)
 	// +optional
 	MemcachedCpuRequest string `json:"memcachedCpuRequest"`
@@ -124,6 +130,9 @@ type ManageIQSpec struct {
 	// +optional
 	OrchestratorInitialDelay string `json:"orchestratorInitialDelay"`
 
+	// Orchestrator deployment CPU limit (default: no limit)
+	// +optional
+	OrchestratorCpuLimit string `json:"orchestratorCpuLimit"`
 	// Orchestrator deployment CPU request (default: no request)
 	// +optional
 	OrchestratorCpuRequest string `json:"orchestratorCpuRequest"`
@@ -141,6 +150,9 @@ type ManageIQSpec struct {
 	// +optional
 	PostgresqlImageTag string `json:"postgresqlImageTag"`
 
+	// PostgreSQL deployment CPU limit (default: no limit)
+	// +optional
+	PostgresqlCpuLimit string `json:"postgresqlCpuLimit"`
 	// PostgreSQL deployment CPU request (default: no request)
 	// +optional
 	PostgresqlCpuRequest string `json:"postgresqlCpuRequest"`

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -281,12 +281,18 @@ func (r *ReconcileManageIQ) generateKafkaResources(cr *miqv1alpha1.ManageIQ) err
 		return err
 	}
 
-	kafkaDeployment := miqtool.KafkaDeployment(cr)
+	kafkaDeployment, err := miqtool.KafkaDeployment(cr)
+	if err != nil {
+		return err
+	}
 	if err := r.createk8sResIfNotExist(cr, kafkaDeployment, &appsv1.Deployment{}); err != nil {
 		return err
 	}
 
-	zookeeperDeployment := miqtool.ZookeeperDeployment(cr)
+	zookeeperDeployment, err := miqtool.ZookeeperDeployment(cr)
+	if err != nil {
+		return err
+	}
 	if err := r.createk8sResIfNotExist(cr, zookeeperDeployment, &appsv1.Deployment{}); err != nil {
 		return err
 	}

--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -241,7 +241,7 @@ func initializeHttpdContainer(spec *miqv1alpha1.ManageIQSpec, privileged bool, c
 
 	assignHttpdPorts(privileged, c)
 
-	err := addResourceReqs(spec.HttpdMemoryLimit, spec.HttpdMemoryRequest, "", spec.HttpdCpuRequest, c)
+	err := addResourceReqs(spec.HttpdMemoryLimit, spec.HttpdMemoryRequest, spec.HttpdCpuLimit, spec.HttpdCpuRequest, c)
 	if err != nil {
 		return err
 	}

--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -241,7 +241,7 @@ func initializeHttpdContainer(spec *miqv1alpha1.ManageIQSpec, privileged bool, c
 
 	assignHttpdPorts(privileged, c)
 
-	err := addResourceReqs(spec.HttpdMemoryLimit, spec.HttpdMemoryRequest, spec.HttpdCpuRequest, c)
+	err := addResourceReqs(spec.HttpdMemoryLimit, spec.HttpdMemoryRequest, "", spec.HttpdCpuRequest, c)
 	if err != nil {
 		return err
 	}

--- a/manageiq-operator/pkg/helpers/miq-components/memcached.go
+++ b/manageiq-operator/pkg/helpers/miq-components/memcached.go
@@ -50,7 +50,7 @@ func NewMemcachedDeployment(cr *miqv1alpha1.ManageIQ) (*appsv1.Deployment, error
 		},
 	}
 
-	err := addResourceReqs(cr.Spec.MemcachedMemoryLimit, cr.Spec.MemcachedMemoryRequest, cr.Spec.MemcachedCpuRequest, &container)
+	err := addResourceReqs(cr.Spec.MemcachedMemoryLimit, cr.Spec.MemcachedMemoryRequest, "", cr.Spec.MemcachedCpuRequest, &container)
 	if err != nil {
 		return nil, err
 	}

--- a/manageiq-operator/pkg/helpers/miq-components/memcached.go
+++ b/manageiq-operator/pkg/helpers/miq-components/memcached.go
@@ -50,7 +50,7 @@ func NewMemcachedDeployment(cr *miqv1alpha1.ManageIQ) (*appsv1.Deployment, error
 		},
 	}
 
-	err := addResourceReqs(cr.Spec.MemcachedMemoryLimit, cr.Spec.MemcachedMemoryRequest, "", cr.Spec.MemcachedCpuRequest, &container)
+	err := addResourceReqs(cr.Spec.MemcachedMemoryLimit, cr.Spec.MemcachedMemoryRequest, cr.Spec.MemcachedCpuLimit, cr.Spec.MemcachedCpuRequest, &container)
 	if err != nil {
 		return nil, err
 	}

--- a/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
@@ -134,7 +134,7 @@ func NewOrchestratorDeployment(cr *miqv1alpha1.ManageIQ) (*appsv1.Deployment, er
 		},
 	}
 
-	err = addResourceReqs(cr.Spec.OrchestratorMemoryLimit, cr.Spec.OrchestratorMemoryRequest, cr.Spec.OrchestratorCpuRequest, &container)
+	err = addResourceReqs(cr.Spec.OrchestratorMemoryLimit, cr.Spec.OrchestratorMemoryRequest, "", cr.Spec.OrchestratorCpuRequest, &container)
 	if err != nil {
 		return nil, err
 	}

--- a/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
@@ -134,7 +134,7 @@ func NewOrchestratorDeployment(cr *miqv1alpha1.ManageIQ) (*appsv1.Deployment, er
 		},
 	}
 
-	err = addResourceReqs(cr.Spec.OrchestratorMemoryLimit, cr.Spec.OrchestratorMemoryRequest, "", cr.Spec.OrchestratorCpuRequest, &container)
+	err = addResourceReqs(cr.Spec.OrchestratorMemoryLimit, cr.Spec.OrchestratorMemoryRequest, cr.Spec.OrchestratorCpuLimit, cr.Spec.OrchestratorCpuRequest, &container)
 	if err != nil {
 		return nil, err
 	}

--- a/manageiq-operator/pkg/helpers/miq-components/postgresql.go
+++ b/manageiq-operator/pkg/helpers/miq-components/postgresql.go
@@ -168,7 +168,7 @@ func NewPostgresqlDeployment(cr *miqv1alpha1.ManageIQ) (*appsv1.Deployment, erro
 		},
 	}
 
-	err := addResourceReqs(cr.Spec.PostgresqlMemoryLimit, cr.Spec.PostgresqlMemoryRequest, "", cr.Spec.PostgresqlCpuRequest, &container)
+	err := addResourceReqs(cr.Spec.PostgresqlMemoryLimit, cr.Spec.PostgresqlMemoryRequest, cr.Spec.PostgresqlCpuLimit, cr.Spec.PostgresqlCpuRequest, &container)
 	if err != nil {
 		return nil, err
 	}

--- a/manageiq-operator/pkg/helpers/miq-components/postgresql.go
+++ b/manageiq-operator/pkg/helpers/miq-components/postgresql.go
@@ -168,7 +168,7 @@ func NewPostgresqlDeployment(cr *miqv1alpha1.ManageIQ) (*appsv1.Deployment, erro
 		},
 	}
 
-	err := addResourceReqs(cr.Spec.PostgresqlMemoryLimit, cr.Spec.PostgresqlMemoryRequest, cr.Spec.PostgresqlCpuRequest, &container)
+	err := addResourceReqs(cr.Spec.PostgresqlMemoryLimit, cr.Spec.PostgresqlMemoryRequest, "", cr.Spec.PostgresqlCpuRequest, &container)
 	if err != nil {
 		return nil, err
 	}

--- a/manageiq-operator/pkg/helpers/miq-components/util.go
+++ b/manageiq-operator/pkg/helpers/miq-components/util.go
@@ -5,9 +5,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func addResourceReqs(memLimit string, memReq string, cpuReq string, c *corev1.Container) error {
-	if memLimit == "" && memReq == "" && cpuReq == "" {
+func addResourceReqs(memLimit, memReq, cpuLimit, cpuReq string, c *corev1.Container) error {
+	if memLimit == "" && memReq == "" && cpuLimit == "" && cpuReq == "" {
 		return nil
+	}
+
+	if memLimit != "" || cpuLimit != "" {
+		c.Resources.Limits = make(map[corev1.ResourceName]resource.Quantity)
 	}
 
 	if memLimit != "" {
@@ -15,7 +19,15 @@ func addResourceReqs(memLimit string, memReq string, cpuReq string, c *corev1.Co
 		if err != nil {
 			return err
 		}
-		c.Resources.Limits = corev1.ResourceList{"memory": limit}
+		c.Resources.Limits["memory"] = limit
+	}
+
+	if cpuLimit != "" {
+		limit, err := resource.ParseQuantity(cpuLimit)
+		if err != nil {
+			return err
+		}
+		c.Resources.Limits["cpu"] = limit
 	}
 
 	if memReq != "" || cpuReq != "" {


### PR DESCRIPTION
This adds cpu and memory request/limit settings to every component that was previously missing them. Before this change kafka and zookeeper had no resource requests or limits. The rest of the components were missing the cpu limit setting for some reason.

All additional settings still default to no limit/request so that things are more easily deployed to environments with limited resources.
