### PR TITLE
Generate rpm manifest

### DIFF
--- a/images/manageiq-base-worker/Dockerfile
+++ b/images/manageiq-base-worker/Dockerfile
@@ -10,4 +10,6 @@ LABEL name="manageiq-base-worker" \
 COPY container-assets/entrypoint /usr/local/bin
 COPY container-assets/manageiq_liveness_check /usr/local/bin
 
+RUN source /etc/default/evm && /usr/bin/generate_rpm_manifest.sh
+
 CMD ["entrypoint"]

--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -72,4 +72,6 @@ ADD container-assets/container_env ${APP_ROOT}
 RUN curl -L -o /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_${ARCH} && \
     chmod +x /usr/bin/dumb-init
 
+RUN source /etc/default/evm && /usr/bin/generate_rpm_manifest.sh
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--single-child", "--"]

--- a/images/manageiq-orchestrator/Dockerfile
+++ b/images/manageiq-orchestrator/Dockerfile
@@ -9,4 +9,6 @@ LABEL name="manageiq-orchestrator" \
 
 COPY container-assets/entrypoint /usr/local/bin
 
+RUN source /etc/default/evm && /usr/bin/generate_rpm_manifest.sh
+
 CMD ["entrypoint"]

--- a/images/manageiq-ui-worker/Dockerfile
+++ b/images/manageiq-ui-worker/Dockerfile
@@ -16,4 +16,6 @@ RUN sed -i '/^Listen 80/d' /etc/httpd/conf/httpd.conf
 
 COPY container-assets/manageiq-http.conf /etc/httpd/conf.d
 
+RUN source /etc/default/evm && /usr/bin/generate_rpm_manifest.sh
+
 RUN rm -rf /tmp/rpms /create_local_yum_repo.sh /etc/yum.repos.d/local_rpm.repo

--- a/images/manageiq-webserver-worker/Dockerfile
+++ b/images/manageiq-webserver-worker/Dockerfile
@@ -11,4 +11,6 @@ LABEL name="manageiq-webserver-worker" \
 
 RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install ${RPM_PREFIX}-ui && dnf clean all
 
+RUN source /etc/default/evm && /usr/bin/generate_rpm_manifest.sh
+
 EXPOSE 3000


### PR DESCRIPTION
Requires https://github.com/ManageIQ/manageiq-appliance/pull/289 and https://github.com/ManageIQ/manageiq-rpm_build/pull/73 (and new rpm created with the changes)

Although creating rpm manifest is needed only in manageiq-base and manageiq-orchestrator right now, calling the script in all images, in case we add/remove rpms in other images in the future.

A part of https://github.com/ManageIQ/manageiq-appliance-build/pull/429