### PR TITLE
Add a flag to gate deploying kafka and zookeeper

### DIFF
--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -48,6 +48,10 @@ spec:
             databaseVolumeCapacity:
               description: 'Database volume size (default: 15Gi)'
               type: string
+            deployMessagingService:
+              description: 'Flag to indicate if Kafka and Zookeeper should be deployed
+                (default: false)'
+              type: boolean
             enableApplicationLocalLogin:
               description: 'Flag to allow logging into the application without SSO
                 (default: true)'

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -48,6 +48,10 @@ spec:
             databaseVolumeCapacity:
               description: 'Database volume size (default: 15Gi)'
               type: string
+            deployMessagingService:
+              description: 'Flag to indicate if Kafka and Zookeeper should be deployed
+                (default: false)'
+              type: boolean
             enableApplicationLocalLogin:
               description: 'Flag to allow logging into the application without SSO
                 (default: true)'

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -184,6 +184,10 @@ type ManageIQSpec struct {
 	// +optional
 	PostgresqlSharedBuffers string `json:"postgresqlSharedBuffers"`
 
+	// Flag to indicate if Kafka and Zookeeper should be deployed (default: false)
+	// +optional
+	DeployMessagingService *bool `json:"deployMessagingService"`
+
 	// Image used for the kafka deployment (default: docker.io/bitnami/kafka)
 	// +optional
 	KafkaImageName string `json:"kafkaImageName"`
@@ -352,6 +356,10 @@ func (m *ManageIQ) Initialize() {
 
 	if spec.PostgresqlSharedBuffers == "" {
 		spec.PostgresqlSharedBuffers = "1GB"
+	}
+
+	if spec.DeployMessagingService == nil {
+		spec.DeployMessagingService = new(bool)
 	}
 
 	if spec.KafkaImageName == "" {

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/zz_generated.deepcopy.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/zz_generated.deepcopy.go
@@ -82,6 +82,11 @@ func (in *ManageIQSpec) DeepCopyInto(out *ManageIQSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DeployMessagingService != nil {
+		in, out := &in.DeployMessagingService, &out.DeployMessagingService
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -128,8 +128,10 @@ func (r *ReconcileManageIQ) Reconcile(request reconcile.Request) (reconcile.Resu
 	if e := r.generateMemcachedResources(miqInstance); e != nil {
 		return reconcile.Result{}, e
 	}
-	if e := r.generateKafkaResources(miqInstance); err != nil {
-		return reconcile.Result{}, e
+	if *miqInstance.Spec.DeployMessagingService {
+		if e := r.generateKafkaResources(miqInstance); e != nil {
+			return reconcile.Result{}, e
+		}
 	}
 	if e := r.generateOrchestratorResources(miqInstance); e != nil {
 		return reconcile.Result{}, e


### PR DESCRIPTION
The application doesn't actually rely on these services so we don't
need to deploy them by default.

If a user wants events published to kafka they can still enable the
flag on deploy and consume those events from a separate application.

Requires https://github.com/ManageIQ/manageiq/pull/20268
Fixes #541