### PR TITLE
[JANSA] Enhancement to optionally fetch the OIDCAuthIntrospectionURL from the Provider

### DIFF
--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -169,7 +169,9 @@ spec:
               type: string
             oidcClientSecret:
               description: Secret name containing the OIDC client id and secret Only
-                used with the openid-connect authentication type
+                used with the openid-connect authentication type. If not specified,
+                the operator will attempt to fetch its value from the "token_introspection_endpoint"
+                field in the Provider metadata at the OIDCProviderURL provided.
               type: string
             oidcProviderURL:
               description: URL for the OIDC provider Only used with the openid-connect

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -169,7 +169,9 @@ spec:
               type: string
             oidcClientSecret:
               description: Secret name containing the OIDC client id and secret Only
-                used with the openid-connect authentication type
+                used with the openid-connect authentication type. If not specified,
+                the operator will attempt to fetch its value from the "token_introspection_endpoint"
+                field in the Provider metadata at the OIDCProviderURL provided.
               type: string
             oidcProviderURL:
               description: URL for the OIDC provider Only used with the openid-connect

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -411,9 +411,9 @@ func (m *ManageIQ) Validate() error {
 		if spec.HttpdAuthConfig != "" && (spec.OIDCProviderURL != "" || spec.OIDCOAuthIntrospectionURL != "" || spec.OIDCClientSecret != "") {
 			// Invalid if config and any other info is also provided
 			errs = append(errs, "OIDCProviderURL, OIDCOAuthIntrospectionURL, and OIDCClientSecret are invalid when HttpdAuthConfig is specified")
-		} else if spec.HttpdAuthConfig == "" && (spec.OIDCProviderURL == "" || spec.OIDCOAuthIntrospectionURL == "" || spec.OIDCClientSecret == "") {
+		} else if spec.HttpdAuthConfig == "" && (spec.OIDCProviderURL == "" || spec.OIDCClientSecret == "") {
 			// Need to provide either the entire config or a secret and provider url
-			errs = append(errs, "HttpdAuthConfig or all of OIDCProviderURL, OIDCOAuthIntrospectionURL, and OIDCClientSecret must be provided for openid-connect authentication")
+			errs = append(errs, "HttpdAuthConfig or both OIDCProviderURL and OIDCClientSecret must be provided for openid-connect authentication")
 		}
 	} else {
 		if spec.OIDCProviderURL != "" {

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -73,7 +73,10 @@ type ManageIQSpec struct {
 	// +optional
 	OIDCOAuthIntrospectionURL string `json:"oidcAuthIntrospectionURL"`
 	// Secret name containing the OIDC client id and secret
-	// Only used with the openid-connect authentication type
+	// Only used with the openid-connect authentication type.
+	// If not specified, the operator will attempt to fetch its value from the
+	// "token_introspection_endpoint" field in the Provider metadata at the
+	// OIDCProviderURL provided.
 	// +optional
 	OIDCClientSecret string `json:"oidcClientSecret"`
 	// Secret containing the httpd configuration files

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -153,7 +153,10 @@ func (r *ReconcileManageIQ) generateHttpdResources(cr *miqv1alpha1.ManageIQ) err
 		}
 	}
 
-	httpdConfigMap := miqtool.NewHttpdConfigMap(cr)
+	httpdConfigMap, err := miqtool.NewHttpdConfigMap(cr)
+	if err != nil {
+		return err
+	}
 	if err := r.createk8sResIfNotExist(cr, httpdConfigMap, &corev1.ConfigMap{}); err != nil {
 		return err
 	}

--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -68,7 +68,7 @@ func NewHttpdConfigMap(cr *miqv1alpha1.ManageIQ) (*corev1.ConfigMap, error) {
 		if err != nil {
 			return nil, err
 		}
-		(&cr.Spec).OIDCOAuthIntrospectionURL = introspectionURL
+		cr.Spec.OIDCOAuthIntrospectionURL = introspectionURL
 	}
 
 	data := map[string]string{
@@ -76,14 +76,16 @@ func NewHttpdConfigMap(cr *miqv1alpha1.ManageIQ) (*corev1.ConfigMap, error) {
 		"authentication.conf": httpdAuthenticationConf(&cr.Spec),
 	}
 
-	return &corev1.ConfigMap{
+	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "httpd-configs",
 			Namespace: cr.ObjectMeta.Namespace,
 			Labels:    labels,
 		},
 		Data: data,
-	}, nil
+	}
+
+	return configMap, nil
 }
 
 func NewHttpdAuthConfigMap(cr *miqv1alpha1.ManageIQ) *corev1.ConfigMap {
@@ -531,7 +533,7 @@ func fetchIntrospectionUrl(providerUrl string) (string, error) {
 	}
 
 	if result["token_introspection_endpoint"] == nil {
-		return "", fmt.Errorf("%s - token_introspection_endpoint is missing", errMsg)
+		return "", fmt.Errorf("%s - token_introspection_endpoint is missing from the Provider metadata", errMsg)
 	}
 
 	return result["token_introspection_endpoint"].(string), nil


### PR DESCRIPTION
Enhancement to optionally fetch the OIDCAuthIntrospectionURL from the Provider Metadata URL if not provided to us.

Jansa backport of #571 