### PR TITLE
[JANSA] Fix oidcAuthIntrospectionURL/oidcClientSecret description

### DIFF
--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -160,7 +160,9 @@ spec:
               type: string
             oidcAuthIntrospectionURL:
               description: URL for OIDC authentication introspection Only used with
-                the openid-connect authentication type
+                the openid-connect authentication type. If not specified, the operator
+                will attempt to fetch its value from the "token_introspection_endpoint"
+                field in the Provider metadata at the OIDCProviderURL provided.
               type: string
             oidcCaCertSecret:
               description: Secret containing the trusted CA certificate file(s) for
@@ -169,9 +171,7 @@ spec:
               type: string
             oidcClientSecret:
               description: Secret name containing the OIDC client id and secret Only
-                used with the openid-connect authentication type. If not specified,
-                the operator will attempt to fetch its value from the "token_introspection_endpoint"
-                field in the Provider metadata at the OIDCProviderURL provided.
+                used with the openid-connect authentication type
               type: string
             oidcProviderURL:
               description: URL for the OIDC provider Only used with the openid-connect

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -160,7 +160,9 @@ spec:
               type: string
             oidcAuthIntrospectionURL:
               description: URL for OIDC authentication introspection Only used with
-                the openid-connect authentication type
+                the openid-connect authentication type. If not specified, the operator
+                will attempt to fetch its value from the "token_introspection_endpoint"
+                field in the Provider metadata at the OIDCProviderURL provided.
               type: string
             oidcCaCertSecret:
               description: Secret containing the trusted CA certificate file(s) for
@@ -169,9 +171,7 @@ spec:
               type: string
             oidcClientSecret:
               description: Secret name containing the OIDC client id and secret Only
-                used with the openid-connect authentication type. If not specified,
-                the operator will attempt to fetch its value from the "token_introspection_endpoint"
-                field in the Provider metadata at the OIDCProviderURL provided.
+                used with the openid-connect authentication type
               type: string
             oidcProviderURL:
               description: URL for the OIDC provider Only used with the openid-connect

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -74,14 +74,14 @@ type ManageIQSpec struct {
 	// +optional
 	OIDCCACertSecret string `json:"oidcCaCertSecret"`
 	// URL for OIDC authentication introspection
-	// Only used with the openid-connect authentication type
-	// +optional
-	OIDCOAuthIntrospectionURL string `json:"oidcAuthIntrospectionURL"`
-	// Secret name containing the OIDC client id and secret
 	// Only used with the openid-connect authentication type.
 	// If not specified, the operator will attempt to fetch its value from the
 	// "token_introspection_endpoint" field in the Provider metadata at the
 	// OIDCProviderURL provided.
+	// +optional
+	OIDCOAuthIntrospectionURL string `json:"oidcAuthIntrospectionURL"`
+	// Secret name containing the OIDC client id and secret
+	// Only used with the openid-connect authentication type
 	// +optional
 	OIDCClientSecret string `json:"oidcClientSecret"`
 	// Secret containing the httpd configuration files


### PR DESCRIPTION
Follow up for https://github.com/ManageIQ/manageiq-pods/pull/582 (backport of https://github.com/ManageIQ/manageiq-pods/pull/571) - looks like that PR added description to wrong variables.