### PR TITLE
Use controllerutil.CreateOrUpdate to maintain memcached resources

### DIFF
--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -207,17 +207,22 @@ func (r *ReconcileManageIQ) generateHttpdResources(cr *miqv1alpha1.ManageIQ) err
 }
 
 func (r *ReconcileManageIQ) generateMemcachedResources(cr *miqv1alpha1.ManageIQ) error {
-	memcachedDeployment, err := miqtool.NewMemcachedDeployment(cr)
+	deployment, mutateFunc, err := miqtool.NewMemcachedDeployment(cr, r.scheme)
 	if err != nil {
 		return err
 	}
-	if err := r.createk8sResIfNotExist(cr, memcachedDeployment, &appsv1.Deployment{}); err != nil {
+
+	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, deployment, mutateFunc); err != nil {
 		return err
+	} else {
+		logger.Info("Deployment has been reconciled", "component", "memcached", "result", result)
 	}
 
-	memcachedService := miqtool.NewMemcachedService(cr)
-	if err := r.createk8sResIfNotExist(cr, memcachedService, &corev1.Service{}); err != nil {
+	service, mutateFunc := miqtool.NewMemcachedService(cr, r.scheme)
+	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, service, mutateFunc); err != nil {
 		return err
+	} else {
+		logger.Info("Service has been reconciled", "component", "memcached", "result", result)
 	}
 
 	return nil

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -18,13 +18,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = logf.Log.WithName("controller_manageiq")
+var logger = log.Log.WithName("controller_manageiq")
 
 // Add creates a new ManageIQ Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -99,7 +99,7 @@ type ReconcileManageIQ struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileManageIQ) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger := logger.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling ManageIQ")
 
 	// Fetch the ManageIQ instance
@@ -346,7 +346,7 @@ func (r *ReconcileManageIQ) generateSecrets(cr *miqv1alpha1.ManageIQ) error {
 }
 
 func (r *ReconcileManageIQ) createk8sResIfNotExist(cr *miqv1alpha1.ManageIQ, res, restype metav1.Object) error {
-	reqLogger := log.WithValues("task: ", "create resource")
+	reqLogger := logger.WithValues("task: ", "create resource")
 	if err := controllerutil.SetControllerReference(cr, res, r.scheme); err != nil {
 		return err
 	}

--- a/manageiq-operator/pkg/helpers/miq-components/memcached.go
+++ b/manageiq-operator/pkg/helpers/miq-components/memcached.go
@@ -5,10 +5,12 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func NewMemcachedDeployment(cr *miqv1alpha1.ManageIQ) (*appsv1.Deployment, error) {
+func NewMemcachedDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*appsv1.Deployment, controllerutil.MutateFn, error) {
 	container := corev1.Container{
 		Name:  "memcached",
 		Image: cr.Spec.MemcachedImageName + ":" + cr.Spec.MemcachedImageTag,
@@ -52,65 +54,78 @@ func NewMemcachedDeployment(cr *miqv1alpha1.ManageIQ) (*appsv1.Deployment, error
 
 	err := addResourceReqs(cr.Spec.MemcachedMemoryLimit, cr.Spec.MemcachedMemoryRequest, cr.Spec.MemcachedCpuLimit, cr.Spec.MemcachedCpuRequest, &container)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	deploymentLabels := map[string]string{
-		"app": cr.Spec.AppName,
-	}
 	podLabels := map[string]string{
 		"name": "memcached",
 		"app":  cr.Spec.AppName,
 	}
 	var repNum int32 = 1
 
+	spec := appsv1.DeploymentSpec{
+		Replicas: &repNum,
+		Selector: &metav1.LabelSelector{
+			MatchLabels: podLabels,
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "memcached",
+				Labels: podLabels,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{container},
+			},
+		},
+	}
+
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "memcached",
 			Namespace: cr.ObjectMeta.Namespace,
-			Labels:    deploymentLabels,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: &repNum,
-			Selector: &metav1.LabelSelector{
-				MatchLabels: podLabels,
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "memcached",
-					Labels: podLabels,
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{container},
-				},
-			},
 		},
 	}
 
-	return deployment, nil
+	f := func() error {
+		if err := controllerutil.SetControllerReference(cr, deployment, scheme); err != nil {
+			return err
+		}
+		if deployment.ObjectMeta.Labels == nil {
+			deployment.ObjectMeta.Labels = make(map[string]string)
+		}
+		deployment.ObjectMeta.Labels["app"] = cr.Spec.AppName
+		deployment.Spec = spec
+		return nil
+	}
+
+	return deployment, f, nil
 }
 
-func NewMemcachedService(cr *miqv1alpha1.ManageIQ) *corev1.Service {
-	labels := map[string]string{
-		"app": cr.Spec.AppName,
-	}
-	selector := map[string]string{
-		"name": "memcached",
-	}
-	return &corev1.Service{
+func NewMemcachedService(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*corev1.Service, controllerutil.MutateFn) {
+	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "memcached",
 			Namespace: cr.ObjectMeta.Namespace,
-			Labels:    labels,
-		},
-		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{
-				corev1.ServicePort{
-					Name: "memcached",
-					Port: 11211,
-				},
-			},
-			Selector: selector,
 		},
 	}
+
+	f := func() error {
+		if err := controllerutil.SetControllerReference(cr, service, scheme); err != nil {
+			return err
+		}
+		if service.ObjectMeta.Labels == nil {
+			service.ObjectMeta.Labels = make(map[string]string)
+		}
+		service.ObjectMeta.Labels["app"] = cr.Spec.AppName
+		service.Spec.Ports = []corev1.ServicePort{
+			corev1.ServicePort{
+				Name: "memcached",
+				Port: 11211,
+			},
+		}
+		service.Spec.Selector = map[string]string{"name": "memcached"}
+		return nil
+	}
+
+	return service, f
 }


### PR DESCRIPTION
Prior to this change, any changes to the on-cluster CR would not be
reflected in the memcached service and deployment. Additionally
changes to the service and deployment would not be resolved to the
correct state by the operator.

Both of those cases are now handled by this patch.

Applies to #438

The first commit also does some light refactoring of the logger so the naming is easier to understand.