### PR TITLE
Add backup annotations for velero

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/kafka.go
+++ b/manageiq-operator/pkg/helpers/miq-components/kafka.go
@@ -244,6 +244,7 @@ func KafkaDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*appsv1.
 			return err
 		}
 		addAppLabel(cr.Spec.AppName, &deployment.ObjectMeta)
+		addBackupAnnotation("kafka-data", &deployment.Spec.Template.ObjectMeta)
 		var repNum int32 = 1
 		deployment.Spec.Replicas = &repNum
 		deployment.Spec.Template.Spec.Containers = []corev1.Container{container}
@@ -321,6 +322,7 @@ func ZookeeperDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*app
 			return err
 		}
 		addAppLabel(cr.Spec.AppName, &deployment.ObjectMeta)
+		addBackupAnnotation("zookeeper-data", &deployment.Spec.Template.ObjectMeta)
 		var repNum int32 = 1
 		deployment.Spec.Replicas = &repNum
 		deployment.Spec.Template.Spec.Containers = []corev1.Container{container}

--- a/manageiq-operator/pkg/helpers/miq-components/postgresql.go
+++ b/manageiq-operator/pkg/helpers/miq-components/postgresql.go
@@ -227,6 +227,7 @@ func PostgresqlDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*ap
 			return err
 		}
 		addAppLabel(cr.Spec.AppName, &deployment.ObjectMeta)
+		addBackupAnnotation("miq-pgdb-volume", &deployment.Spec.Template.ObjectMeta)
 		var repNum int32 = 1
 		deployment.Spec.Replicas = &repNum
 		deployment.Spec.Template.Spec.Containers = []corev1.Container{container}

--- a/manageiq-operator/pkg/helpers/miq-components/util.go
+++ b/manageiq-operator/pkg/helpers/miq-components/util.go
@@ -60,3 +60,10 @@ func addAppLabel(appName string, meta *metav1.ObjectMeta) {
 	}
 	meta.Labels["app"] = appName
 }
+
+func addBackupAnnotation(volumesToBackup string, meta *metav1.ObjectMeta) {
+	if meta.Annotations == nil {
+		meta.Annotations = make(map[string]string)
+	}
+	meta.Annotations["backup.velero.io/backup-volumes"] = volumesToBackup
+}


### PR DESCRIPTION
Adding the backup annotations tells velero that it should create a backup of the listed volumes.

https://blog.kubernauts.io/backup-and-restore-of-kubernetes-applications-using-heptios-velero-with-restic-and-rook-ceph-as-2e8df15b1487
```
oc describe pod/postgresql-6cdcdc5d9d-jml9m

Name:           postgresql-6cdcdc5d9d-jml9m
Namespace:      bdunne-miq
Priority:       0
Node:           <redacted>
Start Time:     Thu, 10 Sep 2020 21:13:31 -0400
Labels:         app=manageiq
                name=postgresql
                pod-template-hash=2787871858
Annotations:    backup.velero.io/backup-volumes: miq-pgdb-volume
                openshift.io/scc: restricted
....
```