### PR TITLE
Add OIDCCacheShmEntrySizeMax parameter

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
@@ -240,6 +240,7 @@ OIDCClientSecret             ${HTTPD_AUTH_OIDC_CLIENT_SECRET}
 OIDCRedirectURI              "https://%s/oidc_login/redirect_uri"
 OIDCCryptoPassphrase         sp-secret
 OIDCOAuthRemoteUserClaim     username
+OIDCCacheShmEntrySizeMax     65536
 
 OIDCOAuthClientID                  ${HTTPD_AUTH_OIDC_CLIENT_ID}
 OIDCOAuthClientSecret              ${HTTPD_AUTH_OIDC_CLIENT_SECRET}


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq/issues/20511

This PR helps to ensure OIDC Cache is not undersized for most installations by increasing OIDCCacheShmEntrySizeMax from the default of 16913 bytes to 65536.
