### PR TITLE
Prevent API calls from going to the UI worker

### DIFF
--- a/images/manageiq-ui-worker/Dockerfile
+++ b/images/manageiq-ui-worker/Dockerfile
@@ -4,15 +4,10 @@ ARG FROM_TAG=latest
 FROM ${FROM_REPO}/manageiq-webserver-worker:${FROM_TAG}
 MAINTAINER ManageIQ https://manageiq.org
 
-ARG RPM_PREFIX=manageiq
-
 LABEL name="manageiq-ui-worker" \
       summary="ManageIQ user interface worker image"
 
-# Install packages needed for UI and remove the existing httpd config
-RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install ${RPM_PREFIX}-ui && \
-    rm -f /etc/httpd/conf.d/* && \
-    dnf clean all
+RUN rm -f /etc/httpd/conf.d/*
 
 # Configure httpd to run without root privileges
 RUN chgrp root /var/run/httpd && chmod g+rwx /var/run/httpd && \

--- a/images/manageiq-webserver-worker/Dockerfile
+++ b/images/manageiq-webserver-worker/Dockerfile
@@ -4,7 +4,11 @@ ARG FROM_TAG=latest
 FROM ${FROM_REPO}/manageiq-base-worker:${FROM_TAG}
 MAINTAINER ManageIQ https://manageiq.org
 
+ARG RPM_PREFIX=manageiq
+
 LABEL name="manageiq-webserver-worker" \
       summary="ManageIQ web server worker image"
+
+RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install ${RPM_PREFIX}-ui && dnf clean all
 
 EXPOSE 3000

--- a/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
@@ -37,6 +37,8 @@ Options SymLinksIfOwnerMatch
   RewriteRule .* ws://websocket:3000%{REQUEST_URI}  [P,QSA,L]
   ProxyPassReverse /ws ws://websocket:3000/ws
 
+  RewriteCond %{REQUEST_URI} !^/api
+
   # For httpd, some ErrorDocuments must by served by the httpd pod
   RewriteCond %{REQUEST_URI} !^/proxy_pages
 

--- a/templates/app/httpd.yaml
+++ b/templates/app/httpd.yaml
@@ -31,6 +31,8 @@ objects:
         RewriteRule .* ws://websocket:3000%{REQUEST_URI}  [P,QSA,L]
         ProxyPassReverse /ws ws://websocket:3000/ws
 
+        RewriteCond %{REQUEST_URI} !^/api
+
         # For httpd, some ErrorDocuments must by served by the httpd pod
         RewriteCond %{REQUEST_URI} !^/proxy_pages
 


### PR DESCRIPTION
Fixes #516

After making this change, assets were not accessible on the SUI login page. This is because the API doesn't have access to asset paths as they are not compiled for that image. The problematic code is https://github.com/ManageIQ/manageiq-api/blob/7776a631894bc71438c46a5c14d649432e93f52b/app/controllers/api/api_controller.rb#L95-L102

I think it would be easier to wait for RPM-based builds than to make and test the changes needed to get asset compilation into the API image.

@simaishi I'm not sure what the granularity is for the rpms, will there be a single package for the assets or will it be more complicated than that?