### PR TITLE
[JANSA] We should default to jansa, not master

### DIFF
--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -359,7 +359,7 @@ func (m *ManageIQ) Initialize() {
 	}
 
 	if spec.OrchestratorImageTag == "" {
-		spec.OrchestratorImageTag = "latest"
+		spec.OrchestratorImageTag = "latest-jansa"
 	}
 
 	if spec.OrchestratorInitialDelay == "" {


### PR DESCRIPTION
I guess we should default to `jansa-latest` here.  Not sure if we should change to a release tag at some point.  @simaishi @Fryguy @abellotti thoughts?

I noticed this yesterday while smoke testing jansa-1-rc1.