### PR TITLE
Add Ingress Network Policies to the operator

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/network_policies.go
+++ b/manageiq-operator/pkg/helpers/miq-components/network_policies.go
@@ -40,21 +40,14 @@ func NetworkPolicyAllowInboundHttpd(cr *miqv1alpha1.ManageIQ, scheme *runtime.Sc
 		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"name": "httpd"}
 
 		ensureIngressRule(networkPolicy)
+		setFirstIngressTCPPort(networkPolicy, 8080)
 		if len(networkPolicy.Spec.Ingress[0].From) != 1 {
 			networkPolicy.Spec.Ingress[0].From = []extensionsv1beta1.NetworkPolicyPeer{
 				extensionsv1beta1.NetworkPolicyPeer{},
 			}
 		}
-		if len(networkPolicy.Spec.Ingress[0].Ports) != 1 {
-			networkPolicy.Spec.Ingress[0].Ports = []extensionsv1beta1.NetworkPolicyPort{
-				extensionsv1beta1.NetworkPolicyPort{},
-			}
-		}
-		tcp := corev1.ProtocolTCP
 		networkPolicy.Spec.Ingress[0].From[0].IPBlock = &extensionsv1beta1.IPBlock{}
 		networkPolicy.Spec.Ingress[0].From[0].IPBlock.CIDR = "0.0.0.0/0"
-		networkPolicy.Spec.Ingress[0].Ports[0].Protocol = &tcp
-		networkPolicy.Spec.Ingress[0].Ports[0].Port = &intstr.IntOrString{Type: intstr.Int, IntVal: 8080}
 
 		return nil
 	}
@@ -75,21 +68,14 @@ func NetworkPolicyAllowHttpdApi(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme
 		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"service": "web-service"}
 
 		ensureIngressRule(networkPolicy)
+		setFirstIngressTCPPort(networkPolicy, 3000)
 		if len(networkPolicy.Spec.Ingress[0].From) != 1 {
 			networkPolicy.Spec.Ingress[0].From = []extensionsv1beta1.NetworkPolicyPeer{
 				extensionsv1beta1.NetworkPolicyPeer{},
 			}
 		}
-		if len(networkPolicy.Spec.Ingress[0].Ports) != 1 {
-			networkPolicy.Spec.Ingress[0].Ports = []extensionsv1beta1.NetworkPolicyPort{
-				extensionsv1beta1.NetworkPolicyPort{},
-			}
-		}
-		tcp := corev1.ProtocolTCP
 		networkPolicy.Spec.Ingress[0].From[0].PodSelector = &metav1.LabelSelector{}
 		networkPolicy.Spec.Ingress[0].From[0].PodSelector.MatchLabels = map[string]string{"name": "httpd"}
-		networkPolicy.Spec.Ingress[0].Ports[0].Protocol = &tcp
-		networkPolicy.Spec.Ingress[0].Ports[0].Port = &intstr.IntOrString{Type: intstr.Int, IntVal: 3000}
 
 		return nil
 	}
@@ -110,21 +96,14 @@ func NetworkPolicyAllowHttpdUi(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme)
 		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"service": "ui"}
 
 		ensureIngressRule(networkPolicy)
+		setFirstIngressTCPPort(networkPolicy, 3000)
 		if len(networkPolicy.Spec.Ingress[0].From) != 1 {
 			networkPolicy.Spec.Ingress[0].From = []extensionsv1beta1.NetworkPolicyPeer{
 				extensionsv1beta1.NetworkPolicyPeer{},
 			}
 		}
-		if len(networkPolicy.Spec.Ingress[0].Ports) != 1 {
-			networkPolicy.Spec.Ingress[0].Ports = []extensionsv1beta1.NetworkPolicyPort{
-				extensionsv1beta1.NetworkPolicyPort{},
-			}
-		}
-		tcp := corev1.ProtocolTCP
 		networkPolicy.Spec.Ingress[0].From[0].PodSelector = &metav1.LabelSelector{}
 		networkPolicy.Spec.Ingress[0].From[0].PodSelector.MatchLabels = map[string]string{"name": "httpd"}
-		networkPolicy.Spec.Ingress[0].Ports[0].Protocol = &tcp
-		networkPolicy.Spec.Ingress[0].Ports[0].Port = &intstr.IntOrString{Type: intstr.Int, IntVal: 3000}
 
 		return nil
 	}
@@ -150,26 +129,19 @@ func NetworkPolicyAllowMemcached(cr *miqv1alpha1.ManageIQ, scheme *runtime.Schem
 		}
 
 		ensureIngressRule(networkPolicy)
+		setFirstIngressTCPPort(networkPolicy, 11211)
 		if len(networkPolicy.Spec.Ingress[0].From) != 2 {
 			networkPolicy.Spec.Ingress[0].From = []extensionsv1beta1.NetworkPolicyPeer{
 				extensionsv1beta1.NetworkPolicyPeer{},
 				extensionsv1beta1.NetworkPolicyPeer{},
 			}
 		}
-		if len(networkPolicy.Spec.Ingress[0].Ports) != 1 {
-			networkPolicy.Spec.Ingress[0].Ports = []extensionsv1beta1.NetworkPolicyPort{
-				extensionsv1beta1.NetworkPolicyPort{},
-			}
-		}
 		orchestratedByLabelKey := cr.Spec.AppName + "-orchestrated-by"
 		orchestratedByLabelValue := pod.Name
-		tcp := corev1.ProtocolTCP
 		networkPolicy.Spec.Ingress[0].From[0].PodSelector = &metav1.LabelSelector{}
 		networkPolicy.Spec.Ingress[0].From[0].PodSelector.MatchLabels = map[string]string{"name": "orchestrator"}
 		networkPolicy.Spec.Ingress[0].From[1].PodSelector = &metav1.LabelSelector{}
 		networkPolicy.Spec.Ingress[0].From[1].PodSelector.MatchLabels = map[string]string{orchestratedByLabelKey: orchestratedByLabelValue}
-		networkPolicy.Spec.Ingress[0].Ports[0].Protocol = &tcp
-		networkPolicy.Spec.Ingress[0].Ports[0].Port = &intstr.IntOrString{Type: intstr.Int, IntVal: 11211}
 
 		return nil
 	}
@@ -195,26 +167,19 @@ func NetworkPolicyAllowPostgres(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme
 		}
 
 		ensureIngressRule(networkPolicy)
+		setFirstIngressTCPPort(networkPolicy, 5432)
 		if len(networkPolicy.Spec.Ingress[0].From) != 2 {
 			networkPolicy.Spec.Ingress[0].From = []extensionsv1beta1.NetworkPolicyPeer{
 				extensionsv1beta1.NetworkPolicyPeer{},
 				extensionsv1beta1.NetworkPolicyPeer{},
 			}
 		}
-		if len(networkPolicy.Spec.Ingress[0].Ports) != 1 {
-			networkPolicy.Spec.Ingress[0].Ports = []extensionsv1beta1.NetworkPolicyPort{
-				extensionsv1beta1.NetworkPolicyPort{},
-			}
-		}
 		orchestratedByLabelKey := cr.Spec.AppName + "-orchestrated-by"
 		orchestratedByLabelValue := pod.Name
-		tcp := corev1.ProtocolTCP
 		networkPolicy.Spec.Ingress[0].From[0].PodSelector = &metav1.LabelSelector{}
 		networkPolicy.Spec.Ingress[0].From[0].PodSelector.MatchLabels = map[string]string{"name": "orchestrator"}
 		networkPolicy.Spec.Ingress[0].From[1].PodSelector = &metav1.LabelSelector{}
 		networkPolicy.Spec.Ingress[0].From[1].PodSelector.MatchLabels = map[string]string{orchestratedByLabelKey: orchestratedByLabelValue}
-		networkPolicy.Spec.Ingress[0].Ports[0].Protocol = &tcp
-		networkPolicy.Spec.Ingress[0].Ports[0].Port = &intstr.IntOrString{Type: intstr.Int, IntVal: 5432}
 
 		return nil
 	}
@@ -244,4 +209,16 @@ func ensureIngressRule(networkPolicy *extensionsv1beta1.NetworkPolicy) {
 			extensionsv1beta1.NetworkPolicyIngressRule{},
 		}
 	}
+}
+
+func setFirstIngressTCPPort(networkPolicy *extensionsv1beta1.NetworkPolicy, port int32) {
+	if len(networkPolicy.Spec.Ingress[0].Ports) != 1 {
+		networkPolicy.Spec.Ingress[0].Ports = []extensionsv1beta1.NetworkPolicyPort{
+			extensionsv1beta1.NetworkPolicyPort{},
+		}
+	}
+	tcp := corev1.ProtocolTCP
+	ports := &networkPolicy.Spec.Ingress[0].Ports[0]
+	ports.Protocol = &tcp
+	ports.Port = &intstr.IntOrString{Type: intstr.Int, IntVal: port}
 }

--- a/manageiq-operator/pkg/helpers/miq-components/network_policies.go
+++ b/manageiq-operator/pkg/helpers/miq-components/network_policies.go
@@ -19,11 +19,7 @@ func NetworkPolicyDefaultDeny(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) 
 			return err
 		}
 		addAppLabel(cr.Spec.AppName, &networkPolicy.ObjectMeta)
-
-		if len(networkPolicy.Spec.PolicyTypes) == 0 {
-			networkPolicy.Spec.PolicyTypes = append(networkPolicy.Spec.PolicyTypes, "Ingress")
-		}
-		networkPolicy.Spec.PolicyTypes[0] = "Ingress"
+		setIngressPolicyType(networkPolicy)
 
 		return nil
 	}
@@ -39,13 +35,9 @@ func NetworkPolicyAllowInboundHttpd(cr *miqv1alpha1.ManageIQ, scheme *runtime.Sc
 			return err
 		}
 		addAppLabel(cr.Spec.AppName, &networkPolicy.ObjectMeta)
+		setIngressPolicyType(networkPolicy)
 
 		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"name": "httpd"}
-
-		if len(networkPolicy.Spec.PolicyTypes) != 1 {
-			networkPolicy.Spec.PolicyTypes = append(networkPolicy.Spec.PolicyTypes, "Ingress")
-		}
-		networkPolicy.Spec.PolicyTypes[0] = "Ingress"
 
 		if len(networkPolicy.Spec.Ingress) != 1 {
 			networkPolicy.Spec.Ingress = []extensionsv1beta1.NetworkPolicyIngressRule{
@@ -82,13 +74,9 @@ func NetworkPolicyAllowHttpdApi(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme
 			return err
 		}
 		addAppLabel(cr.Spec.AppName, &networkPolicy.ObjectMeta)
+		setIngressPolicyType(networkPolicy)
 
 		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"service": "web-service"}
-
-		if len(networkPolicy.Spec.PolicyTypes) != 1 {
-			networkPolicy.Spec.PolicyTypes = append(networkPolicy.Spec.PolicyTypes, "Ingress")
-		}
-		networkPolicy.Spec.PolicyTypes[0] = "Ingress"
 
 		if len(networkPolicy.Spec.Ingress) != 1 {
 			networkPolicy.Spec.Ingress = []extensionsv1beta1.NetworkPolicyIngressRule{
@@ -125,13 +113,9 @@ func NetworkPolicyAllowHttpdUi(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme)
 			return err
 		}
 		addAppLabel(cr.Spec.AppName, &networkPolicy.ObjectMeta)
+		setIngressPolicyType(networkPolicy)
 
 		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"service": "ui"}
-
-		if len(networkPolicy.Spec.PolicyTypes) != 1 {
-			networkPolicy.Spec.PolicyTypes = append(networkPolicy.Spec.PolicyTypes, "Ingress")
-		}
-		networkPolicy.Spec.PolicyTypes[0] = "Ingress"
 
 		if len(networkPolicy.Spec.Ingress) != 1 {
 			networkPolicy.Spec.Ingress = []extensionsv1beta1.NetworkPolicyIngressRule{
@@ -168,13 +152,9 @@ func NetworkPolicyAllowMemcached(cr *miqv1alpha1.ManageIQ, scheme *runtime.Schem
 			return err
 		}
 		addAppLabel(cr.Spec.AppName, &networkPolicy.ObjectMeta)
+		setIngressPolicyType(networkPolicy)
 
 		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"name": "memcached"}
-
-		if len(networkPolicy.Spec.PolicyTypes) != 1 {
-			networkPolicy.Spec.PolicyTypes = append(networkPolicy.Spec.PolicyTypes, "Ingress")
-		}
-		networkPolicy.Spec.PolicyTypes[0] = "Ingress"
 
 		pod := orchestratorPod(*c)
 		if pod == nil {
@@ -221,13 +201,9 @@ func NetworkPolicyAllowPostgres(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme
 			return err
 		}
 		addAppLabel(cr.Spec.AppName, &networkPolicy.ObjectMeta)
+		setIngressPolicyType(networkPolicy)
 
 		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"name": "postgresql"}
-
-		if len(networkPolicy.Spec.PolicyTypes) != 1 {
-			networkPolicy.Spec.PolicyTypes = append(networkPolicy.Spec.PolicyTypes, "Ingress")
-		}
-		networkPolicy.Spec.PolicyTypes[0] = "Ingress"
 
 		pod := orchestratorPod(*c)
 		if pod == nil {
@@ -273,4 +249,11 @@ func newNetworkPolicy(cr *miqv1alpha1.ManageIQ, name string) *extensionsv1beta1.
 			Namespace: cr.ObjectMeta.Namespace,
 		},
 	}
+}
+
+func setIngressPolicyType(networkPolicy *extensionsv1beta1.NetworkPolicy) {
+	if len(networkPolicy.Spec.PolicyTypes) != 1 {
+		networkPolicy.Spec.PolicyTypes = append(networkPolicy.Spec.PolicyTypes, "Ingress")
+	}
+	networkPolicy.Spec.PolicyTypes[0] = "Ingress"
 }

--- a/manageiq-operator/pkg/helpers/miq-components/network_policies.go
+++ b/manageiq-operator/pkg/helpers/miq-components/network_policies.go
@@ -39,11 +39,7 @@ func NetworkPolicyAllowInboundHttpd(cr *miqv1alpha1.ManageIQ, scheme *runtime.Sc
 
 		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"name": "httpd"}
 
-		if len(networkPolicy.Spec.Ingress) != 1 {
-			networkPolicy.Spec.Ingress = []extensionsv1beta1.NetworkPolicyIngressRule{
-				extensionsv1beta1.NetworkPolicyIngressRule{},
-			}
-		}
+		ensureIngressRule(networkPolicy)
 		if len(networkPolicy.Spec.Ingress[0].From) != 1 {
 			networkPolicy.Spec.Ingress[0].From = []extensionsv1beta1.NetworkPolicyPeer{
 				extensionsv1beta1.NetworkPolicyPeer{},
@@ -78,11 +74,7 @@ func NetworkPolicyAllowHttpdApi(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme
 
 		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"service": "web-service"}
 
-		if len(networkPolicy.Spec.Ingress) != 1 {
-			networkPolicy.Spec.Ingress = []extensionsv1beta1.NetworkPolicyIngressRule{
-				extensionsv1beta1.NetworkPolicyIngressRule{},
-			}
-		}
+		ensureIngressRule(networkPolicy)
 		if len(networkPolicy.Spec.Ingress[0].From) != 1 {
 			networkPolicy.Spec.Ingress[0].From = []extensionsv1beta1.NetworkPolicyPeer{
 				extensionsv1beta1.NetworkPolicyPeer{},
@@ -117,11 +109,7 @@ func NetworkPolicyAllowHttpdUi(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme)
 
 		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"service": "ui"}
 
-		if len(networkPolicy.Spec.Ingress) != 1 {
-			networkPolicy.Spec.Ingress = []extensionsv1beta1.NetworkPolicyIngressRule{
-				extensionsv1beta1.NetworkPolicyIngressRule{},
-			}
-		}
+		ensureIngressRule(networkPolicy)
 		if len(networkPolicy.Spec.Ingress[0].From) != 1 {
 			networkPolicy.Spec.Ingress[0].From = []extensionsv1beta1.NetworkPolicyPeer{
 				extensionsv1beta1.NetworkPolicyPeer{},
@@ -161,11 +149,7 @@ func NetworkPolicyAllowMemcached(cr *miqv1alpha1.ManageIQ, scheme *runtime.Schem
 			return nil
 		}
 
-		if len(networkPolicy.Spec.Ingress) != 1 {
-			networkPolicy.Spec.Ingress = []extensionsv1beta1.NetworkPolicyIngressRule{
-				extensionsv1beta1.NetworkPolicyIngressRule{},
-			}
-		}
+		ensureIngressRule(networkPolicy)
 		if len(networkPolicy.Spec.Ingress[0].From) != 2 {
 			networkPolicy.Spec.Ingress[0].From = []extensionsv1beta1.NetworkPolicyPeer{
 				extensionsv1beta1.NetworkPolicyPeer{},
@@ -210,11 +194,7 @@ func NetworkPolicyAllowPostgres(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme
 			return nil
 		}
 
-		if len(networkPolicy.Spec.Ingress) != 1 {
-			networkPolicy.Spec.Ingress = []extensionsv1beta1.NetworkPolicyIngressRule{
-				extensionsv1beta1.NetworkPolicyIngressRule{},
-			}
-		}
+		ensureIngressRule(networkPolicy)
 		if len(networkPolicy.Spec.Ingress[0].From) != 2 {
 			networkPolicy.Spec.Ingress[0].From = []extensionsv1beta1.NetworkPolicyPeer{
 				extensionsv1beta1.NetworkPolicyPeer{},
@@ -256,4 +236,12 @@ func setIngressPolicyType(networkPolicy *extensionsv1beta1.NetworkPolicy) {
 		networkPolicy.Spec.PolicyTypes = append(networkPolicy.Spec.PolicyTypes, "Ingress")
 	}
 	networkPolicy.Spec.PolicyTypes[0] = "Ingress"
+}
+
+func ensureIngressRule(networkPolicy *extensionsv1beta1.NetworkPolicy) {
+	if len(networkPolicy.Spec.Ingress) != 1 {
+		networkPolicy.Spec.Ingress = []extensionsv1beta1.NetworkPolicyIngressRule{
+			extensionsv1beta1.NetworkPolicyIngressRule{},
+		}
+	}
 }

--- a/manageiq-operator/pkg/helpers/miq-components/network_policies.go
+++ b/manageiq-operator/pkg/helpers/miq-components/network_policies.go
@@ -12,12 +12,7 @@ import (
 )
 
 func NetworkPolicyDefaultDeny(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*extensionsv1beta1.NetworkPolicy, controllerutil.MutateFn) {
-	networkPolicy := &extensionsv1beta1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Spec.AppName + "-default-deny",
-			Namespace: cr.ObjectMeta.Namespace,
-		},
-	}
+	networkPolicy := newNetworkPolicy(cr, "-default-deny")
 
 	f := func() error {
 		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
@@ -37,12 +32,7 @@ func NetworkPolicyDefaultDeny(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) 
 }
 
 func NetworkPolicyAllowInboundHttpd(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*extensionsv1beta1.NetworkPolicy, controllerutil.MutateFn) {
-	networkPolicy := &extensionsv1beta1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Spec.AppName + "-allow-inbound-httpd",
-			Namespace: cr.ObjectMeta.Namespace,
-		},
-	}
+	networkPolicy := newNetworkPolicy(cr, "-allow-inbound-httpd")
 
 	f := func() error {
 		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
@@ -85,12 +75,7 @@ func NetworkPolicyAllowInboundHttpd(cr *miqv1alpha1.ManageIQ, scheme *runtime.Sc
 }
 
 func NetworkPolicyAllowHttpdApi(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*extensionsv1beta1.NetworkPolicy, controllerutil.MutateFn) {
-	networkPolicy := &extensionsv1beta1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Spec.AppName + "-allow-httpd-api",
-			Namespace: cr.ObjectMeta.Namespace,
-		},
-	}
+	networkPolicy := newNetworkPolicy(cr, "-allow-httpd-api")
 
 	f := func() error {
 		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
@@ -133,12 +118,7 @@ func NetworkPolicyAllowHttpdApi(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme
 }
 
 func NetworkPolicyAllowHttpdUi(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*extensionsv1beta1.NetworkPolicy, controllerutil.MutateFn) {
-	networkPolicy := &extensionsv1beta1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Spec.AppName + "-allow-httpd-ui",
-			Namespace: cr.ObjectMeta.Namespace,
-		},
-	}
+	networkPolicy := newNetworkPolicy(cr, "-allow-httpd-ui")
 
 	f := func() error {
 		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
@@ -181,12 +161,7 @@ func NetworkPolicyAllowHttpdUi(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme)
 }
 
 func NetworkPolicyAllowMemcached(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, c *client.Client) (*extensionsv1beta1.NetworkPolicy, controllerutil.MutateFn) {
-	networkPolicy := &extensionsv1beta1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Spec.AppName + "-allow-memcached",
-			Namespace: cr.ObjectMeta.Namespace,
-		},
-	}
+	networkPolicy := newNetworkPolicy(cr, "-allow-memcached")
 
 	f := func() error {
 		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
@@ -239,12 +214,7 @@ func NetworkPolicyAllowMemcached(cr *miqv1alpha1.ManageIQ, scheme *runtime.Schem
 }
 
 func NetworkPolicyAllowPostgres(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, c *client.Client) (*extensionsv1beta1.NetworkPolicy, controllerutil.MutateFn) {
-	networkPolicy := &extensionsv1beta1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Spec.AppName + "-allow-postgres",
-			Namespace: cr.ObjectMeta.Namespace,
-		},
-	}
+	networkPolicy := newNetworkPolicy(cr, "-allow-postgres")
 
 	f := func() error {
 		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
@@ -294,4 +264,13 @@ func NetworkPolicyAllowPostgres(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme
 	}
 
 	return networkPolicy, f
+}
+
+func newNetworkPolicy(cr *miqv1alpha1.ManageIQ, name string) *extensionsv1beta1.NetworkPolicy {
+	return &extensionsv1beta1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Spec.AppName + name,
+			Namespace: cr.ObjectMeta.Namespace,
+		},
+	}
 }

--- a/manageiq-operator/pkg/helpers/miq-components/network_policies.go
+++ b/manageiq-operator/pkg/helpers/miq-components/network_policies.go
@@ -12,7 +12,7 @@ import (
 )
 
 func NetworkPolicyDefaultDeny(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*extensionsv1beta1.NetworkPolicy, controllerutil.MutateFn) {
-	networkPolicy := newNetworkPolicy(cr, "-default-deny")
+	networkPolicy := newNetworkPolicy(cr, "default-deny")
 
 	f := func() error {
 		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
@@ -28,7 +28,7 @@ func NetworkPolicyDefaultDeny(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) 
 }
 
 func NetworkPolicyAllowInboundHttpd(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*extensionsv1beta1.NetworkPolicy, controllerutil.MutateFn) {
-	networkPolicy := newNetworkPolicy(cr, "-allow-inbound-httpd")
+	networkPolicy := newNetworkPolicy(cr, "allow-inbound-httpd")
 
 	f := func() error {
 		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
@@ -56,7 +56,7 @@ func NetworkPolicyAllowInboundHttpd(cr *miqv1alpha1.ManageIQ, scheme *runtime.Sc
 }
 
 func NetworkPolicyAllowHttpdApi(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*extensionsv1beta1.NetworkPolicy, controllerutil.MutateFn) {
-	networkPolicy := newNetworkPolicy(cr, "-allow-httpd-api")
+	networkPolicy := newNetworkPolicy(cr, "allow-httpd-api")
 
 	f := func() error {
 		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
@@ -84,7 +84,7 @@ func NetworkPolicyAllowHttpdApi(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme
 }
 
 func NetworkPolicyAllowHttpdUi(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*extensionsv1beta1.NetworkPolicy, controllerutil.MutateFn) {
-	networkPolicy := newNetworkPolicy(cr, "-allow-httpd-ui")
+	networkPolicy := newNetworkPolicy(cr, "allow-httpd-ui")
 
 	f := func() error {
 		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
@@ -112,7 +112,7 @@ func NetworkPolicyAllowHttpdUi(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme)
 }
 
 func NetworkPolicyAllowMemcached(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, c *client.Client) (*extensionsv1beta1.NetworkPolicy, controllerutil.MutateFn) {
-	networkPolicy := newNetworkPolicy(cr, "-allow-memcached")
+	networkPolicy := newNetworkPolicy(cr, "allow-memcached")
 
 	f := func() error {
 		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
@@ -150,7 +150,7 @@ func NetworkPolicyAllowMemcached(cr *miqv1alpha1.ManageIQ, scheme *runtime.Schem
 }
 
 func NetworkPolicyAllowPostgres(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, c *client.Client) (*extensionsv1beta1.NetworkPolicy, controllerutil.MutateFn) {
-	networkPolicy := newNetworkPolicy(cr, "-allow-postgres")
+	networkPolicy := newNetworkPolicy(cr, "allow-postgres")
 
 	f := func() error {
 		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
@@ -190,7 +190,7 @@ func NetworkPolicyAllowPostgres(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme
 func newNetworkPolicy(cr *miqv1alpha1.ManageIQ, name string) *extensionsv1beta1.NetworkPolicy {
 	return &extensionsv1beta1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Spec.AppName + name,
+			Name:      cr.Spec.AppName + "-" + name,
 			Namespace: cr.ObjectMeta.Namespace,
 		},
 	}

--- a/manageiq-operator/pkg/helpers/miq-components/network_policies.go
+++ b/manageiq-operator/pkg/helpers/miq-components/network_policies.go
@@ -1,0 +1,297 @@
+package miqtools
+
+import (
+	miqv1alpha1 "github.com/ManageIQ/manageiq-pods/manageiq-operator/pkg/apis/manageiq/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func NetworkPolicyDefaultDeny(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*extensionsv1beta1.NetworkPolicy, controllerutil.MutateFn) {
+	networkPolicy := &extensionsv1beta1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Spec.AppName + "-default-deny",
+			Namespace: cr.ObjectMeta.Namespace,
+		},
+	}
+
+	f := func() error {
+		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
+			return err
+		}
+		addAppLabel(cr.Spec.AppName, &networkPolicy.ObjectMeta)
+
+		if len(networkPolicy.Spec.PolicyTypes) == 0 {
+			networkPolicy.Spec.PolicyTypes = append(networkPolicy.Spec.PolicyTypes, "Ingress")
+		}
+		networkPolicy.Spec.PolicyTypes[0] = "Ingress"
+
+		return nil
+	}
+
+	return networkPolicy, f
+}
+
+func NetworkPolicyAllowInboundHttpd(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*extensionsv1beta1.NetworkPolicy, controllerutil.MutateFn) {
+	networkPolicy := &extensionsv1beta1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Spec.AppName + "-allow-inbound-httpd",
+			Namespace: cr.ObjectMeta.Namespace,
+		},
+	}
+
+	f := func() error {
+		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
+			return err
+		}
+		addAppLabel(cr.Spec.AppName, &networkPolicy.ObjectMeta)
+
+		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"name": "httpd"}
+
+		if len(networkPolicy.Spec.PolicyTypes) != 1 {
+			networkPolicy.Spec.PolicyTypes = append(networkPolicy.Spec.PolicyTypes, "Ingress")
+		}
+		networkPolicy.Spec.PolicyTypes[0] = "Ingress"
+
+		if len(networkPolicy.Spec.Ingress) != 1 {
+			networkPolicy.Spec.Ingress = []extensionsv1beta1.NetworkPolicyIngressRule{
+				extensionsv1beta1.NetworkPolicyIngressRule{},
+			}
+		}
+		if len(networkPolicy.Spec.Ingress[0].From) != 1 {
+			networkPolicy.Spec.Ingress[0].From = []extensionsv1beta1.NetworkPolicyPeer{
+				extensionsv1beta1.NetworkPolicyPeer{},
+			}
+		}
+		if len(networkPolicy.Spec.Ingress[0].Ports) != 1 {
+			networkPolicy.Spec.Ingress[0].Ports = []extensionsv1beta1.NetworkPolicyPort{
+				extensionsv1beta1.NetworkPolicyPort{},
+			}
+		}
+		tcp := corev1.ProtocolTCP
+		networkPolicy.Spec.Ingress[0].From[0].IPBlock = &extensionsv1beta1.IPBlock{}
+		networkPolicy.Spec.Ingress[0].From[0].IPBlock.CIDR = "0.0.0.0/0"
+		networkPolicy.Spec.Ingress[0].Ports[0].Protocol = &tcp
+		networkPolicy.Spec.Ingress[0].Ports[0].Port = &intstr.IntOrString{Type: intstr.Int, IntVal: 8080}
+
+		return nil
+	}
+
+	return networkPolicy, f
+}
+
+func NetworkPolicyAllowHttpdApi(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*extensionsv1beta1.NetworkPolicy, controllerutil.MutateFn) {
+	networkPolicy := &extensionsv1beta1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Spec.AppName + "-allow-httpd-api",
+			Namespace: cr.ObjectMeta.Namespace,
+		},
+	}
+
+	f := func() error {
+		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
+			return err
+		}
+		addAppLabel(cr.Spec.AppName, &networkPolicy.ObjectMeta)
+
+		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"service": "web-service"}
+
+		if len(networkPolicy.Spec.PolicyTypes) != 1 {
+			networkPolicy.Spec.PolicyTypes = append(networkPolicy.Spec.PolicyTypes, "Ingress")
+		}
+		networkPolicy.Spec.PolicyTypes[0] = "Ingress"
+
+		if len(networkPolicy.Spec.Ingress) != 1 {
+			networkPolicy.Spec.Ingress = []extensionsv1beta1.NetworkPolicyIngressRule{
+				extensionsv1beta1.NetworkPolicyIngressRule{},
+			}
+		}
+		if len(networkPolicy.Spec.Ingress[0].From) != 1 {
+			networkPolicy.Spec.Ingress[0].From = []extensionsv1beta1.NetworkPolicyPeer{
+				extensionsv1beta1.NetworkPolicyPeer{},
+			}
+		}
+		if len(networkPolicy.Spec.Ingress[0].Ports) != 1 {
+			networkPolicy.Spec.Ingress[0].Ports = []extensionsv1beta1.NetworkPolicyPort{
+				extensionsv1beta1.NetworkPolicyPort{},
+			}
+		}
+		tcp := corev1.ProtocolTCP
+		networkPolicy.Spec.Ingress[0].From[0].PodSelector = &metav1.LabelSelector{}
+		networkPolicy.Spec.Ingress[0].From[0].PodSelector.MatchLabels = map[string]string{"name": "httpd"}
+		networkPolicy.Spec.Ingress[0].Ports[0].Protocol = &tcp
+		networkPolicy.Spec.Ingress[0].Ports[0].Port = &intstr.IntOrString{Type: intstr.Int, IntVal: 3000}
+
+		return nil
+	}
+
+	return networkPolicy, f
+}
+
+func NetworkPolicyAllowHttpdUi(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*extensionsv1beta1.NetworkPolicy, controllerutil.MutateFn) {
+	networkPolicy := &extensionsv1beta1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Spec.AppName + "-allow-httpd-ui",
+			Namespace: cr.ObjectMeta.Namespace,
+		},
+	}
+
+	f := func() error {
+		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
+			return err
+		}
+		addAppLabel(cr.Spec.AppName, &networkPolicy.ObjectMeta)
+
+		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"service": "ui"}
+
+		if len(networkPolicy.Spec.PolicyTypes) != 1 {
+			networkPolicy.Spec.PolicyTypes = append(networkPolicy.Spec.PolicyTypes, "Ingress")
+		}
+		networkPolicy.Spec.PolicyTypes[0] = "Ingress"
+
+		if len(networkPolicy.Spec.Ingress) != 1 {
+			networkPolicy.Spec.Ingress = []extensionsv1beta1.NetworkPolicyIngressRule{
+				extensionsv1beta1.NetworkPolicyIngressRule{},
+			}
+		}
+		if len(networkPolicy.Spec.Ingress[0].From) != 1 {
+			networkPolicy.Spec.Ingress[0].From = []extensionsv1beta1.NetworkPolicyPeer{
+				extensionsv1beta1.NetworkPolicyPeer{},
+			}
+		}
+		if len(networkPolicy.Spec.Ingress[0].Ports) != 1 {
+			networkPolicy.Spec.Ingress[0].Ports = []extensionsv1beta1.NetworkPolicyPort{
+				extensionsv1beta1.NetworkPolicyPort{},
+			}
+		}
+		tcp := corev1.ProtocolTCP
+		networkPolicy.Spec.Ingress[0].From[0].PodSelector = &metav1.LabelSelector{}
+		networkPolicy.Spec.Ingress[0].From[0].PodSelector.MatchLabels = map[string]string{"name": "httpd"}
+		networkPolicy.Spec.Ingress[0].Ports[0].Protocol = &tcp
+		networkPolicy.Spec.Ingress[0].Ports[0].Port = &intstr.IntOrString{Type: intstr.Int, IntVal: 3000}
+
+		return nil
+	}
+
+	return networkPolicy, f
+}
+
+func NetworkPolicyAllowMemcached(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, c *client.Client) (*extensionsv1beta1.NetworkPolicy, controllerutil.MutateFn) {
+	networkPolicy := &extensionsv1beta1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Spec.AppName + "-allow-memcached",
+			Namespace: cr.ObjectMeta.Namespace,
+		},
+	}
+
+	f := func() error {
+		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
+			return err
+		}
+		addAppLabel(cr.Spec.AppName, &networkPolicy.ObjectMeta)
+
+		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"name": "memcached"}
+
+		if len(networkPolicy.Spec.PolicyTypes) != 1 {
+			networkPolicy.Spec.PolicyTypes = append(networkPolicy.Spec.PolicyTypes, "Ingress")
+		}
+		networkPolicy.Spec.PolicyTypes[0] = "Ingress"
+
+		pod := orchestratorPod(*c)
+		if pod == nil {
+			return nil
+		}
+
+		if len(networkPolicy.Spec.Ingress) != 1 {
+			networkPolicy.Spec.Ingress = []extensionsv1beta1.NetworkPolicyIngressRule{
+				extensionsv1beta1.NetworkPolicyIngressRule{},
+			}
+		}
+		if len(networkPolicy.Spec.Ingress[0].From) != 2 {
+			networkPolicy.Spec.Ingress[0].From = []extensionsv1beta1.NetworkPolicyPeer{
+				extensionsv1beta1.NetworkPolicyPeer{},
+				extensionsv1beta1.NetworkPolicyPeer{},
+			}
+		}
+		if len(networkPolicy.Spec.Ingress[0].Ports) != 1 {
+			networkPolicy.Spec.Ingress[0].Ports = []extensionsv1beta1.NetworkPolicyPort{
+				extensionsv1beta1.NetworkPolicyPort{},
+			}
+		}
+		orchestratedByLabelKey := cr.Spec.AppName + "-orchestrated-by"
+		orchestratedByLabelValue := pod.Name
+		tcp := corev1.ProtocolTCP
+		networkPolicy.Spec.Ingress[0].From[0].PodSelector = &metav1.LabelSelector{}
+		networkPolicy.Spec.Ingress[0].From[0].PodSelector.MatchLabels = map[string]string{"name": "orchestrator"}
+		networkPolicy.Spec.Ingress[0].From[1].PodSelector = &metav1.LabelSelector{}
+		networkPolicy.Spec.Ingress[0].From[1].PodSelector.MatchLabels = map[string]string{orchestratedByLabelKey: orchestratedByLabelValue}
+		networkPolicy.Spec.Ingress[0].Ports[0].Protocol = &tcp
+		networkPolicy.Spec.Ingress[0].Ports[0].Port = &intstr.IntOrString{Type: intstr.Int, IntVal: 11211}
+
+		return nil
+	}
+
+	return networkPolicy, f
+}
+
+func NetworkPolicyAllowPostgres(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, c *client.Client) (*extensionsv1beta1.NetworkPolicy, controllerutil.MutateFn) {
+	networkPolicy := &extensionsv1beta1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Spec.AppName + "-allow-postgres",
+			Namespace: cr.ObjectMeta.Namespace,
+		},
+	}
+
+	f := func() error {
+		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
+			return err
+		}
+		addAppLabel(cr.Spec.AppName, &networkPolicy.ObjectMeta)
+
+		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"name": "postgresql"}
+
+		if len(networkPolicy.Spec.PolicyTypes) != 1 {
+			networkPolicy.Spec.PolicyTypes = append(networkPolicy.Spec.PolicyTypes, "Ingress")
+		}
+		networkPolicy.Spec.PolicyTypes[0] = "Ingress"
+
+		pod := orchestratorPod(*c)
+		if pod == nil {
+			return nil
+		}
+
+		if len(networkPolicy.Spec.Ingress) != 1 {
+			networkPolicy.Spec.Ingress = []extensionsv1beta1.NetworkPolicyIngressRule{
+				extensionsv1beta1.NetworkPolicyIngressRule{},
+			}
+		}
+		if len(networkPolicy.Spec.Ingress[0].From) != 2 {
+			networkPolicy.Spec.Ingress[0].From = []extensionsv1beta1.NetworkPolicyPeer{
+				extensionsv1beta1.NetworkPolicyPeer{},
+				extensionsv1beta1.NetworkPolicyPeer{},
+			}
+		}
+		if len(networkPolicy.Spec.Ingress[0].Ports) != 1 {
+			networkPolicy.Spec.Ingress[0].Ports = []extensionsv1beta1.NetworkPolicyPort{
+				extensionsv1beta1.NetworkPolicyPort{},
+			}
+		}
+		orchestratedByLabelKey := cr.Spec.AppName + "-orchestrated-by"
+		orchestratedByLabelValue := pod.Name
+		tcp := corev1.ProtocolTCP
+		networkPolicy.Spec.Ingress[0].From[0].PodSelector = &metav1.LabelSelector{}
+		networkPolicy.Spec.Ingress[0].From[0].PodSelector.MatchLabels = map[string]string{"name": "orchestrator"}
+		networkPolicy.Spec.Ingress[0].From[1].PodSelector = &metav1.LabelSelector{}
+		networkPolicy.Spec.Ingress[0].From[1].PodSelector.MatchLabels = map[string]string{orchestratedByLabelKey: orchestratedByLabelValue}
+		networkPolicy.Spec.Ingress[0].Ports[0].Protocol = &tcp
+		networkPolicy.Spec.Ingress[0].Ports[0].Port = &intstr.IntOrString{Type: intstr.Int, IntVal: 5432}
+
+		return nil
+	}
+
+	return networkPolicy, f
+}


### PR DESCRIPTION
Fixes #590 

Allow the following ingress:
- default deny all
- external traffic -> httpd
- httpd -> api
- httpd -> ui
- orchestrator & orchestrated-by -> postgres
- orchestrator & orchestrated-by -> memcached

TODO:
- [x] refactoring common patterns to make it less verbose
- [x] testing