### PR TITLE
Add httpd config for rewriting remote consoles to the correct service

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
@@ -54,6 +54,12 @@ Options SymLinksIfOwnerMatch
   ProxyPass /api http://web-service:3000/api
   ProxyPassReverse /api http://web-service:3000/api
 
+  RewriteCond %{REQUEST_URI}     ^/ws/console [NC]
+  RewriteCond %{HTTP:UPGRADE}    ^websocket$  [NC]
+  RewriteCond %{HTTP:CONNECTION} ^Upgrade$    [NC]
+  RewriteRule .* ws://remote-console:3000%{REQUEST_URI}  [P,QSA,L]
+  ProxyPassReverse /ws/console ws://remote-console:3000/ws/console
+
   # Ensures httpd stdout/stderr are seen by 'docker logs'.
   ErrorLog  "| /usr/bin/tee /proc/1/fd/2 /var/log/httpd/error_log"
   CustomLog "| /usr/bin/tee /proc/1/fd/1 /var/log/httpd/access_log" common

--- a/templates/app/httpd.yaml
+++ b/templates/app/httpd.yaml
@@ -45,6 +45,12 @@ objects:
         ProxyPass /api http://web-service:3000/api
         ProxyPassReverse /api http://web-service:3000/api
 
+        RewriteCond %{REQUEST_URI}     ^/ws/console [NC]
+        RewriteCond %{HTTP:UPGRADE}    ^websocket$  [NC]
+        RewriteCond %{HTTP:CONNECTION} ^Upgrade$    [NC]
+        RewriteRule .* ws://remote-console:3000%{REQUEST_URI}  [P,QSA,L]
+        ProxyPassReverse /ws/console ws://remote-console:3000/ws/console
+
         # Ensures httpd stdout/stderr are seen by 'docker logs'.
         ErrorLog  "| /usr/bin/tee /proc/1/fd/2 /var/log/httpd/error_log"
         CustomLog "| /usr/bin/tee /proc/1/fd/1 /var/log/httpd/access_log" common


### PR DESCRIPTION
Prior to this change we didn't have a proxy for remote consoles
so there was no way for them to work properly.

Fixes #536