### PR TITLE
Add oidcCaCertSecret parameter

### DIFF
--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -140,6 +140,11 @@ spec:
               description: URL for OIDC authentication introspection Only used with
                 the openid-connect authentication type
               type: string
+            oidcCaCertSecret:
+              description: Secret containing the trusted CA certificate file(s) for
+                the OIDC server. Only used with the openid-connect authentication
+                type
+              type: string
             oidcClientSecret:
               description: Secret name containing the OIDC client id and secret Only
                 used with the openid-connect authentication type

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -140,6 +140,11 @@ spec:
               description: URL for OIDC authentication introspection Only used with
                 the openid-connect authentication type
               type: string
+            oidcCaCertSecret:
+              description: Secret containing the trusted CA certificate file(s) for
+                the OIDC server. Only used with the openid-connect authentication
+                type
+              type: string
             oidcClientSecret:
               description: Secret name containing the OIDC client id and secret Only
                 used with the openid-connect authentication type

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -60,6 +60,10 @@ type ManageIQSpec struct {
 	// Only used with the openid-connect authentication type
 	// +optional
 	OIDCProviderURL string `json:"oidcProviderURL"`
+	// Secret containing the trusted CA certificate file(s) for the OIDC server.
+	// Only used with the openid-connect authentication type
+	// +optional
+	OIDCCACertSecret string `json:"oidcCaCertSecret"`
 	// URL for OIDC authentication introspection
 	// Only used with the openid-connect authentication type
 	// +optional
@@ -347,11 +351,11 @@ func (m *ManageIQ) Validate() error {
 	errs := []string{}
 
 	if spec.HttpdAuthenticationType == "openid-connect" {
-		// Invalid if config and any other info is also provided
 		if spec.HttpdAuthConfig != "" && (spec.OIDCProviderURL != "" || spec.OIDCOAuthIntrospectionURL != "" || spec.OIDCClientSecret != "") {
+			// Invalid if config and any other info is also provided
 			errs = append(errs, "OIDCProviderURL, OIDCOAuthIntrospectionURL, and OIDCClientSecret are invalid when HttpdAuthConfig is specified")
-			// Need to provide either the entire config or a secret and provider url
 		} else if spec.HttpdAuthConfig == "" && (spec.OIDCProviderURL == "" || spec.OIDCOAuthIntrospectionURL == "" || spec.OIDCClientSecret == "") {
+			// Need to provide either the entire config or a secret and provider url
 			errs = append(errs, "HttpdAuthConfig or all of OIDCProviderURL, OIDCOAuthIntrospectionURL, and OIDCClientSecret must be provided for openid-connect authentication")
 		}
 	} else {
@@ -365,6 +369,10 @@ func (m *ManageIQ) Validate() error {
 
 		if spec.OIDCClientSecret != "" {
 			errs = append(errs, fmt.Sprintf("OIDCClientSecret is not allowed for authentication type %s", spec.HttpdAuthenticationType))
+		}
+
+		if spec.OIDCCACertSecret != "" {
+			errs = append(errs, fmt.Sprintf("OIDCCACertSecret is not allowed for authentication type %s", spec.HttpdAuthenticationType))
 		}
 	}
 

--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -156,6 +156,21 @@ func addUserAuthVolume(secretName string, podSpec *corev1.PodSpec) {
 	podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, mount)
 }
 
+func addOIDCCACertVolume(secretName string, podSpec *corev1.PodSpec) {
+	vol := corev1.Volume{
+		Name: "oidc-ca-cert",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: secretName,
+			},
+		},
+	}
+	podSpec.Volumes = append(podSpec.Volumes, vol)
+
+	mount := corev1.VolumeMount{Name: "oidc-ca-cert", MountPath: "/etc/pki/ca-trust/source/anchors"}
+	podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, mount)
+}
+
 func configureHttpdAuth(spec *miqv1alpha1.ManageIQSpec, podSpec *corev1.PodSpec) {
 	authType := spec.HttpdAuthenticationType
 
@@ -165,6 +180,10 @@ func configureHttpdAuth(spec *miqv1alpha1.ManageIQSpec, podSpec *corev1.PodSpec)
 
 	if spec.HttpdAuthConfig != "" {
 		addUserAuthVolume(spec.HttpdAuthConfig, podSpec)
+	}
+
+	if spec.OIDCCACertSecret != "" {
+		addOIDCCACertVolume(spec.OIDCCACertSecret, podSpec)
 	}
 
 	if authType == "openid-connect" && spec.OIDCClientSecret != "" {


### PR DESCRIPTION
A user can now provide a secret containing the CA certs necessary
for httpd to securely connect to the OIDC server.
If the secret name is specified in the CR the operator will mount
the secret to `/etc/pki/ca-trust/source/anchors`.
If the secret name is not specified, but oidc-connect authentication
type is selected, the operator will add the parameters required to
disable server validation when communicating with the OIDC server.

Fixes #507

<!-- 1. Describe what this PR does and why you think it is needed -->

<!--
2. If this issue fixes an existing issue, please specify in `Fixes #<id>` format
(See https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Tell the bot to mark this with an appropriate label (e.g. bug, enhancement, etc)
e.g. `@miq-bot add-label bug`
-->
