### PR TITLE
Pull the latest base image for operator build

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -105,7 +105,7 @@ popd
 
 if [ -z "$NO_OPERATOR" ]; then
   pushd "$OPERATOR_DIR"
-    cmd="operator-sdk build $REPO/manageiq-operator:$TAG"
+    cmd="operator-sdk build --image-build-args --pull $REPO/manageiq-operator:$TAG"
     echo "Building manageiq-operator: $cmd"
     $cmd
   popd


### PR DESCRIPTION
Without `--pull` option, the base image specified in manageiq-operator Dockerfile (registry.access.redhat.com/ubi8/ubi-minimal:latest) doesn't get updated even if there is a newer version available.