### PR TITLE
Set the TLS certificate CN to the application domain

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -516,7 +516,7 @@ func HttpdDbusAPIService(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*cor
 }
 
 func TLSSecret(cr *miqv1alpha1.ManageIQ) (*corev1.Secret, error) {
-	crt, key, err := tlstools.GenerateCrt("server")
+	crt, key, err := tlstools.GenerateCrt(cr.Spec.ApplicationDomain)
 	if err != nil {
 		return nil, err
 	}

--- a/manageiq-operator/pkg/helpers/tlstools/generate_crt.go
+++ b/manageiq-operator/pkg/helpers/tlstools/generate_crt.go
@@ -24,7 +24,7 @@ func GenerateCrt(CN string) (crt []byte, key []byte, err error) {
 	template := x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
-			Organization: []string{CN},
+			CommonName: CN,
 		},
 		NotBefore: notBefore,
 		NotAfter:  notAfter,


### PR DESCRIPTION
This is still a self-signed certificate, but now at least it matches the name on the ingress route.