### PR TITLE
Fixed typo in the description for httpdAuthConfig

### DIFF
--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -65,7 +65,7 @@ spec:
               type: boolean
             httpdAuthConfig:
               description: Secret containing the httpd configuration files Mutually
-                exclusive with the OIDCCliencSecret and OIDCProviderURL if using openid-connect
+                exclusive with the OIDCClientSecret and OIDCProviderURL if using openid-connect
               type: string
             httpdAuthenticationType:
               description: 'Type of httpd authentication (default: internal) Options:

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -65,7 +65,7 @@ spec:
               type: boolean
             httpdAuthConfig:
               description: Secret containing the httpd configuration files Mutually
-                exclusive with the OIDCCliencSecret and OIDCProviderURL if using openid-connect
+                exclusive with the OIDCClientSecret and OIDCProviderURL if using openid-connect
               type: string
             httpdAuthenticationType:
               description: 'Type of httpd authentication (default: internal) Options:

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -78,7 +78,7 @@ type ManageIQSpec struct {
 	// +optional
 	OIDCClientSecret string `json:"oidcClientSecret"`
 	// Secret containing the httpd configuration files
-	// Mutually exclusive with the OIDCCliencSecret and OIDCProviderURL if using openid-connect
+	// Mutually exclusive with the OIDCClientSecret and OIDCProviderURL if using openid-connect
 	// +optional
 	HttpdAuthConfig string `json:"httpdAuthConfig"`
 	// Flag to enable SSO in the application (default: false)


### PR DESCRIPTION
- Fixed typo in the description for httpdAuthConfig, referencing OIDCCliencSecret, should be OIDCClientSecret.

/cc @carbonin, minor.