### PR TITLE
Pass RPM_PREFIX to all images

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -85,20 +85,16 @@ pushd $IMAGE_DIR
   echo "Building manageiq-base: $cmd"
   $cmd manageiq-base
 
-  build_images="manageiq-base-worker manageiq-orchestrator manageiq-webserver-worker"
+  build_images="manageiq-base-worker manageiq-orchestrator manageiq-webserver-worker manageiq-ui-worker"
   for image in $build_images; do
-    cmd="docker build -t $REPO/$image:$TAG --build-arg FROM_REPO=$REPO --build-arg FROM_TAG=$TAG $image"
+    cmd="docker build --tag $REPO/$image:$TAG \
+                      --build-arg FROM_REPO=$REPO \
+                      --build-arg FROM_TAG=$TAG \
+                      --build-arg RPM_PREFIX=$RPM_PREFIX \
+                      $image"
     echo "Building $image: $cmd"
     $cmd
   done
-
-  cmd="docker build --tag $REPO/manageiq-ui-worker:$TAG \
-                    --build-arg FROM_REPO=$REPO \
-                    --build-arg FROM_TAG=$TAG \
-                    --build-arg RPM_PREFIX=$RPM_PREFIX \
-                    manageiq-ui-worker"
-  echo "Building manageiq-ui-worker: $cmd"
-  $cmd
 popd
 
 pushd "$OPERATOR_DIR"


### PR DESCRIPTION
If the build_arg is not consumed, then you get the following warning:

    [Warning] One or more build-args [RPM_PREFIX] were not consumed

However, the builds succeed, so it's not a problem. This will make the
bin/build simpler and less prone to error if and when the actual image
Dockerfiles change.

See https://github.com/ManageIQ/manageiq-pods/pull/519#issuecomment-637609255

@carbonin @simaishi Please review.