### PR TITLE
[WIP] Remove manageiq-appliance-build clone and customization hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,16 +176,6 @@ Additional options are also available:
   - `-s` Run a release build, using the latest tagged rpm build, excluding nightly rpm builds
   - `-t <tag>` Tag the built images with the specified tag (default: latest)
 
-Additionally the source fork and git ref for manageiq-appliance-build can be set using the following environment variables:
-  - `BUILD_REF`
-  - `BUILD_ORG`
-
-A more complicated example would be to build and push all the images to the quay.io repository "test" using the source from the "feature" branch on the "example" fork:
-
-```bash
-BUILD_ORG=example BUILD_REF=feature ./bin/build -d images -r quay.io/test -p
-```
-
 ### Building RPMs locally
 
 If you want to build images containing your fork or different branches of ManageIQ source code, the `-b` option can be used, which will build RPMs locally before building the images. RPMs are built in `manageiq/rpm_build` container image but a different image can be used if needed.

--- a/bin/build
+++ b/bin/build
@@ -2,14 +2,7 @@
 
 TAG=latest
 
-BUILD_REF=${BUILD_REF:-master}
-BUILD_ORG=${BUILD_ORG:-ManageIQ}
-
 ARCH=`uname -m`
-CORE_REPO_NAME=${CORE_REPO_NAME:-manageiq}
-
-GIT_HOST=${GIT_HOST:-github.com}
-GIT_AUTH=${GIT_AUTH:-""}
 
 OPERATOR_DIR=${OPERATOR_DIR:-manageiq-operator}
 
@@ -65,11 +58,6 @@ fi
 pushd $IMAGE_DIR
   cmd="docker build --tag $REPO/manageiq-base:$TAG \
                     --pull \
-                    --build-arg BUILD_REF=$BUILD_REF \
-                    --build-arg BUILD_ORG=$BUILD_ORG \
-                    --build-arg GIT_AUTH=$GIT_AUTH \
-                    --build-arg GIT_HOST=$GIT_HOST \
-                    --build-arg CORE_REPO_NAME=$CORE_REPO_NAME \
                     --build-arg ARCH=$ARCH \
                     --build-arg RPM_PREFIX=$RPM_PREFIX"
 

--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -1,15 +1,4 @@
 FROM registry.access.redhat.com/ubi8/ubi:8.3
-
-ARG BUILD_REF=master
-ARG BUILD_ORG=ManageIQ
-ARG CORE_REPO_NAME=manageiq
-ARG GIT_HOST=github.com
-ARG GIT_AUTH
-
-RUN mkdir build && \
-    if [[ -n "$GIT_AUTH" ]]; then GIT_HOST=${GIT_AUTH}@${GIT_HOST}; fi && curl -L https://${GIT_HOST}/${BUILD_ORG}/${CORE_REPO_NAME}-appliance-build/tarball/${BUILD_REF} | tar vxz -C build --strip 1
-
-FROM registry.access.redhat.com/ubi8/ubi:8.3
 MAINTAINER ManageIQ https://manageiq.org
 
 ARG ARCH=x86_64
@@ -52,10 +41,6 @@ RUN dnf -y --disableplugin=subscription-manager install \
       &&                          \
     dnf -y --disableplugin=subscription-manager upgrade && \
     dnf clean all
-
-# Install python packages the same way the appliance does
-COPY --from=0 build/kickstarts/partials/post/python_modules.ks.erb /tmp/python_modules
-RUN bash /tmp/python_modules && rm -f /tmp/python_modules
 
 RUN chgrp -R 0 $APP_ROOT && \
     chmod -R g=u $APP_ROOT


### PR DESCRIPTION
The last use of manageiq-appiance-build repo is removed and we no longer need to multi stage pods build to clone appliance build repo, etc.

Since no source clone is done in pods build, customization hook is no loner needed either.

Depends on:
- Build manageiq-ansible-venv rpm for supported architecture and add 'Requires' to rpm spec file

For https://github.com/ManageIQ/manageiq-appliance-build/issues/423