### PR TITLE
Add controller reference to PG objects

### DIFF
--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -250,7 +250,7 @@ func (r *ReconcileManageIQ) generatePostgresqlResources(cr *miqv1alpha1.ManageIQ
 		logger.Info("Service has been reconciled", "component", "postgresql", "result", result)
 	}
 
-	service, mutateFunc := miqtool.PostgresqlService(cr)
+	service, mutateFunc := miqtool.PostgresqlService(cr, r.scheme)
 	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, service, mutateFunc); err != nil {
 		return err
 	} else {

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -236,28 +236,28 @@ func (r *ReconcileManageIQ) generatePostgresqlResources(cr *miqv1alpha1.ManageIQ
 		return err
 	}
 
-	configMap, mutateFunc := miqtool.NewPostgresqlConfigsConfigMap(cr)
+	configMap, mutateFunc := miqtool.PostgresqlConfigMap(cr)
 	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, configMap, mutateFunc); err != nil {
 		return err
 	} else {
 		logger.Info("ConfigMap has been reconciled", "component", "postgresql", "result", result)
 	}
 
-	pvc, mutateFunc := miqtool.NewPostgresqlPVC(cr)
+	pvc, mutateFunc := miqtool.PostgresqlPVC(cr)
 	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, pvc, mutateFunc); err != nil {
 		return err
 	} else {
 		logger.Info("Service has been reconciled", "component", "postgresql", "result", result)
 	}
 
-	service, mutateFunc := miqtool.NewPostgresqlService(cr)
+	service, mutateFunc := miqtool.PostgresqlService(cr)
 	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, service, mutateFunc); err != nil {
 		return err
 	} else {
 		logger.Info("Service has been reconciled", "component", "postgresql", "result", result)
 	}
 
-	deployment, mutateFunc, err := miqtool.NewPostgresqlDeployment(cr, r.scheme)
+	deployment, mutateFunc, err := miqtool.PostgresqlDeployment(cr, r.scheme)
 	if err != nil {
 		return err
 	}

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -243,7 +243,7 @@ func (r *ReconcileManageIQ) generatePostgresqlResources(cr *miqv1alpha1.ManageIQ
 		logger.Info("ConfigMap has been reconciled", "component", "postgresql", "result", result)
 	}
 
-	pvc, mutateFunc := miqtool.PostgresqlPVC(cr)
+	pvc, mutateFunc := miqtool.PostgresqlPVC(cr, r.scheme)
 	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, pvc, mutateFunc); err != nil {
 		return err
 	} else {

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -236,7 +236,7 @@ func (r *ReconcileManageIQ) generatePostgresqlResources(cr *miqv1alpha1.ManageIQ
 		return err
 	}
 
-	configMap, mutateFunc := miqtool.PostgresqlConfigMap(cr)
+	configMap, mutateFunc := miqtool.PostgresqlConfigMap(cr, r.scheme)
 	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, configMap, mutateFunc); err != nil {
 		return err
 	} else {

--- a/manageiq-operator/pkg/helpers/miq-components/memcached.go
+++ b/manageiq-operator/pkg/helpers/miq-components/memcached.go
@@ -85,10 +85,7 @@ func NewMemcachedDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*
 		if err := controllerutil.SetControllerReference(cr, deployment, scheme); err != nil {
 			return err
 		}
-		if deployment.ObjectMeta.Labels == nil {
-			deployment.ObjectMeta.Labels = make(map[string]string)
-		}
-		deployment.ObjectMeta.Labels["app"] = cr.Spec.AppName
+		addAppLabel(cr.Spec.AppName, &deployment.ObjectMeta)
 		var repNum int32 = 1
 		deployment.Spec.Replicas = &repNum
 		deployment.Spec.Template.Spec.Containers = []corev1.Container{container}
@@ -110,10 +107,7 @@ func NewMemcachedService(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*cor
 		if err := controllerutil.SetControllerReference(cr, service, scheme); err != nil {
 			return err
 		}
-		if service.ObjectMeta.Labels == nil {
-			service.ObjectMeta.Labels = make(map[string]string)
-		}
-		service.ObjectMeta.Labels["app"] = cr.Spec.AppName
+		addAppLabel(cr.Spec.AppName, &service.ObjectMeta)
 		service.Spec.Ports = []corev1.ServicePort{
 			corev1.ServicePort{
 				Name: "memcached",

--- a/manageiq-operator/pkg/helpers/miq-components/postgresql.go
+++ b/manageiq-operator/pkg/helpers/miq-components/postgresql.go
@@ -219,10 +219,7 @@ func PostgresqlDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*ap
 		if err := controllerutil.SetControllerReference(cr, deployment, scheme); err != nil {
 			return err
 		}
-		if deployment.ObjectMeta.Labels == nil {
-			deployment.ObjectMeta.Labels = make(map[string]string)
-		}
-		deployment.ObjectMeta.Labels["app"] = cr.Spec.AppName
+		addAppLabel(cr.Spec.AppName, &deployment.ObjectMeta)
 		var repNum int32 = 1
 		deployment.Spec.Replicas = &repNum
 		deployment.Spec.Template.Spec.Containers = []corev1.Container{container}

--- a/manageiq-operator/pkg/helpers/miq-components/postgresql.go
+++ b/manageiq-operator/pkg/helpers/miq-components/postgresql.go
@@ -42,7 +42,7 @@ func postgresqlSecretName(cr *miqv1alpha1.ManageIQ) string {
 	return secretName
 }
 
-func NewPostgresqlConfigsConfigMap(cr *miqv1alpha1.ManageIQ) (*corev1.ConfigMap, controllerutil.MutateFn) {
+func PostgresqlConfigMap(cr *miqv1alpha1.ManageIQ) (*corev1.ConfigMap, controllerutil.MutateFn) {
 	labels := map[string]string{
 		"app": cr.Spec.AppName,
 	}
@@ -59,7 +59,7 @@ func NewPostgresqlConfigsConfigMap(cr *miqv1alpha1.ManageIQ) (*corev1.ConfigMap,
 	return configMap, configMapMutateFn(configMap, labels, data)
 }
 
-func NewPostgresqlPVC(cr *miqv1alpha1.ManageIQ) (*corev1.PersistentVolumeClaim, controllerutil.MutateFn) {
+func PostgresqlPVC(cr *miqv1alpha1.ManageIQ) (*corev1.PersistentVolumeClaim, controllerutil.MutateFn) {
 	labels := map[string]string{
 		"app": cr.Spec.AppName,
 	}
@@ -90,7 +90,7 @@ func NewPostgresqlPVC(cr *miqv1alpha1.ManageIQ) (*corev1.PersistentVolumeClaim, 
 	return pvc, pvcMutateFn(pvc, labels, accessModes, resources)
 }
 
-func NewPostgresqlService(cr *miqv1alpha1.ManageIQ) (*corev1.Service, controllerutil.MutateFn) {
+func PostgresqlService(cr *miqv1alpha1.ManageIQ) (*corev1.Service, controllerutil.MutateFn) {
 	labels := map[string]string{
 		"app": cr.Spec.AppName,
 	}
@@ -116,7 +116,7 @@ func NewPostgresqlService(cr *miqv1alpha1.ManageIQ) (*corev1.Service, controller
 	return service, serviceMutateFn(service, labels, ports, selector)
 }
 
-func NewPostgresqlDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*appsv1.Deployment, controllerutil.MutateFn, error) {
+func PostgresqlDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*appsv1.Deployment, controllerutil.MutateFn, error) {
 	deploymentLabels := map[string]string{
 		"name": "postgresql",
 		"app":  cr.Spec.AppName,

--- a/manageiq-operator/pkg/helpers/miq-components/util.go
+++ b/manageiq-operator/pkg/helpers/miq-components/util.go
@@ -73,15 +73,3 @@ func serviceMutateFn(service *corev1.Service, labels map[string]string, ports []
 
 	return mutateFn
 }
-
-func pvcMutateFn(pvc *corev1.PersistentVolumeClaim, labels map[string]string, accessModes []corev1.PersistentVolumeAccessMode, resources corev1.ResourceRequirements) controllerutil.MutateFn {
-
-	mutateFn := func() error {
-		pvc.ObjectMeta.Labels = labels
-		pvc.Spec.AccessModes = accessModes
-		pvc.Spec.Resources = resources
-		return nil
-	}
-
-	return mutateFn
-}

--- a/manageiq-operator/pkg/helpers/miq-components/util.go
+++ b/manageiq-operator/pkg/helpers/miq-components/util.go
@@ -4,7 +4,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func addResourceReqs(memLimit, memReq, cpuLimit, cpuReq string, c *corev1.Container) error {
@@ -60,16 +59,4 @@ func addAppLabel(appName string, meta *metav1.ObjectMeta) {
 		meta.Labels = make(map[string]string)
 	}
 	meta.Labels["app"] = appName
-}
-
-func serviceMutateFn(service *corev1.Service, labels map[string]string, ports []corev1.ServicePort, selector map[string]string) controllerutil.MutateFn {
-
-	mutateFn := func() error {
-		service.ObjectMeta.Labels = labels
-		service.Spec.Ports = ports
-		service.Spec.Selector = selector
-		return nil
-	}
-
-	return mutateFn
 }

--- a/manageiq-operator/pkg/helpers/miq-components/util.go
+++ b/manageiq-operator/pkg/helpers/miq-components/util.go
@@ -3,6 +3,7 @@ package miqtools
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -54,25 +55,19 @@ func addResourceReqs(memLimit, memReq, cpuLimit, cpuReq string, c *corev1.Contai
 	return nil
 }
 
+func addAppLabel(appName string, meta *metav1.ObjectMeta) {
+	if meta.Labels == nil {
+		meta.Labels = make(map[string]string)
+	}
+	meta.Labels["app"] = appName
+}
+
 func serviceMutateFn(service *corev1.Service, labels map[string]string, ports []corev1.ServicePort, selector map[string]string) controllerutil.MutateFn {
 
 	mutateFn := func() error {
 		service.ObjectMeta.Labels = labels
 		service.Spec.Ports = ports
 		service.Spec.Selector = selector
-		return nil
-	}
-
-	return mutateFn
-}
-
-func configMapMutateFn(configMap *corev1.ConfigMap, labels map[string]string, data map[string]string) controllerutil.MutateFn {
-
-	mutateFn := func() error {
-		configMap.ObjectMeta.Labels = labels
-		if len(data) > 0 {
-			configMap.Data = data
-		}
 		return nil
 	}
 


### PR DESCRIPTION
Primarily this PR adds the controller references that were missing from https://github.com/ManageIQ/manageiq-pods/pull/547

In addition it does some minor refactoring by renaming some functions and removing the generic mutate function generating functions in favor of smaller bits of shared logic (in this case around adding the app label).

Fixes #554