### PR TITLE
Add ManageIQ as the provider of the upstream operator

### DIFF
--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq-operator.v0.0.1.clusterserviceversion.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq-operator.v0.0.1.clusterserviceversion.yaml
@@ -145,5 +145,6 @@ spec:
   - supported: true
     type: AllNamespaces
   maturity: alpha
-  provider: {}
+  provider:
+    name: ManageIQ
   version: 0.0.1


### PR DESCRIPTION
The ManageIQ operator was missing an entry for `provider:`, causing it to show as `provider by [object Object]` under "Installed Operators" in the OCP console.

/cc @bdunne @abellotti  