### PR TITLE
Move ovirt-ansible rpm installs to manageiq-gemset requires

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -63,8 +63,6 @@ RUN dnf -y --disableplugin=subscription-manager install \
 # Install python packages the same way the appliance does
 COPY --from=0 build/kickstarts/partials/post/python_modules.ks.erb /tmp/python_modules
 RUN bash /tmp/python_modules && rm -f /tmp/python_modules
-COPY --from=0 build/kickstarts/partials/post/ovirt_ansible.ks.erb /tmp/ovirt_ansible
-RUN bash /tmp/ovirt_ansible && rm -f /tmp/ovirt_ansible
 
 RUN chgrp -R 0 $APP_ROOT && \
     chmod -R g=u $APP_ROOT


### PR DESCRIPTION
A part of https://github.com/ManageIQ/manageiq-appliance-build/issues/422

Requires https://github.com/ManageIQ/manageiq-rpm_build/pull/58 (and new rpm build with this change)