### PR TITLE
Move notification handling to the UI worker

### DIFF
--- a/images/manageiq-ui-worker/container-assets/manageiq-http.conf
+++ b/images/manageiq-ui-worker/container-assets/manageiq-http.conf
@@ -10,6 +10,12 @@ Listen 3000
 <VirtualHost *:3000>
   DocumentRoot /var/www/miq/vmdb/public
 
+  RewriteCond %{REQUEST_URI}     ^/ws/notifications [NC]
+  RewriteCond %{HTTP:UPGRADE}    ^websocket$ [NC]
+  RewriteCond %{HTTP:CONNECTION} ^Upgrade$   [NC]
+  RewriteRule .* ws://localhost:3001%{REQUEST_URI}  [P,QSA,L]
+  ProxyPassReverse /ws/notifications ws://localhost:3001/ws/notifications
+
   RewriteRule ^/ui/service(?!/(assets|images|img|styles|js|fonts|vendor|gettext)) /ui/service/index.html [L]
   RewriteCond %{REQUEST_URI} !^/proxy_pages
   RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_FILENAME} !-f

--- a/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
@@ -31,11 +31,11 @@ Options SymLinksIfOwnerMatch
 
   ProxyPreserveHost on
 
-  RewriteCond %{REQUEST_URI}     ^/ws        [NC]
+  RewriteCond %{REQUEST_URI}     ^/ws/notifications [NC]
   RewriteCond %{HTTP:UPGRADE}    ^websocket$ [NC]
   RewriteCond %{HTTP:CONNECTION} ^Upgrade$   [NC]
-  RewriteRule .* ws://websocket:3000%{REQUEST_URI}  [P,QSA,L]
-  ProxyPassReverse /ws ws://websocket:3000/ws
+  RewriteRule .* ws://ui:3000%{REQUEST_URI}  [P,QSA,L]
+  ProxyPassReverse /ws/notifications ws://ui:3000/ws/notifications
 
   RewriteCond %{REQUEST_URI} !^/api
 

--- a/templates/app/httpd.yaml
+++ b/templates/app/httpd.yaml
@@ -25,11 +25,11 @@ objects:
 
         ProxyPreserveHost on
 
-        RewriteCond %{REQUEST_URI}     ^/ws        [NC]
+        RewriteCond %{REQUEST_URI}     ^/ws/notifications [NC]
         RewriteCond %{HTTP:UPGRADE}    ^websocket$ [NC]
         RewriteCond %{HTTP:CONNECTION} ^Upgrade$   [NC]
-        RewriteRule .* ws://websocket:3000%{REQUEST_URI}  [P,QSA,L]
-        ProxyPassReverse /ws ws://websocket:3000/ws
+        RewriteRule .* ws://ui:3000%{REQUEST_URI}  [P,QSA,L]
+        ProxyPassReverse /ws/notifications ws://ui:3000/ws/notifications
 
         RewriteCond %{REQUEST_URI} !^/api
 


### PR DESCRIPTION
This changes the httpd pod config to push notifications requests
to the ui service instead of the "websocket" service (which actually
doesn't exist anymore).

It also configures the httpd instance in the ui image to handle
websockets in the same way

Fixes #517