### PR TITLE
Use the CR's UID rather than generating a new one for the orchestrator

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
@@ -10,8 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"strconv"
 	"strings"
-
-	"github.com/google/uuid"
 )
 
 func OrchestratorServiceAccount(cr *miqv1alpha1.ManageIQ) *corev1.ServiceAccount {
@@ -192,7 +190,7 @@ func OrchestratorDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*
 			},
 			corev1.EnvVar{
 				Name:  "GUID",
-				Value: uuid.New().String(),
+				Value: string(cr.GetUID()),
 			},
 			corev1.EnvVar{
 				Name:  "DATABASE_REGION",


### PR DESCRIPTION
Since we only have one server, it should be static.
Also, prevent the reconcile from generating a new GUID on every run.

Fixes #573 