### PR TITLE
[IVANCHUK] Change the httpd image to httpd-init

### DIFF
--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -812,7 +812,7 @@ parameters:
 - name: HTTPD_IMG_NAME
   displayName: Apache httpd Image Name
   description: This is the httpd image name requested to deploy.
-  value: docker.io/manageiq/httpd
+  value: docker.io/manageiq/httpd-init
 - name: HTTPD_IMG_TAG
   displayName: Apache httpd Image Tag
   description: This is the httpd image tag/version requested to deploy.

--- a/templates/miq-template-ext-db.yaml
+++ b/templates/miq-template-ext-db.yaml
@@ -339,7 +339,9 @@ objects:
       RewriteEngine On
       Options SymLinksIfOwnerMatch
 
-      <VirtualHost *:80>
+      Listen 8080
+
+      <VirtualHost *:8080>
         KeepAlive on
         # Without ServerName mod_auth_mellon compares against http:// and not https:// from the IdP
         ServerName https://%{REQUEST_HOST}
@@ -552,7 +554,7 @@ objects:
     ports:
     - name: http
       port: 80
-      targetPort: 80
+      targetPort: 8080
     selector:
       name: httpd
 - apiVersion: v1
@@ -564,8 +566,8 @@ objects:
   spec:
     ports:
     - name: http-dbus-api
-      port: 8080
-      targetPort: 8080
+      port: 8081
+      targetPort: 8081
     selector:
       name: httpd
 - apiVersion: v1
@@ -601,9 +603,9 @@ objects:
         - name: httpd
           image: "${HTTPD_IMG_NAME}:${HTTPD_IMG_TAG}"
           ports:
-          - containerPort: 80
-            protocol: TCP
           - containerPort: 8080
+            protocol: TCP
+          - containerPort: 8081
             protocol: TCP
           livenessProbe:
             exec:
@@ -614,7 +616,7 @@ objects:
             timeoutSeconds: 3
           readinessProbe:
             tcpSocket:
-              port: 80
+              port: 8080
             initialDelaySeconds: 10
             timeoutSeconds: 3
           volumeMounts:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -154,7 +154,9 @@ objects:
       RewriteEngine On
       Options SymLinksIfOwnerMatch
 
-      <VirtualHost *:80>
+      Listen 8080
+
+      <VirtualHost *:8080>
         KeepAlive on
         # Without ServerName mod_auth_mellon compares against http:// and not https:// from the IdP
         ServerName https://%{REQUEST_HOST}
@@ -721,7 +723,7 @@ objects:
     ports:
     - name: http
       port: 80
-      targetPort: 80
+      targetPort: 8080
     selector:
       name: httpd
 - apiVersion: v1
@@ -733,8 +735,8 @@ objects:
   spec:
     ports:
     - name: http-dbus-api
-      port: 8080
-      targetPort: 8080
+      port: 8081
+      targetPort: 8081
     selector:
       name: httpd
 - apiVersion: v1
@@ -770,9 +772,9 @@ objects:
         - name: httpd
           image: "${HTTPD_IMG_NAME}:${HTTPD_IMG_TAG}"
           ports:
-          - containerPort: 80
-            protocol: TCP
           - containerPort: 8080
+            protocol: TCP
+          - containerPort: 8081
             protocol: TCP
           livenessProbe:
             exec:
@@ -783,7 +785,7 @@ objects:
             timeoutSeconds: 3
           readinessProbe:
             tcpSocket:
-              port: 80
+              port: 8080
             initialDelaySeconds: 10
             timeoutSeconds: 3
           volumeMounts:

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -1007,7 +1007,7 @@ parameters:
 - name: HTTPD_IMG_NAME
   displayName: Apache httpd Image Name
   description: This is the httpd image name requested to deploy.
-  value: docker.io/manageiq/httpd
+  value: docker.io/manageiq/httpd-init
 - name: HTTPD_IMG_TAG
   displayName: Apache httpd Image Tag
   description: This is the httpd image tag/version requested to deploy.


### PR DESCRIPTION
After the image rename, the deploy will fail with the non-init httpd
image.