### PR TITLE
Attempt to pull server GUID from existing orchestrator if one exists

### DIFF
--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -473,7 +473,7 @@ func (r *ReconcileManageIQ) generateSecrets(cr *miqv1alpha1.ManageIQ) error {
 }
 
 func (r *ReconcileManageIQ) manageCR(cr *miqv1alpha1.ManageIQ) error {
-	manageiq, mutateFunc := miqtool.ManageCR(cr)
+	manageiq, mutateFunc := miqtool.ManageCR(cr, &r.client)
 	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, manageiq, mutateFunc); err != nil {
 		return err
 	} else if result != controllerutil.OperationResultNone {

--- a/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
@@ -1,12 +1,14 @@
 package miqtools
 
 import (
+	"context"
 	miqv1alpha1 "github.com/ManageIQ/manageiq-pods/manageiq-operator/pkg/apis/manageiq/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"strconv"
 	"strings"
@@ -358,4 +360,17 @@ func OrchestratorDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*
 	}
 
 	return deployment, f, nil
+}
+
+func orchestratorPod(c client.Client) *corev1.Pod {
+	podList := &corev1.PodList{}
+	c.List(context.TODO(), podList)
+
+	for _, pod := range podList.Items {
+		if pod.ObjectMeta.Labels["name"] == "orchestrator" {
+			return &pod
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
In kasparov the source of truth for the server GUID was moved to the CR, but we didn't have a way to migrate the existing value to the CR.  Now, if the CR value is empty, we first look for an existing orchestrator pod and if found, we pull the GUID from the ENV var there, otherwise we generate a new one.  As before, if a value is specified in the CR, that value is used.
