### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,25 +1,16 @@
 ---
 name: Bug report
 about: Tell us about a problem you are experiencing
-
 ---
 
-@miq-bot add_label bug
+<!-- 1. Describe the issue you are having and what you expected to happen -->
 
-**What steps did you take and what happened:**
-[A clear and concise description of what the bug is.]
+<!-- 2. Describe steps to reproduce -->
 
-
-**What did you expect to happen:**
-
-
-**Anything else you would like to add:**
-[Miscellaneous information that will assist in solving the issue.]
-
-
-**Environment:**
-
+<!-- 3. Fill out the following details -->
 - ManageIQ version:
-- Minikube/KIND/OCP version:
+- Minikube/KIND/OCP/CRC version:
 - Kubernetes version: (use `kubectl version`):
 - OS (e.g. from `/etc/os-release`):
+
+@miq-bot add-label bug

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,14 +1,8 @@
 ---
-name: Feature enhancement request
+name: Enhancement request
 about: Suggest an idea for this project
-
 ---
 
-@miq-bot add_label enhancement
+<!-- 1. Describe the enhancement and why you think it is needed -->
 
-**Describe the solution you'd like**
-[A clear and concise description of what you want to happen.]
-
-
-**Anything else you would like to add:**
-[Miscellaneous information that will assist in solving the issue.]
+@miq-bot add-label enhancement

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,11 @@
-**What this PR does / why we need it**:
+<!-- 1. Describe what this PR does and why you think it is needed -->
 
-**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
+<!--
+2. If this issue fixes an existing issue, please specify in `Fixes #<id>` format
+(See https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
+-->
 
-Fixes #
-
-**Special notes for your reviewer**:
-
+<!--
+3. Tell the bot to mark this with an appropriate label (e.g. bug, enhancement, etc)
+e.g. `@miq-bot add-label bug`
+-->


### PR DESCRIPTION
I find the current issue templates wordy, and also put too much "stuff" into the actual issue.  These templates instead use comments to show the user what to do, but won't present themselves in the final issue, making it cleaner for readers (i.e. committers/mergers)

@carbonin Please review.