### PR TITLE
Add an override for the worker images deployed by the orchestrator

### DIFF
--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -38,6 +38,10 @@ spec:
               description: Domain name for the external route. Used for external authentication
                 configuration
               type: string
+            baseWorkerImage:
+              description: Image string used for the base worker deployments By default
+                this is determined by the orchestrator pod
+              type: string
             databaseRegion:
               description: 'Database region number (default: 0)'
               type: string
@@ -226,6 +230,14 @@ spec:
             tlsSecret:
               description: 'Secret containing the tls cert and key for the ingress,
                 content generated if not provided (default: tls-secret)'
+              type: string
+            uiWorkerImage:
+              description: Image string used for the UI worker deployments By default
+                this is determined by the orchestrator pod
+              type: string
+            webserverWorkerImage:
+              description: Image string used for the webserver worker deployments
+                By default this is determined by the orchestrator pod
               type: string
             zookeeperCpuRequest:
               description: 'Zookeeper deployment CPU request (default: no request)'

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -38,6 +38,10 @@ spec:
               description: Domain name for the external route. Used for external authentication
                 configuration
               type: string
+            baseWorkerImage:
+              description: Image string used for the base worker deployments By default
+                this is determined by the orchestrator pod
+              type: string
             databaseRegion:
               description: 'Database region number (default: 0)'
               type: string
@@ -226,6 +230,14 @@ spec:
             tlsSecret:
               description: 'Secret containing the tls cert and key for the ingress,
                 content generated if not provided (default: tls-secret)'
+              type: string
+            uiWorkerImage:
+              description: Image string used for the UI worker deployments By default
+                this is determined by the orchestrator pod
+              type: string
+            webserverWorkerImage:
+              description: Image string used for the webserver worker deployments
+                By default this is determined by the orchestrator pod
               type: string
             zookeeperCpuRequest:
               description: 'Zookeeper deployment CPU request (default: no request)'

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -157,6 +157,19 @@ type ManageIQSpec struct {
 	// +optional
 	OrchestratorMemoryRequest string `json:"orchestratorMemoryRequest"`
 
+	// Image string used for the base worker deployments
+	// By default this is determined by the orchestrator pod
+	// +optional
+	BaseWorkerImage string `json:"baseWorkerImage"`
+	// Image string used for the webserver worker deployments
+	// By default this is determined by the orchestrator pod
+	// +optional
+	WebserverWorkerImage string `json:"webserverWorkerImage"`
+	// Image string used for the UI worker deployments
+	// By default this is determined by the orchestrator pod
+	// +optional
+	UIWorkerImage string `json:"uiWorkerImage"`
+
 	// Image used for the postgresql deployment (Default: docker.io/manageiq/postgresql)
 	// +optional
 	PostgresqlImageName string `json:"postgresqlImageName"`


### PR DESCRIPTION
Previously a user was not able to change the actual image name for
the worker images nor were they able to deploy with anything other
than the namespace and tag deployed for the orchestrator.

This gives a bit more flexability in that one image can be replaced
at a time and also allows a user to specify an image ref with a
digest rather than a tag

Should be backported only if https://github.com/ManageIQ/manageiq/pull/20297 is backported.

Fixes #557 
cc @Fryguy 