### PR TITLE
Add policy for orchestrator

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
@@ -22,8 +22,8 @@ func NewOrchestratorDeployment(cr *miqv1alpha1.ManageIQ) (*appsv1.Deployment, er
 	}
 
 	container := corev1.Container{
-		Name:  "orchestrator",
-		Image: cr.Spec.OrchestratorImageNamespace + "/" + cr.Spec.OrchestratorImageName + ":" + cr.Spec.OrchestratorImageTag,
+		Name:            "orchestrator",
+		Image:           cr.Spec.OrchestratorImageNamespace + "/" + cr.Spec.OrchestratorImageName + ":" + cr.Spec.OrchestratorImageTag,
 		ImagePullPolicy: pullPolicy,
 		LivenessProbe: &corev1.Probe{
 			Handler: corev1.Handler{

--- a/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
@@ -6,6 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strconv"
+	"strings"
 
 	"github.com/google/uuid"
 )
@@ -15,11 +16,15 @@ func NewOrchestratorDeployment(cr *miqv1alpha1.ManageIQ) (*appsv1.Deployment, er
 	if err != nil {
 		return nil, err
 	}
+	pullPolicy := corev1.PullIfNotPresent
+	if strings.Contains(cr.Spec.OrchestratorImageTag, "latest") {
+		pullPolicy = corev1.PullAlways
+	}
 
 	container := corev1.Container{
 		Name:  "orchestrator",
 		Image: cr.Spec.OrchestratorImageNamespace + "/" + cr.Spec.OrchestratorImageName + ":" + cr.Spec.OrchestratorImageTag,
-		ImagePullPolicy: corev1.PullAlways,
+		ImagePullPolicy: pullPolicy,
 		LivenessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				Exec: &corev1.ExecAction{

--- a/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
@@ -19,6 +19,7 @@ func NewOrchestratorDeployment(cr *miqv1alpha1.ManageIQ) (*appsv1.Deployment, er
 	container := corev1.Container{
 		Name:  "orchestrator",
 		Image: cr.Spec.OrchestratorImageNamespace + "/" + cr.Spec.OrchestratorImageName + ":" + cr.Spec.OrchestratorImageTag,
+		ImagePullPolicy: corev1.PullAlways,
 		LivenessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				Exec: &corev1.ExecAction{

--- a/templates/app/orchestrator.yaml
+++ b/templates/app/orchestrator.yaml
@@ -25,6 +25,7 @@ objects:
         containers:
         - name: orchestrator
           image: "${ORCHESTRATOR_IMAGE_NAMESPACE}/${ORCHESTRATOR_IMAGE_NAME}:${ORCHESTRATOR_IMAGE_TAG}"
+          imagePullPolicy: Always
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
Set's the pull policy to `Always` for the orchestrator image. Allows `jansa-latest` or other tags that contain latest to be constantly pulled. 

Fixes https://github.com/ManageIQ/manageiq-pods/issues/518 

Requesting backport to jansa branch
