### PR TITLE
[JANSA] Install ovirt packages before ansible venv packages

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -63,10 +63,10 @@ RUN dnf -y --disableplugin=subscription-manager install \
     dnf clean all
 
 # Install python packages the same way the appliance does
-COPY --from=0 build/kickstarts/partials/post/python_modules.ks.erb /tmp/python_modules
-RUN bash /tmp/python_modules && rm -f /tmp/python_modules
 COPY --from=0 build/kickstarts/partials/post/ovirt_ansible.ks.erb /tmp/ovirt_ansible
 RUN bash /tmp/ovirt_ansible && rm -f /tmp/ovirt_ansible
+COPY --from=0 build/kickstarts/partials/post/python_modules.ks.erb /tmp/python_modules
+RUN bash /tmp/python_modules && rm -f /tmp/python_modules
 
 RUN chgrp -R 0 $APP_ROOT && \
     chmod -R g=u $APP_ROOT


### PR DESCRIPTION
The Jansa podified build is hitting the same error as described in https://github.com/ManageIQ/manageiq-appliance-build/pull/440 for ansible venv setup.  That PR didn't fix the issue for podified, as podified build doesn't run post actions in the same order as appliance build:

ovirt_ansible -> python_modules (appliance)
python_modules -> ovirt_ansible (podified)

ovirt_ansible is what installs the needed package.

This is not an issue in master branch, as ovirt related packages were moved to rpm "Requires" and packages are no longer being installed as a post action. So I'm going to just swap the order for jansa podified build to match appliance build, which will eliminate the error.