### PR TITLE
Add simple installation process for the VMware VDDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ manageiq-operator/build/_output/*
 parameters
 manageiq-operator/vendor/*
 images/manageiq-base/rpms
+images/manageiq-base-worker/container-assets/VMware-*
 
 *.swp

--- a/README.md
+++ b/README.md
@@ -220,3 +220,7 @@ Then, run:
 ```bash
 bin/build -d images -r manageiq -l
 ```
+
+### Including the VMware VDDK in the image build
+
+Download the VMware VDDK library and move or copy it into the `images/manageiq-base-worker/container-assets/` directory before starting the image build.  If found, the image build will copy the files into the desired location and link the shared objects for you.

--- a/images/manageiq-base-worker/Dockerfile
+++ b/images/manageiq-base-worker/Dockerfile
@@ -1,6 +1,13 @@
 ARG FROM_REPO=manageiq
 ARG FROM_TAG=latest
 
+FROM ${FROM_REPO}/manageiq-base:${FROM_TAG} AS vddk
+
+COPY container-assets/ /vddk/
+
+RUN /vddk/extract-vmware-vddk
+
+
 FROM ${FROM_REPO}/manageiq-base:${FROM_TAG}
 MAINTAINER ManageIQ https://manageiq.org
 
@@ -9,6 +16,10 @@ LABEL name="manageiq-base-worker" \
 
 COPY container-assets/entrypoint /usr/local/bin
 COPY container-assets/manageiq_liveness_check /usr/local/bin
+
+COPY --from=vddk /vddk/vmware-vix-disklib-distrib/ /usr/lib/vmware-vix-disklib/
+COPY container-assets/install-vmware-vddk /tmp/
+RUN /tmp/install-vmware-vddk
 
 RUN source /etc/default/evm && /usr/bin/generate_rpm_manifest.sh
 

--- a/images/manageiq-base-worker/container-assets/extract-vmware-vddk
+++ b/images/manageiq-base-worker/container-assets/extract-vmware-vddk
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd /vddk
+filename=$(ls VMware-*)
+
+# Skip the install if the VDDK library is not found
+[[ -f $filename ]] && tar -zxvf VMware-* || mkdir vmware-vix-disklib-distrib

--- a/images/manageiq-base-worker/container-assets/install-vmware-vddk
+++ b/images/manageiq-base-worker/container-assets/install-vmware-vddk
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Skip the install if the VDDK library is not found
+[[ -d /usr/lib/vmware-vix-disklib/lib64/ ]] || exit 0
+
+echo "VDDK library found, installing..."
+for SO in $(ls /usr/lib/vmware-vix-disklib/lib64/libvixDiskLib.so*)
+  do ln -s $SO /usr/lib/$(basename $SO)
+done
+
+ldconfig


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-pods/issues/538

I'm not sure if we want to go this route or have a dedicated `Dockerfile` that builds on top of the worker base image, but since it's used for both scanning and webmks, I thought this might be easier.  Either way, the code would be the same.