### PR TITLE
Exclude net-snmp* packages from ubi repo

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -53,7 +53,7 @@ RUN dnf -y --disableplugin=subscription-manager install \
     dnf -y --disableplugin=subscription-manager module enable nodejs:12 && \
     dnf -y --disableplugin=subscription-manager module enable ruby:2.6 && \
     if [[ "$RELEASE_BUILD" != "true" ]]; then dnf config-manager --enable manageiq-12-lasker-nightly; fi && \
-    dnf config-manager --setopt=ubi-8-*.exclude=redhat-release* --save && \
+    dnf config-manager --setopt=ubi-8-*.exclude=net-snmp*,redhat-release* --save && \
     if [[ "$LOCAL_RPM" = "true" ]]; then /create_local_yum_repo.sh; fi && \
     dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
       ${RPM_PREFIX}-pods          \


### PR DESCRIPTION
UBI 8.3 image was updated yesterday and that is causing build to fail:

```
 Problem 1: package net-snmp-utils-1:5.8-17.el8.x86_64 requires net-snmp-libs(x86-64) = 1:5.8-17.el8, but none of the providers can be installed
  - cannot install both net-snmp-libs-1:5.8-18.el8_3.1.x86_64 and net-snmp-libs-1:5.8-17.el8.x86_64
  - cannot install the best update candidate for package net-snmp-utils-1:5.8-17.el8.x86_64
  - cannot install the best update candidate for package net-snmp-libs-1:5.8-17.el8.x86_64
 ...
```

Reported by @jrafanie 