### PR TITLE
Add debug logging for the reconcile loop

### DIFF
--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -109,14 +109,17 @@ func (r *ReconcileManageIQ) Reconcile(request reconcile.Request) (reconcile.Resu
 		return reconcile.Result{}, nil
 	}
 
+	logger.Info("Reconciling the CR...")
 	if e := r.manageCR(miqInstance); e != nil {
 		return reconcile.Result{}, e
 	}
 
+	logger.Info("Validating the CR...")
 	if e := miqInstance.Validate(); e != nil {
 		return reconcile.Result{}, e
 	}
 
+	logger.Info("Reconciling the operator pod...")
 	if os.Getenv("POD_NAME") != "" {
 		if e := r.manageOperator(miqInstance); e != nil {
 			return reconcile.Result{}, e
@@ -125,29 +128,37 @@ func (r *ReconcileManageIQ) Reconcile(request reconcile.Request) (reconcile.Resu
 		logger.Info("Skipping reconcile of the operator pod; not running in a cluster.")
 	}
 
+	logger.Info("Reconciling the NetworkPolicies...")
 	if e := r.generateNetworkPolicies(miqInstance); e != nil {
 		return reconcile.Result{}, e
 	}
+	logger.Info("Reconciling the Secrets...")
 	if e := r.generateSecrets(miqInstance); e != nil {
 		return reconcile.Result{}, e
 	}
+	logger.Info("Reconciling the default Service Account...")
 	if e := r.generateDefaultServiceAccount(miqInstance); e != nil {
 		return reconcile.Result{}, e
 	}
+	logger.Info("Reconciling the Postgresql resources...")
 	if e := r.generatePostgresqlResources(miqInstance); e != nil {
 		return reconcile.Result{}, e
 	}
+	logger.Info("Reconciling the HTTPD resources...")
 	if e := r.generateHttpdResources(miqInstance); e != nil {
 		return reconcile.Result{}, e
 	}
+	logger.Info("Reconciling the Memcached resources...")
 	if e := r.generateMemcachedResources(miqInstance); e != nil {
 		return reconcile.Result{}, e
 	}
 	if *miqInstance.Spec.DeployMessagingService {
+		logger.Info("Reconciling the Kafka resources...")
 		if e := r.generateKafkaResources(miqInstance); e != nil {
 			return reconcile.Result{}, e
 		}
 	}
+	logger.Info("Reconciling the Orchestrator resources...")
 	if e := r.generateOrchestratorResources(miqInstance); e != nil {
 		return reconcile.Result{}, e
 	}


### PR DESCRIPTION
This should help with debugging when something unexpected blows up during reconcile.  Unfortunately there is only `Info` or `Error`, no `Debug` or anything else.  https://godoc.org/github.com/go-logr/logr#Logger

After:
```
$ operator-sdk run --local --namespace=bdunne-miq
INFO[0000] Running the operator locally in namespace bdunne-miq. 
{"level":"info","ts":1607556770.8386567,"logger":"cmd","msg":"Operator Version: 0.0.1"}
{"level":"info","ts":1607556770.838682,"logger":"cmd","msg":"Go Version: go1.14.4"}
{"level":"info","ts":1607556770.8386874,"logger":"cmd","msg":"Go OS/Arch: linux/amd64"}
{"level":"info","ts":1607556770.8386927,"logger":"cmd","msg":"Version of operator-sdk: v0.15.1"}
{"level":"info","ts":1607556770.8412135,"logger":"leader","msg":"Trying to become the leader."}
{"level":"info","ts":1607556770.841233,"logger":"leader","msg":"Skipping leader election; not running in a cluster."}
{"level":"info","ts":1607556771.7643633,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":"0.0.0.0:8383"}
{"level":"info","ts":1607556771.7645845,"logger":"cmd","msg":"Registering Components."}
{"level":"info","ts":1607556771.7648163,"logger":"cmd","msg":"Skipping CR metrics server creation; not running in a cluster."}
{"level":"info","ts":1607556771.7648256,"logger":"cmd","msg":"Starting the Cmd."}
{"level":"info","ts":1607556771.7649767,"logger":"controller-runtime.manager","msg":"starting metrics server","path":"/metrics"}
{"level":"info","ts":1607556771.7650287,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"manageiq-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1607556771.8653333,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"manageiq-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1607556771.9663239,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"manageiq-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1607556772.0665567,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"manageiq-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1607556772.1668022,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"manageiq-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1607556772.4671407,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"manageiq-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1607556772.567397,"logger":"controller-runtime.controller","msg":"Starting Controller","controller":"manageiq-controller"}
{"level":"info","ts":1607556772.5674253,"logger":"controller-runtime.controller","msg":"Starting workers","controller":"manageiq-controller","worker count":1}
{"level":"info","ts":1607556772.567477,"logger":"controller_manageiq","msg":"Reconciling ManageIQ","Request.Namespace":"bdunne-miq","Request.Name":"miq"}
{"level":"info","ts":1607556772.5675042,"logger":"controller_manageiq","msg":"Reconciling the CR..."}
{"level":"info","ts":1607556772.567537,"logger":"controller_manageiq","msg":"Validating the CR..."}
{"level":"info","ts":1607556772.5675397,"logger":"controller_manageiq","msg":"Reconciling the operator pod..."}
{"level":"info","ts":1607556772.5675445,"logger":"controller_manageiq","msg":"Skipping reconcile of the operator pod; not running in a cluster."}
{"level":"info","ts":1607556772.5675528,"logger":"controller_manageiq","msg":"Reconciling the NetworkPolicies..."}
{"level":"info","ts":1607556772.8683853,"logger":"controller_manageiq","msg":"Reconciling the Secrets..."}
{"level":"info","ts":1607556772.9490652,"logger":"controller_manageiq","msg":"Reconciling the default Service Account..."}
{"level":"info","ts":1607556773.0493145,"logger":"controller_manageiq","msg":"Reconciling the Postgresql resources..."}
{"level":"info","ts":1607556773.0791745,"logger":"controller_manageiq","msg":"Deployment has been reconciled","component":"postgresql","result":"updated"}
{"level":"info","ts":1607556773.0792482,"logger":"controller_manageiq","msg":"Reconciling the HTTPD resources..."}
{"level":"info","ts":1607556773.102431,"logger":"controller_manageiq","msg":"Deployment has been reconciled","component":"httpd","result":"updated"}
{"level":"info","ts":1607556773.2026544,"logger":"controller_manageiq","msg":"Reconciling the Memcached resources..."}
{"level":"info","ts":1607556773.2287612,"logger":"controller_manageiq","msg":"Deployment has been reconciled","component":"memcached","result":"updated"}
{"level":"info","ts":1607556773.2288496,"logger":"controller_manageiq","msg":"Reconciling the Orchestrator resources..."}
{"level":"info","ts":1607556773.485772,"logger":"controller_manageiq","msg":"Deployment has been reconciled","component":"orchestrator","result":"updated"}
{"level":"info","ts":1607556773.4858267,"logger":"controller_manageiq","msg":"Reconciling ManageIQ","Request.Namespace":"bdunne-miq","Request.Name":"miq"}
{"level":"info","ts":1607556773.4858525,"logger":"controller_manageiq","msg":"Reconciling the CR..."}
{"level":"info","ts":1607556773.485898,"logger":"controller_manageiq","msg":"Validating the CR..."}
{"level":"info","ts":1607556773.4859056,"logger":"controller_manageiq","msg":"Reconciling the operator pod..."}
{"level":"info","ts":1607556773.4859111,"logger":"controller_manageiq","msg":"Skipping reconcile of the operator pod; not running in a cluster."}
{"level":"info","ts":1607556773.485916,"logger":"controller_manageiq","msg":"Reconciling the NetworkPolicies..."}
{"level":"info","ts":1607556773.48634,"logger":"controller_manageiq","msg":"Reconciling the Secrets..."}
{"level":"info","ts":1607556773.71239,"logger":"controller_manageiq","msg":"Reconciling the default Service Account..."}
{"level":"info","ts":1607556773.712433,"logger":"controller_manageiq","msg":"Reconciling the Postgresql resources..."}
{"level":"info","ts":1607556773.7733874,"logger":"controller_manageiq","msg":"Deployment has been reconciled","component":"postgresql","result":"updated"}
{"level":"info","ts":1607556773.7734163,"logger":"controller_manageiq","msg":"Reconciling the HTTPD resources..."}
{"level":"info","ts":1607556773.7961938,"logger":"controller_manageiq","msg":"Deployment has been reconciled","component":"httpd","result":"updated"}
{"level":"info","ts":1607556773.79628,"logger":"controller_manageiq","msg":"Reconciling the Memcached resources..."}
{"level":"info","ts":1607556773.8190548,"logger":"controller_manageiq","msg":"Deployment has been reconciled","component":"memcached","result":"updated"}
{"level":"info","ts":1607556773.8191292,"logger":"controller_manageiq","msg":"Reconciling the Orchestrator resources..."}
{"level":"info","ts":1607556773.8427503,"logger":"controller_manageiq","msg":"Deployment has been reconciled","component":"orchestrator","result":"updated"}

```