### PR TITLE
Prefer recreate as the deployment strategy for many services.

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -361,6 +361,9 @@ func HttpdDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*appsv1.
 		addAppLabel(cr.Spec.AppName, &deployment.ObjectMeta)
 		var repNum int32 = 1
 		deployment.Spec.Replicas = &repNum
+		deployment.Spec.Strategy = appsv1.DeploymentStrategy{
+			Type: "Recreate",
+		}
 		deployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 		deployment.Spec.Template.Spec.Volumes = []corev1.Volume{
 			corev1.Volume{

--- a/manageiq-operator/pkg/helpers/miq-components/kafka.go
+++ b/manageiq-operator/pkg/helpers/miq-components/kafka.go
@@ -250,6 +250,9 @@ func KafkaDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*appsv1.
 		addBackupLabel(cr.Spec.BackupLabelName, &deployment.Spec.Template.ObjectMeta)
 		var repNum int32 = 1
 		deployment.Spec.Replicas = &repNum
+		deployment.Spec.Strategy = appsv1.DeploymentStrategy{
+			Type: "Recreate",
+		}
 		deployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 		deployment.Spec.Template.Spec.ServiceAccountName = defaultServiceAccountName(cr.Spec.AppName)
 		var termSecs int64 = 10
@@ -330,6 +333,9 @@ func ZookeeperDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*app
 		addBackupLabel(cr.Spec.BackupLabelName, &deployment.Spec.Template.ObjectMeta)
 		var repNum int32 = 1
 		deployment.Spec.Replicas = &repNum
+		deployment.Spec.Strategy = appsv1.DeploymentStrategy{
+			Type: "Recreate",
+		}
 		deployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 		deployment.Spec.Template.Spec.ServiceAccountName = defaultServiceAccountName(cr.Spec.AppName)
 		deployment.Spec.Template.Spec.Volumes = []corev1.Volume{

--- a/manageiq-operator/pkg/helpers/miq-components/memcached.go
+++ b/manageiq-operator/pkg/helpers/miq-components/memcached.go
@@ -88,6 +88,9 @@ func NewMemcachedDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*
 		addAppLabel(cr.Spec.AppName, &deployment.ObjectMeta)
 		var repNum int32 = 1
 		deployment.Spec.Replicas = &repNum
+		deployment.Spec.Strategy = appsv1.DeploymentStrategy{
+			Type: "Recreate",
+		}
 		deployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 		deployment.Spec.Template.Spec.ServiceAccountName = defaultServiceAccountName(cr.Spec.AppName)
 		return nil

--- a/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
@@ -346,6 +346,9 @@ func OrchestratorDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*
 		addAppLabel(cr.Spec.AppName, &deployment.ObjectMeta)
 		var repNum int32 = 1
 		deployment.Spec.Replicas = &repNum
+		deployment.Spec.Strategy = appsv1.DeploymentStrategy{
+			Type: "Recreate",
+		}
 		deployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 		var termSecs int64 = 90
 		deployment.Spec.Template.Spec.ServiceAccountName = cr.Spec.AppName + "-orchestrator"

--- a/manageiq-operator/pkg/helpers/miq-components/postgresql.go
+++ b/manageiq-operator/pkg/helpers/miq-components/postgresql.go
@@ -233,6 +233,9 @@ func PostgresqlDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*ap
 		addBackupAnnotation("miq-pgdb-volume", &deployment.Spec.Template.ObjectMeta)
 		var repNum int32 = 1
 		deployment.Spec.Replicas = &repNum
+		deployment.Spec.Strategy = appsv1.DeploymentStrategy{
+			Type: "Recreate",
+		}
 		deployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 		deployment.Spec.Template.Spec.ServiceAccountName = defaultServiceAccountName(cr.Spec.AppName)
 		deployment.Spec.Template.Spec.Volumes = []corev1.Volume{


### PR DESCRIPTION
Rolling deployments require that a new pod be available before the old pod is killed for availability reasons.  However we have many services that should only ever have a single replica and having a second pod can actually cause some strange bugs.  This went unnoticed for many of our services since nothing would prevent a second pod from coming up, but it was found on the postgresql deployment since it needs to mount the data PVC and with most backing storages are `ReadWriteOnce` and the pod can not mount the PVC if another pod has it mounted.

I switched postgresql, kafka, zookeeper, memcached and the orchestrator to `Recreate` since there should only ever be one replica of those.  ~~I didn't see a problem with having multiple replicas of httpd, so I left that as `Rolling`.~~

EDIT: I switched httpd to `Recreate` as well until we have time to test whether or not it is safe to have multiple pods running concurrently.