### PR TITLE
Add a CR parameter for an initial group name

### DIFF
--- a/images/manageiq-orchestrator/container-assets/entrypoint
+++ b/images/manageiq-orchestrator/container-assets/entrypoint
@@ -43,6 +43,13 @@ EOS
   bin/rails runner "$script"
 }
 
+function create_initial_group() {
+  if [ "$ADMIN_GROUP" != "" ]; then
+    echo "== Creating initial group "$ADMIN_GROUP" =="
+    bin/rails runner "MiqGroup.create!(:miq_user_role => MiqUserRole.find_by(:name => 'EvmRole-super_administrator'), :description => ENV['ADMIN_GROUP'], :tenant => Tenant.root_tenant)"
+  fi
+}
+
 check_svc_status ${MEMCACHED_SERVICE_HOST} ${MEMCACHED_SERVICE_PORT}
 check_svc_status ${DATABASE_HOSTNAME} ${DATABASE_PORT}
 
@@ -66,7 +73,8 @@ case $? in
     pushd ${APP_ROOT}
       set -e
       REGION=${DATABASE_REGION} bin/rake db:migrate
-      REGION=${DATABASE_REGION} bin/rails runner "MiqDatabase.seed; MiqRegion.seed"
+      REGION=${DATABASE_REGION} bin/rake db:seed
+      create_initial_group
     popd
   ;;
   4) # new_replica
@@ -88,5 +96,7 @@ case $? in
     exit 1
 esac
 
-update_auth_settings
+pushd ${APP_ROOT}
+  update_auth_settings
+popd
 exec ruby /var/www/miq/vmdb/lib/workers/bin/evm_server.rb

--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -89,6 +89,10 @@ spec:
               description: Secret containing the image registry authentication information
                 needed for the manageiq images
               type: string
+            initialAdminGroupName:
+              description: Group name to create with the super admin role. This can
+                be used to seed a group when using external authentication
+              type: string
             kafkaCpuRequest:
               description: 'Kafka deployment CPU request (default: no request)'
               type: string

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -89,6 +89,10 @@ spec:
               description: Secret containing the image registry authentication information
                 needed for the manageiq images
               type: string
+            initialAdminGroupName:
+              description: Group name to create with the super admin role. This can
+                be used to seed a group when using external authentication
+              type: string
             kafkaCpuRequest:
               description: 'Kafka deployment CPU request (default: no request)'
               type: string

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -23,6 +23,11 @@ type ManageIQSpec struct {
 	// +optional
 	DatabaseRegion string `json:"databaseRegion"`
 
+	// Group name to create with the super admin role.
+	// This can be used to seed a group when using external authentication
+	// +optional
+	InitialAdminGroupName string `json:"initialAdminGroupName"`
+
 	// Database volume size (default: 15Gi)
 	// +optional
 	DatabaseVolumeCapacity string `json:"databaseVolumeCapacity"`

--- a/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
@@ -131,6 +131,10 @@ func NewOrchestratorDeployment(cr *miqv1alpha1.ManageIQ) (*appsv1.Deployment, er
 					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.uid"},
 				},
 			},
+			corev1.EnvVar{
+				Name:  "ADMIN_GROUP",
+				Value: cr.Spec.InitialAdminGroupName,
+			},
 		},
 	}
 


### PR DESCRIPTION
When provided, we will create a group with the given name with
the super administrator role. The main use case would be when
a user wants to deploy with basic auth totally disabled as soon
as the application comes up. This means that they need at least one
group in the application that matches a group in their identity
provider.

We also now run a full seed after migrating the database on initial
deploy so that we can create the initial group correctly.

Fixes #508