### PR TITLE
Add permissions to our role for Network Policies

### DIFF
--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq-operator.v0.0.1.clusterserviceversion.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq-operator.v0.0.1.clusterserviceversion.yaml
@@ -73,14 +73,14 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - configmaps
+          - persistentvolumeclaims
           - pods
           - pods/finalizers
-          - services
-          - services/finalizers
-          - persistentvolumeclaims
-          - configmaps
           - secrets
           - serviceaccounts
+          - services
+          - services/finalizers
           verbs:
           - '*'
         - apiGroups:
@@ -111,8 +111,8 @@ spec:
           resources:
           - servicemonitors
           verbs:
-          - get
           - create
+          - get
         - apiGroups:
           - apps
           resourceNames:

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq-operator.v0.0.1.clusterserviceversion.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq-operator.v0.0.1.clusterserviceversion.yaml
@@ -89,6 +89,7 @@ spec:
           - deployments
           - deployments/scale
           - ingresses
+          - networkpolicies
           verbs:
           - '*'
         - apiGroups:

--- a/manageiq-operator/deploy/role.yaml
+++ b/manageiq-operator/deploy/role.yaml
@@ -7,14 +7,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  - persistentvolumeclaims
   - pods
   - pods/finalizers
-  - services
-  - services/finalizers
-  - persistentvolumeclaims
-  - configmaps
   - secrets
   - serviceaccounts
+  - services
+  - services/finalizers
   verbs:
   - '*'
 - apiGroups:
@@ -45,8 +45,8 @@ rules:
   resources:
   - servicemonitors
   verbs:
-  - get
   - create
+  - get
 - apiGroups:
   - apps
   resourceNames:

--- a/manageiq-operator/deploy/role.yaml
+++ b/manageiq-operator/deploy/role.yaml
@@ -23,6 +23,7 @@ rules:
   - deployments
   - deployments/scale
   - ingresses
+  - networkpolicies
   verbs:
   - '*'
 - apiGroups:


### PR DESCRIPTION
Apparently I missed this in #649 

Caused:
```
{"level":"info","ts":1607019695.5361571,"logger":"cmd","msg":"Operator Version: 0.0.1"}
{"level":"info","ts":1607019695.5362833,"logger":"cmd","msg":"Go Version: go1.15.1"}
{"level":"info","ts":1607019695.536313,"logger":"cmd","msg":"Go OS/Arch: linux/amd64"}
{"level":"info","ts":1607019695.53633,"logger":"cmd","msg":"Version of operator-sdk: v0.15.1"}
{"level":"info","ts":1607019695.5367808,"logger":"leader","msg":"Trying to become the leader."}
{"level":"info","ts":1607019696.4477308,"logger":"leader","msg":"No pre-existing lock was found."}
{"level":"info","ts":1607019696.4512756,"logger":"leader","msg":"Became the leader."}
{"level":"info","ts":1607019697.2886543,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":"0.0.0.0:8383"}
{"level":"info","ts":1607019697.3398645,"logger":"cmd","msg":"Registering Components."}
{"level":"info","ts":1607019699.0022712,"logger":"metrics","msg":"Metrics Service object created","Service.Name":"manageiq-operator-metrics","Service.Namespace":"jrafanie-cpu-memory-limits"}
{"level":"info","ts":1607019699.8253868,"logger":"cmd","msg":"Starting the Cmd."}
{"level":"info","ts":1607019699.8257215,"logger":"controller-runtime.manager","msg":"starting metrics server","path":"/metrics"}
{"level":"info","ts":1607019699.825761,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"manageiq-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1607019699.9261346,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"manageiq-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1607019700.126554,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"manageiq-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1607019700.227045,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"manageiq-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1607019700.3275537,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"manageiq-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1607019700.4280872,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"manageiq-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1607019700.5285304,"logger":"controller-runtime.controller","msg":"Starting Controller","controller":"manageiq-controller"}
{"level":"info","ts":1607019700.528578,"logger":"controller-runtime.controller","msg":"Starting workers","controller":"manageiq-controller","worker count":1}
{"level":"info","ts":1607019700.528687,"logger":"controller_manageiq","msg":"Reconciling ManageIQ","Request.Namespace":"jrafanie-cpu-memory-limits","Request.Name":"miq"}
{"level":"info","ts":1607019700.6354854,"logger":"controller_manageiq","msg":"CR has been reconciled","component":"app","result":"updated"}
{"level":"info","ts":1607019701.0349376,"logger":"controller_manageiq","msg":"Operator has been reconciled","component":"app","result":"updated"}
{"level":"info","ts":1607019701.139003,"logger":"controller_manageiq","msg":"Service Account has been reconciled","component":"operator","result":"updated"}
{"level":"info","ts":1607019701.3550503,"logger":"controller_manageiq","msg":"Role has been reconciled","component":"operator","result":"updated"}
{"level":"info","ts":1607019701.3587835,"logger":"controller_manageiq","msg":"Role Binding has been reconciled","component":"operator","result":"updated"}
E1203 18:21:41.359868       1 reflector.go:123] pkg/mod/k8s.io/client-go@v0.0.0-20191016111102-bec269661e48/tools/cache/reflector.go:96: Failed to list *v1beta1.NetworkPolicy: networkpolicies.extensions is forbidden: User "system:serviceaccount:jrafanie-cpu-memory-limits:manageiq-operator" cannot list networkpolicies.extensions in the namespace "jrafanie-cpu-memory-limits": no RBAC policy matched
E1203 18:21:42.362687       1 reflector.go:123] pkg/mod/k8s.io/client-go@v0.0.0-20191016111102-bec269661e48/tools/cache/reflector.go:96: Failed to list *v1beta1.NetworkPolicy: networkpolicies.extensions is forbidden: User "system:serviceaccount:jrafanie-cpu-memory-limits:manageiq-operator" cannot list networkpolicies.extensions in the namespace "jrafanie-cpu-memory-limits": no RBAC policy matched
```