### PR TITLE
[JANSA] Switch to latest-jansa since v0.0.1 tag doesn't exist yet

### DIFF
--- a/manageiq-operator/README.md
+++ b/manageiq-operator/README.md
@@ -29,7 +29,7 @@ $ operator-sdk build docker.io/example/manageiq-operator:latest
 2. Update the operator deployment with the new image:
 
 ```bash
-$ sed -i 's|docker.io/manageiq/manageiq-operator:v0.0.1|docker.io/example/manageiq-operator:latest|g' deploy/operator.yaml
+$ sed -i 's|docker.io/manageiq/manageiq-operator:latest-jansa|docker.io/example/manageiq-operator:latest-jansa|g' deploy/operator.yaml
 ```
 
 3. Push the new image to the registry:

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq-operator.v0.0.1.clusterserviceversion.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq-operator.v0.0.1.clusterserviceversion.yaml
@@ -57,7 +57,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: manageiq-operator
-                image: docker.io/manageiq/manageiq-operator:v0.0.1
+                image: docker.io/manageiq/manageiq-operator:latest-jansa
                 imagePullPolicy: Always
                 name: manageiq-operator
                 resources:

--- a/manageiq-operator/deploy/operator.yaml
+++ b/manageiq-operator/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: manageiq-operator
       containers:
         - name: manageiq-operator
-          image: docker.io/manageiq/manageiq-operator:v0.0.1
+          image: docker.io/manageiq/manageiq-operator:latest-jansa
           command:
           - manageiq-operator
           imagePullPolicy: Always


### PR DESCRIPTION
Pull always since we're using the latest tag which is not static

Based on https://github.com/ManageIQ/manageiq-pods/pull/546#issuecomment-645419573