### PR TITLE
Add velero-backup label to important resources that need to be backed up

### DIFF
--- a/manageiq-operator/README.md
+++ b/manageiq-operator/README.md
@@ -199,3 +199,29 @@ spec:
   ...
   oidcCaCertSecret: <name of your openshift OIDC CA cert>
 ```
+
+### Backup and restore with Velero and Restic
+
+We will assume that Velero and Restic are already installed and working.
+The operator adds labels and/or annotations to everything that needs to be backed up so that anyone can easily and quickly backup only what is required.
+The operator will add annotations for restic volume backups i.e. `backup.velero.io/backup-volumes: miq-pgdb-volume`.
+The backup label key can be configured by adding the following to the CR, but by default it will apply the label `manageiq.org/backup=t` if nothing else is specified.
+
+```yaml
+...
+spec:
+  ...
+  backupLabelName: <name of your openshift OIDC CA cert> (default: manageiq.org/backup)
+```
+
+Creating a backup is as simple as:
+```bash
+velero backup create <your backup name> --include-namespaces <your namespace> -l manageiq.org/backup=t
+```
+
+Restoring the backup is as simple as:
+- Ensure the ManageIQ CRD already exists
+```bash
+oc new-project <your namespace>
+velero restore create --from-backup <your backup name>
+```

--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -38,6 +38,10 @@ spec:
               description: Domain name for the external route. Used for external authentication
                 configuration
               type: string
+            backupLabelName:
+              description: 'This label will be applied to essential resources that
+                need to be backed up (default: manageiq.org/backup)'
+              type: string
             baseWorkerImage:
               description: Image string used for the base worker deployments By default
                 this is determined by the orchestrator pod

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -38,6 +38,10 @@ spec:
               description: Domain name for the external route. Used for external authentication
                 configuration
               type: string
+            backupLabelName:
+              description: 'This label will be applied to essential resources that
+                need to be backed up (default: manageiq.org/backup)'
+              type: string
             baseWorkerImage:
               description: Image string used for the base worker deployments By default
                 this is determined by the orchestrator pod

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -19,6 +19,10 @@ type ManageIQSpec struct {
 	// Domain name for the external route. Used for external authentication configuration
 	ApplicationDomain string `json:"applicationDomain"`
 
+	// This label will be applied to essential resources that need to be backed up (default: manageiq.org/backup)
+	// +optional
+	BackupLabelName string `json:"backupLabelName"`
+
 	// Database region number (default: 0)
 	// +optional
 	DatabaseRegion string `json:"databaseRegion"`

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -489,6 +489,13 @@ func (r *ReconcileManageIQ) manageOperator(cr *miqv1alpha1.ManageIQ) error {
 		logger.Info("Operator has been reconciled", "component", "app", "result", result)
 	}
 
+	serviceAccount, mutateFunc := miqtool.ManageOperatorServiceAccount(cr, r.client)
+	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, serviceAccount, mutateFunc); err != nil {
+		return err
+	} else if result != controllerutil.OperationResultNone {
+		logger.Info("Service Account has been reconciled", "component", "operator", "result", result)
+	}
+
 	return nil
 }
 

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -440,6 +440,15 @@ func (r *ReconcileManageIQ) generateSecrets(cr *miqv1alpha1.ManageIQ) error {
 		return err
 	}
 
+	if cr.Spec.ImagePullSecret != "" {
+		imagePullSecret, mutateFunc := miqtool.ImagePullSecret(cr, r.client)
+		if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, imagePullSecret, mutateFunc); err != nil {
+			return err
+		} else if result != controllerutil.OperationResultNone {
+			logger.Info("Image Pull Secret has been reconciled", "component", "operator", "result", result)
+		}
+	}
+
 	return nil
 }
 

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -496,6 +496,20 @@ func (r *ReconcileManageIQ) manageOperator(cr *miqv1alpha1.ManageIQ) error {
 		logger.Info("Service Account has been reconciled", "component", "operator", "result", result)
 	}
 
+	role, mutateFunc := miqtool.ManageOperatorRole(cr, r.client)
+	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, role, mutateFunc); err != nil {
+		return err
+	} else if result != controllerutil.OperationResultNone {
+		logger.Info("Role has been reconciled", "component", "operator", "result", result)
+	}
+
+	roleBinding, mutateFunc := miqtool.ManageOperatorRoleBinding(cr, r.client)
+	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, roleBinding, mutateFunc); err != nil {
+		return err
+	} else if result != controllerutil.OperationResultNone {
+		logger.Info("Role Binding has been reconciled", "component", "operator", "result", result)
+	}
+
 	return nil
 }
 

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -449,6 +449,24 @@ func (r *ReconcileManageIQ) generateSecrets(cr *miqv1alpha1.ManageIQ) error {
 		}
 	}
 
+	if cr.Spec.HttpdAuthenticationType == "openid-connect" {
+		oidcClientSecret, mutateFunc := miqtool.OidcClientSecret(cr, r.client)
+		if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, oidcClientSecret, mutateFunc); err != nil {
+			return err
+		} else if result != controllerutil.OperationResultNone {
+			logger.Info("OIDC Client Secret has been reconciled", "component", "operator", "result", result)
+		}
+
+		if cr.Spec.OIDCCACertSecret != "" {
+			oidcCaCertSecret, mutateFunc := miqtool.OidcCaCertSecret(cr, r.client)
+			if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, oidcCaCertSecret, mutateFunc); err != nil {
+				return err
+			} else if result != controllerutil.OperationResultNone {
+				logger.Info("OIDC CA Secret has been reconciled", "component", "operator", "result", result)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/manageiq-operator/pkg/helpers/miq-components/app-secret.go
+++ b/manageiq-operator/pkg/helpers/miq-components/app-secret.go
@@ -7,19 +7,20 @@ import (
 )
 
 func AppSecret(cr *miqv1alpha1.ManageIQ) *corev1.Secret {
-
-	labels := map[string]string{
-		"app": cr.Spec.AppName,
-	}
-	secret := map[string]string{
+	secretData := map[string]string{
 		"encryption-key": generateEncryptionKey(),
 	}
-	return &corev1.Secret{
+
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "app-secrets",
 			Namespace: cr.ObjectMeta.Namespace,
-			Labels:    labels,
 		},
-		StringData: secret,
+		StringData: secretData,
 	}
+
+	addAppLabel(cr.Spec.AppName, &secret.ObjectMeta)
+	addBackupLabel(cr.Spec.BackupLabelName, &secret.ObjectMeta)
+
+	return secret
 }

--- a/manageiq-operator/pkg/helpers/miq-components/cr.go
+++ b/manageiq-operator/pkg/helpers/miq-components/cr.go
@@ -292,6 +292,8 @@ func ManageCR(cr *miqv1alpha1.ManageIQ) (*miqv1alpha1.ManageIQ, controllerutil.M
 		cr.Spec.ZookeeperImageTag = zookeeperImageTag(cr)
 		cr.Spec.ZookeeperVolumeCapacity = zookeeperVolumeCapacity(cr)
 
+		addBackupLabel(backupLabelName(cr), &cr.ObjectMeta)
+
 		return nil
 	}
 

--- a/manageiq-operator/pkg/helpers/miq-components/cr.go
+++ b/manageiq-operator/pkg/helpers/miq-components/cr.go
@@ -13,6 +13,14 @@ func appName(cr *miqv1alpha1.ManageIQ) string {
 	}
 }
 
+func backupLabelName(cr *miqv1alpha1.ManageIQ) string {
+	if cr.Spec.BackupLabelName == "" {
+		return "manageiq.org/backup"
+	} else {
+		return cr.Spec.BackupLabelName
+	}
+}
+
 func enableApplicationLocalLogin(cr *miqv1alpha1.ManageIQ) bool {
 	if cr.Spec.EnableApplicationLocalLogin == nil {
 		return true
@@ -253,6 +261,7 @@ func ManageCR(cr *miqv1alpha1.ManageIQ) (*miqv1alpha1.ManageIQ, controllerutil.M
 		varEnforceWorkerResourceConstraints := enforceWorkerResourceConstraints(cr)
 
 		cr.Spec.AppName = appName(cr)
+		cr.Spec.BackupLabelName = backupLabelName(cr)
 		cr.Spec.DatabaseRegion = databaseRegion(cr)
 		cr.Spec.DatabaseVolumeCapacity = databaseVolumeCapacity(cr)
 		cr.Spec.DeployMessagingService = &varDeployMessagingService

--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -134,6 +134,7 @@ func HttpdAuthConfigMap(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*core
 			return err
 		}
 		addAppLabel(cr.Spec.AppName, &configMap.ObjectMeta)
+		addBackupLabel(cr.Spec.BackupLabelName, &configMap.ObjectMeta)
 		configMap.Data = data
 		return nil
 	}
@@ -512,28 +513,28 @@ func HttpdDbusAPIService(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*cor
 }
 
 func TLSSecret(cr *miqv1alpha1.ManageIQ) (*corev1.Secret, error) {
-	labels := map[string]string{
-		"app": cr.Spec.AppName,
-	}
-
 	crt, key, err := tlstools.GenerateCrt("server")
 	if err != nil {
 		return nil, err
 	}
 
-	data := map[string]string{
+	secretData := map[string]string{
 		"tls.crt": string(crt),
 		"tls.key": string(key),
 	}
+
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      tlsSecretName(cr),
 			Namespace: cr.ObjectMeta.Namespace,
-			Labels:    labels,
 		},
-		StringData: data,
+		StringData: secretData,
 		Type:       "kubernetes.io/tls",
 	}
+
+	addAppLabel(cr.Spec.AppName, &secret.ObjectMeta)
+	addBackupLabel(cr.Spec.BackupLabelName, &secret.ObjectMeta)
+
 	return secret, nil
 }
 

--- a/manageiq-operator/pkg/helpers/miq-components/kafka.go
+++ b/manageiq-operator/pkg/helpers/miq-components/kafka.go
@@ -11,23 +11,24 @@ import (
 )
 
 func DefaultKafkaSecret(cr *miqv1alpha1.ManageIQ) *corev1.Secret {
-	labels := map[string]string{
-		"app": cr.Spec.AppName,
-	}
-	secret := map[string]string{
+	secretData := map[string]string{
 		"username": "root",
 		"password": generatePassword(),
 		"hostname": "kafka",
 	}
 
-	return &corev1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kafkaSecretName(cr),
 			Namespace: cr.ObjectMeta.Namespace,
-			Labels:    labels,
 		},
-		StringData: secret,
+		StringData: secretData,
 	}
+
+	addAppLabel(cr.Spec.AppName, &secret.ObjectMeta)
+	addBackupLabel(cr.Spec.BackupLabelName, &secret.ObjectMeta)
+
+	return secret
 }
 
 func kafkaSecretName(cr *miqv1alpha1.ManageIQ) string {
@@ -245,6 +246,8 @@ func KafkaDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*appsv1.
 		}
 		addAppLabel(cr.Spec.AppName, &deployment.ObjectMeta)
 		addBackupAnnotation("kafka-data", &deployment.Spec.Template.ObjectMeta)
+		addBackupLabel(cr.Spec.BackupLabelName, &deployment.ObjectMeta)
+		addBackupLabel(cr.Spec.BackupLabelName, &deployment.Spec.Template.ObjectMeta)
 		var repNum int32 = 1
 		deployment.Spec.Replicas = &repNum
 		deployment.Spec.Template.Spec.Containers = []corev1.Container{container}
@@ -323,6 +326,8 @@ func ZookeeperDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*app
 		}
 		addAppLabel(cr.Spec.AppName, &deployment.ObjectMeta)
 		addBackupAnnotation("zookeeper-data", &deployment.Spec.Template.ObjectMeta)
+		addBackupLabel(cr.Spec.BackupLabelName, &deployment.ObjectMeta)
+		addBackupLabel(cr.Spec.BackupLabelName, &deployment.Spec.Template.ObjectMeta)
 		var repNum int32 = 1
 		deployment.Spec.Replicas = &repNum
 		deployment.Spec.Template.Spec.Containers = []corev1.Container{container}

--- a/manageiq-operator/pkg/helpers/miq-components/operator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/operator.go
@@ -12,20 +12,7 @@ import (
 )
 
 func ManageOperator(cr *miqv1alpha1.ManageIQ, client client.Client) (*appsv1.Deployment, controllerutil.MutateFn) {
-	operatorPodName := os.Getenv("POD_NAME")
-	podKey := types.NamespacedName{Namespace: cr.Namespace, Name: operatorPodName}
-	pod := &corev1.Pod{}
-	client.Get(context.TODO(), podKey, pod)
-
-	operatorReplicaSetName := pod.ObjectMeta.OwnerReferences[0].Name
-	replicaSetKey := types.NamespacedName{Namespace: cr.Namespace, Name: operatorReplicaSetName}
-	replicaSet := &appsv1.ReplicaSet{}
-	client.Get(context.TODO(), replicaSetKey, replicaSet)
-
-	operatorDeploymentName := replicaSet.ObjectMeta.OwnerReferences[0].Name
-	deploymentKey := types.NamespacedName{Namespace: cr.Namespace, Name: operatorDeploymentName}
-	deployment := &appsv1.Deployment{}
-	client.Get(context.TODO(), deploymentKey, deployment)
+	deployment := operatorDeployment(cr, client)
 
 	f := func() error {
 		addBackupLabel(cr.Spec.BackupLabelName, &deployment.ObjectMeta)
@@ -76,4 +63,33 @@ func OidcCaCertSecret(cr *miqv1alpha1.ManageIQ, client client.Client) (*corev1.S
 	}
 
 	return secret, f
+}
+
+func operatorPod(cr *miqv1alpha1.ManageIQ, client client.Client) *corev1.Pod {
+	operatorPodName := os.Getenv("POD_NAME")
+	podKey := types.NamespacedName{Namespace: cr.Namespace, Name: operatorPodName}
+	pod := &corev1.Pod{}
+	client.Get(context.TODO(), podKey, pod)
+
+	return pod
+}
+
+func operatorReplicaSet(cr *miqv1alpha1.ManageIQ, client client.Client) *appsv1.ReplicaSet {
+	pod := operatorPod(cr, client)
+	operatorReplicaSetName := pod.ObjectMeta.OwnerReferences[0].Name
+	replicaSetKey := types.NamespacedName{Namespace: cr.Namespace, Name: operatorReplicaSetName}
+	replicaSet := &appsv1.ReplicaSet{}
+	client.Get(context.TODO(), replicaSetKey, replicaSet)
+
+	return replicaSet
+}
+
+func operatorDeployment(cr *miqv1alpha1.ManageIQ, client client.Client) *appsv1.Deployment {
+	replicaSet := operatorReplicaSet(cr, client)
+	operatorDeploymentName := replicaSet.ObjectMeta.OwnerReferences[0].Name
+	deploymentKey := types.NamespacedName{Namespace: cr.Namespace, Name: operatorDeploymentName}
+	deployment := &appsv1.Deployment{}
+	client.Get(context.TODO(), deploymentKey, deployment)
+
+	return deployment
 }

--- a/manageiq-operator/pkg/helpers/miq-components/operator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/operator.go
@@ -49,3 +49,31 @@ func ImagePullSecret(cr *miqv1alpha1.ManageIQ, client client.Client) (*corev1.Se
 
 	return secret, f
 }
+
+func OidcClientSecret(cr *miqv1alpha1.ManageIQ, client client.Client) (*corev1.Secret, controllerutil.MutateFn) {
+	secretKey := types.NamespacedName{Namespace: cr.Namespace, Name: cr.Spec.OIDCClientSecret}
+	secret := &corev1.Secret{}
+	client.Get(context.TODO(), secretKey, secret)
+
+	f := func() error {
+		addBackupLabel(cr.Spec.BackupLabelName, &secret.ObjectMeta)
+
+		return nil
+	}
+
+	return secret, f
+}
+
+func OidcCaCertSecret(cr *miqv1alpha1.ManageIQ, client client.Client) (*corev1.Secret, controllerutil.MutateFn) {
+	secretKey := types.NamespacedName{Namespace: cr.Namespace, Name: cr.Spec.OIDCCACertSecret}
+	secret := &corev1.Secret{}
+	client.Get(context.TODO(), secretKey, secret)
+
+	f := func() error {
+		addBackupLabel(cr.Spec.BackupLabelName, &secret.ObjectMeta)
+
+		return nil
+	}
+
+	return secret, f
+}

--- a/manageiq-operator/pkg/helpers/miq-components/operator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/operator.go
@@ -35,3 +35,17 @@ func ManageOperator(cr *miqv1alpha1.ManageIQ, client client.Client) (*appsv1.Dep
 
 	return deployment, f
 }
+
+func ImagePullSecret(cr *miqv1alpha1.ManageIQ, client client.Client) (*corev1.Secret, controllerutil.MutateFn) {
+	secretKey := types.NamespacedName{Namespace: cr.Namespace, Name: cr.Spec.ImagePullSecret}
+	secret := &corev1.Secret{}
+	client.Get(context.TODO(), secretKey, secret)
+
+	f := func() error {
+		addBackupLabel(cr.Spec.BackupLabelName, &secret.ObjectMeta)
+
+		return nil
+	}
+
+	return secret, f
+}

--- a/manageiq-operator/pkg/helpers/miq-components/operator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/operator.go
@@ -1,0 +1,37 @@
+package miqtools
+
+import (
+	"context"
+	miqv1alpha1 "github.com/ManageIQ/manageiq-pods/manageiq-operator/pkg/apis/manageiq/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"os"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func ManageOperator(cr *miqv1alpha1.ManageIQ, client client.Client) (*appsv1.Deployment, controllerutil.MutateFn) {
+	operatorPodName := os.Getenv("POD_NAME")
+	podKey := types.NamespacedName{Namespace: cr.Namespace, Name: operatorPodName}
+	pod := &corev1.Pod{}
+	client.Get(context.TODO(), podKey, pod)
+
+	operatorReplicaSetName := pod.ObjectMeta.OwnerReferences[0].Name
+	replicaSetKey := types.NamespacedName{Namespace: cr.Namespace, Name: operatorReplicaSetName}
+	replicaSet := &appsv1.ReplicaSet{}
+	client.Get(context.TODO(), replicaSetKey, replicaSet)
+
+	operatorDeploymentName := replicaSet.ObjectMeta.OwnerReferences[0].Name
+	deploymentKey := types.NamespacedName{Namespace: cr.Namespace, Name: operatorDeploymentName}
+	deployment := &appsv1.Deployment{}
+	client.Get(context.TODO(), deploymentKey, deployment)
+
+	f := func() error {
+		addBackupLabel(cr.Spec.BackupLabelName, &deployment.ObjectMeta)
+
+		return nil
+	}
+
+	return deployment, f
+}

--- a/manageiq-operator/pkg/helpers/miq-components/rbac.go
+++ b/manageiq-operator/pkg/helpers/miq-components/rbac.go
@@ -44,6 +44,8 @@ func DefaultServiceAccount(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*c
 			addSAPullSecret(sa, cr.Spec.ImagePullSecret)
 		}
 
+		addBackupLabel(cr.Spec.BackupLabelName, &sa.ObjectMeta)
+
 		return nil
 	}
 

--- a/manageiq-operator/pkg/helpers/miq-components/util.go
+++ b/manageiq-operator/pkg/helpers/miq-components/util.go
@@ -61,6 +61,13 @@ func addAppLabel(appName string, meta *metav1.ObjectMeta) {
 	meta.Labels["app"] = appName
 }
 
+func addBackupLabel(backupLabel string, meta *metav1.ObjectMeta) {
+	if meta.Labels == nil {
+		meta.Labels = make(map[string]string)
+	}
+	meta.Labels[backupLabel] = "t"
+}
+
 func addBackupAnnotation(volumesToBackup string, meta *metav1.ObjectMeta) {
 	if meta.Annotations == nil {
 		meta.Annotations = make(map[string]string)


### PR DESCRIPTION
Depends On:
- [x] https://github.com/ManageIQ/manageiq-pods/pull/628
- [x] https://github.com/ManageIQ/manageiq-pods/pull/634

This allows us to simplify the listing the resources that need backing up.
`velero backup create my_backup_name -l velero-backup=t`

WIP because I need to add some logic to ensure that the label exists on some objects that we expect the deployer to create, but I wanted to consolidate the label naming discussion here.

Naming:
- Start the label name with something like `miq-` or `manageiq.org/` causes some problems for productization.
- Other apps in our namespace could use the same label if it's not namespaced.


Items that need to be backed up:

- Secrets from keys in the CR:
  - [X] databaseSecret (default: postgresql-secrets)
  - [X] httpdAuthConfig
  - [x] imagePullSecret
  - [X] kafkaSecret (default: kafka-secrets)
  - [x] oidcCaCertSecret
  - [x] oidcClientSecret
  - [X] tlsSecret (default: tls-secret)

- PVCs:
  - [X] postgresql
  - [X] kafka-data (if present)
  - [X] zookeeper-data (if present)

- Other objects:
  - [X] secrets/app-secrets
  - [x] role/manageiq-operator
  - [x] role_binding/manageiq-operator
  - [x] service_account/manageiq-operator
  - [ ] ~~crd/manageiqs.manageiq.org~~
  - [x] CR
  - [x] deployment.apps/manageiq-operator