### PR TITLE
Use standard token introspection endpoint

### DIFF
--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -161,7 +161,7 @@ spec:
             oidcAuthIntrospectionURL:
               description: URL for OIDC authentication introspection Only used with
                 the openid-connect authentication type. If not specified, the operator
-                will attempt to fetch its value from the "token_introspection_endpoint"
+                will attempt to fetch its value from the "introspection_endpoint"
                 field in the Provider metadata at the OIDCProviderURL provided.
               type: string
             oidcCaCertSecret:

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -161,7 +161,7 @@ spec:
             oidcAuthIntrospectionURL:
               description: URL for OIDC authentication introspection Only used with
                 the openid-connect authentication type. If not specified, the operator
-                will attempt to fetch its value from the "token_introspection_endpoint"
+                will attempt to fetch its value from the "introspection_endpoint"
                 field in the Provider metadata at the OIDCProviderURL provided.
               type: string
             oidcCaCertSecret:

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -76,7 +76,7 @@ type ManageIQSpec struct {
 	// URL for OIDC authentication introspection
 	// Only used with the openid-connect authentication type.
 	// If not specified, the operator will attempt to fetch its value from the
-	// "token_introspection_endpoint" field in the Provider metadata at the
+	// "introspection_endpoint" field in the Provider metadata at the
 	// OIDCProviderURL provided.
 	// +optional
 	OIDCOAuthIntrospectionURL string `json:"oidcAuthIntrospectionURL"`

--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -568,9 +568,9 @@ func fetchIntrospectionUrl(providerUrl string) (string, error) {
 		return "", fmt.Errorf("%s - %s", errMsg, err)
 	}
 
-	if result["token_introspection_endpoint"] == nil {
-		return "", fmt.Errorf("%s - token_introspection_endpoint is missing from the Provider metadata", errMsg)
+	if result["introspection_endpoint"] == nil {
+		return "", fmt.Errorf("%s - introspection_endpoint is missing from the Provider metadata", errMsg)
 	}
 
-	return result["token_introspection_endpoint"].(string), nil
+	return result["introspection_endpoint"].(string), nil
 }


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-pods/issues/605

**Issue Description:**

The code currently uses the Non-standard token introspection endpoint, token_introspection_endpoint.
The standard on is: introspection_endpoint

Fixes https://github.com/ManageIQ/manageiq-pods/issues/605

@miq-bot add-label bug
