### PR TITLE
Skip reconciling the OIDC Client Secret if one isn't specified

### DIFF
--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -450,11 +450,13 @@ func (r *ReconcileManageIQ) generateSecrets(cr *miqv1alpha1.ManageIQ) error {
 	}
 
 	if cr.Spec.HttpdAuthenticationType == "openid-connect" {
-		oidcClientSecret, mutateFunc := miqtool.OidcClientSecret(cr, r.client)
-		if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, oidcClientSecret, mutateFunc); err != nil {
-			return err
-		} else if result != controllerutil.OperationResultNone {
-			logger.Info("OIDC Client Secret has been reconciled", "component", "operator", "result", result)
+		if cr.Spec.OIDCClientSecret != "" {
+			oidcClientSecret, mutateFunc := miqtool.OidcClientSecret(cr, r.client)
+			if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, oidcClientSecret, mutateFunc); err != nil {
+				return err
+			} else if result != controllerutil.OperationResultNone {
+				logger.Info("OIDC Client Secret has been reconciled", "component", "operator", "result", result)
+			}
 		}
 
 		if cr.Spec.OIDCCACertSecret != "" {


### PR DESCRIPTION
Caused `"error":"an empty namespace may not be set during creation"` because the secret didn't exist and `CreateOrUpdate` was trying to create it.