### PR TITLE
[IVANCHUK] Lock bundler to v2.1.4

### DIFF
--- a/images/miq-app/Dockerfile
+++ b/images/miq-app/Dockerfile
@@ -87,7 +87,7 @@ RUN ${APPLIANCE_ROOT}/setup && \
 WORKDIR ${APP_ROOT}
 RUN source /etc/default/evm && \
     export RAILS_USE_MEMORY_STORE="true" && \
-    gem install bundler -v ">=1.16.2" && \
+    gem install bundler -v 2.1.4 && \
     bundle config set with 'qpid_proton' && \
     bundle install && \
     bin/rails log:clear tmp:clear && \


### PR DESCRIPTION
The latest version of bundler (2.2.4) doesn't work with the version of git available on CentOS 7. It's probably not a good idea to keep updating bundler on older branches anyway, so locking to 2.1.4 which is what was used in ivanchuk-7 release.