### PR TITLE
Added support for Managed OIDC Configurations

### DIFF
--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -245,7 +245,7 @@ func (r *ReconcileManageIQ) generateHttpdResources(cr *miqv1alpha1.ManageIQ) err
 		}
 	}
 
-	httpdDeployment, mutateFunc, err := miqtool.HttpdDeployment(cr, r.scheme)
+	httpdDeployment, mutateFunc, err := miqtool.HttpdDeployment(r.client, cr, r.scheme)
 	if err != nil {
 		return err
 	}
@@ -289,7 +289,7 @@ func (r *ReconcileManageIQ) generateMemcachedResources(cr *miqv1alpha1.ManageIQ)
 }
 
 func (r *ReconcileManageIQ) generatePostgresqlResources(cr *miqv1alpha1.ManageIQ) error {
-	hostName := getSecretKeyValue(r.client, cr.Namespace, cr.Spec.DatabaseSecret, "hostname")
+	hostName := miqtool.GetSecretKeyValue(r.client, cr.Namespace, cr.Spec.DatabaseSecret, "hostname")
 	if hostName != "" {
 		logger.Info("External PostgreSQL Database selected, skipping postgresql service reconciliation", "hostname", hostName)
 		return nil
@@ -336,7 +336,7 @@ func (r *ReconcileManageIQ) generatePostgresqlResources(cr *miqv1alpha1.ManageIQ
 }
 
 func (r *ReconcileManageIQ) generateKafkaResources(cr *miqv1alpha1.ManageIQ) error {
-	hostName := getSecretKeyValue(r.client, cr.Namespace, cr.Spec.KafkaSecret, "hostname")
+	hostName := miqtool.GetSecretKeyValue(r.client, cr.Namespace, cr.Spec.KafkaSecret, "hostname")
 	if hostName != "" {
 		logger.Info("External Kafka Messaging Service selected, skipping kafka and zookeeper service reconciliation", "hostname", hostName)
 		return nil
@@ -590,14 +590,4 @@ func (r *ReconcileManageIQ) createk8sResIfNotExist(cr *miqv1alpha1.ManageIQ, res
 		return err
 	}
 	return nil
-}
-
-func getSecretKeyValue(client client.Client, nameSpace string, secretName string, keyName string) string {
-	secretKey := types.NamespacedName{Namespace: nameSpace, Name: secretName}
-	secret := &corev1.Secret{}
-	secretErr := client.Get(context.TODO(), secretKey, secret)
-	if secretErr != nil {
-		return ""
-	}
-	return string(secret.Data[keyName])
 }

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -2,6 +2,7 @@ package manageiq
 
 import (
 	"context"
+	"strings"
 
 	miqv1alpha1 "github.com/ManageIQ/manageiq-pods/manageiq-operator/pkg/apis/manageiq/v1alpha1"
 
@@ -16,14 +17,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 var logger = log.Log.WithName("controller_manageiq")
+var controller_manageiq controller.Controller
 
 // Add creates a new ManageIQ Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -43,6 +47,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	if err != nil {
 		return err
 	}
+	controller_manageiq = c
 
 	// Watch for changes to primary resource ManageIQ
 	err = c.Watch(&source.Kind{Type: &miqv1alpha1.ManageIQ{}}, &handler.EnqueueRequestForObject{})
@@ -101,6 +106,26 @@ func (r *ReconcileManageIQ) Reconcile(request reconcile.Request) (reconcile.Resu
 	reqLogger := logger.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling ManageIQ")
 
+	if strings.HasPrefix(request.Name, "httpd-auth-config-secret-") {
+		// Mapped secret name coming as httpd-auth-config-secret-<miq_instance_name>-<secret_name>
+		rString := strings.TrimPrefix(request.Name, "httpd-auth-config-secret-")
+		nSlices := strings.SplitN(rString, "-", 2)
+		// Fetch the ManageIQ instance
+		miqInstance := &miqv1alpha1.ManageIQ{}
+		err := r.client.Get(context.TODO(), types.NamespacedName{
+			Namespace: request.Namespace,
+			Name:      nSlices[0],
+		}, miqInstance)
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		logger.Info("Reconciling the HTTPD Deployment ...")
+		if e := r.reconcileHttpdDeployment(miqInstance); e != nil {
+			return reconcile.Result{}, e
+		}
+		return reconcile.Result{}, nil
+	}
+
 	// Fetch the ManageIQ instance
 	miqInstance := &miqv1alpha1.ManageIQ{}
 
@@ -116,6 +141,11 @@ func (r *ReconcileManageIQ) Reconcile(request reconcile.Request) (reconcile.Resu
 
 	logger.Info("Validating the CR...")
 	if e := miqInstance.Validate(); e != nil {
+		return reconcile.Result{}, e
+	}
+
+	logger.Info("Creating Secret Watchers ...")
+	if e := r.createSecretWatchers(miqInstance); e != nil {
 		return reconcile.Result{}, e
 	}
 
@@ -245,6 +275,21 @@ func (r *ReconcileManageIQ) generateHttpdResources(cr *miqv1alpha1.ManageIQ) err
 		}
 	}
 
+	if err := r.reconcileHttpdDeployment(cr); err != nil {
+		return err
+	}
+
+	httpdIngress, mutateFunc := miqtool.Ingress(cr, r.scheme)
+	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, httpdIngress, mutateFunc); err != nil {
+		return err
+	} else if result != controllerutil.OperationResultNone {
+		logger.Info("Ingress has been reconciled", "component", "httpd", "result", result)
+	}
+
+	return nil
+}
+
+func (r *ReconcileManageIQ) reconcileHttpdDeployment(cr *miqv1alpha1.ManageIQ) error {
 	httpdDeployment, mutateFunc, err := miqtool.HttpdDeployment(r.client, cr, r.scheme)
 	if err != nil {
 		return err
@@ -255,14 +300,6 @@ func (r *ReconcileManageIQ) generateHttpdResources(cr *miqv1alpha1.ManageIQ) err
 	} else if result != controllerutil.OperationResultNone {
 		logger.Info("Deployment has been reconciled", "component", "httpd", "result", result)
 	}
-
-	httpdIngress, mutateFunc := miqtool.Ingress(cr, r.scheme)
-	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, httpdIngress, mutateFunc); err != nil {
-		return err
-	} else if result != controllerutil.OperationResultNone {
-		logger.Info("Ingress has been reconciled", "component", "httpd", "result", result)
-	}
-
 	return nil
 }
 
@@ -537,6 +574,52 @@ func (r *ReconcileManageIQ) manageCR(cr *miqv1alpha1.ManageIQ) error {
 		logger.Info("CR has been reconciled", "component", "app", "result", result)
 	}
 
+	return nil
+}
+
+func (r *ReconcileManageIQ) createSecretWatchers(cr *miqv1alpha1.ManageIQ) error {
+	if cr.Spec.HttpdAuthConfig != "" {
+		secret := &corev1.Secret{}
+		secretErr := r.client.Get(context.TODO(), types.NamespacedName{Namespace: cr.Namespace, Name: cr.Spec.HttpdAuthConfig}, secret)
+		if secretErr != nil {
+			return nil
+		}
+		mapFn := handler.ToRequestsFunc(
+			func(a handler.MapObject) []reconcile.Request {
+				mappedName := a.Meta.GetName()
+				if mappedName == cr.Spec.HttpdAuthConfig {
+					mappedName = "httpd-auth-config-secret-" + cr.Name + "-" + mappedName
+				}
+				return []reconcile.Request{
+					{NamespacedName: types.NamespacedName{
+						Name:      mappedName,
+						Namespace: a.Meta.GetNamespace(),
+					}},
+				}
+			})
+
+		predicateFn := predicate.Funcs{
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				return e.MetaNew.GetName() == cr.Spec.HttpdAuthConfig
+			},
+			CreateFunc: func(e event.CreateEvent) bool {
+				return e.Meta.GetName() == cr.Spec.HttpdAuthConfig
+			},
+		}
+
+		err := controller_manageiq.Watch(&source.Kind{Type: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: cr.Namespace,
+				Name:      cr.Spec.HttpdAuthConfig,
+			},
+		}}, &handler.EnqueueRequestsFromMapFunc{
+			ToRequests: mapFn,
+		}, predicateFn)
+
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -289,7 +289,7 @@ func (r *ReconcileManageIQ) generateMemcachedResources(cr *miqv1alpha1.ManageIQ)
 }
 
 func (r *ReconcileManageIQ) generatePostgresqlResources(cr *miqv1alpha1.ManageIQ) error {
-	hostName := miqtool.GetSecretKeyValue(r.client, cr.Namespace, cr.Spec.DatabaseSecret, "hostname")
+	hostName := getSecretKeyValue(r.client, cr.Namespace, cr.Spec.DatabaseSecret, "hostname")
 	if hostName != "" {
 		logger.Info("External PostgreSQL Database selected, skipping postgresql service reconciliation", "hostname", hostName)
 		return nil
@@ -336,7 +336,7 @@ func (r *ReconcileManageIQ) generatePostgresqlResources(cr *miqv1alpha1.ManageIQ
 }
 
 func (r *ReconcileManageIQ) generateKafkaResources(cr *miqv1alpha1.ManageIQ) error {
-	hostName := miqtool.GetSecretKeyValue(r.client, cr.Namespace, cr.Spec.KafkaSecret, "hostname")
+	hostName := getSecretKeyValue(r.client, cr.Namespace, cr.Spec.KafkaSecret, "hostname")
 	if hostName != "" {
 		logger.Info("External Kafka Messaging Service selected, skipping kafka and zookeeper service reconciliation", "hostname", hostName)
 		return nil
@@ -590,4 +590,14 @@ func (r *ReconcileManageIQ) createk8sResIfNotExist(cr *miqv1alpha1.ManageIQ, res
 		return err
 	}
 	return nil
+}
+
+func getSecretKeyValue(client client.Client, nameSpace string, secretName string, keyName string) string {
+	secretKey := types.NamespacedName{Namespace: nameSpace, Name: secretName}
+	secret := &corev1.Secret{}
+	secretErr := client.Get(context.TODO(), secretKey, secret)
+	if secretErr != nil {
+		return ""
+	}
+	return string(secret.Data[keyName])
 }

--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -191,6 +191,7 @@ func getHttpdAuthConfigVersion(client client.Client, namespace string, spec *miq
 }
 
 func setManagedHttpdCfgVersion(httpdAuthConfigVersion string, podSpec *corev1.PodSpec) {
+	// This is not used by the pod, it is defined to trigger a redeployment if the secret was updated
 	managedHttpdCfgRevision := corev1.EnvVar{Name: "MANAGED_HTTPD_CFG_VERSION", Value: httpdAuthConfigVersion}
 	podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, managedHttpdCfgRevision)
 }

--- a/manageiq-operator/pkg/helpers/miq-components/util.go
+++ b/manageiq-operator/pkg/helpers/miq-components/util.go
@@ -1,9 +1,12 @@
 package miqtools
 
 import (
+	"context"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func addResourceReqs(memLimit, memReq, cpuLimit, cpuReq string, c *corev1.Container) error {
@@ -84,4 +87,14 @@ func addAnnotations(annotations map[string]string, meta *metav1.ObjectMeta) {
 			meta.Annotations[key] = value
 		}
 	}
+}
+
+func GetSecretKeyValue(client client.Client, nameSpace string, secretName string, keyName string) string {
+	secretKey := types.NamespacedName{Namespace: nameSpace, Name: secretName}
+	secret := &corev1.Secret{}
+	secretErr := client.Get(context.TODO(), secretKey, secret)
+	if secretErr != nil {
+		return ""
+	}
+	return string(secret.Data[keyName])
 }

--- a/manageiq-operator/pkg/helpers/miq-components/util.go
+++ b/manageiq-operator/pkg/helpers/miq-components/util.go
@@ -1,12 +1,9 @@
 package miqtools
 
 import (
-	"context"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func addResourceReqs(memLimit, memReq, cpuLimit, cpuReq string, c *corev1.Container) error {
@@ -87,14 +84,4 @@ func addAnnotations(annotations map[string]string, meta *metav1.ObjectMeta) {
 			meta.Annotations[key] = value
 		}
 	}
-}
-
-func GetSecretKeyValue(client client.Client, nameSpace string, secretName string, keyName string) string {
-	secretKey := types.NamespacedName{Namespace: nameSpace, Name: secretName}
-	secret := &corev1.Secret{}
-	secretErr := client.Get(context.TODO(), secretKey, secret)
-	if secretErr != nil {
-		return ""
-	}
-	return string(secret.Data[keyName])
 }


### PR DESCRIPTION
Added Support for Managed OIDC Configurations.

With Managed OIDC configurations, parent managing applications, can rewire and reconfigure all OIDC client registrations against an identity provider, then provide us the updated parameters via the HttpdAuthConfig secret.

With this PR, the operator would define the following httpd pod environment variable:

- MANAGED_HTTPD_CFG_VERSION

to reflect the latest resourceVersion of the provided HttpdAuthConfig secret. 
Upon an update to the secret, the Httpd pod environment will get updated and then restarted by Openshift for Apache to honor the new configuration.

- [x] Tested

<strike>Added support for Managed OIDC Configurations.

Managed environments provide the configured OIDC parameters as secret key/value pairs in the HttpdAuthConfig secret
as follows:

- managed.cfg.client_id       (OIDC Client ID)
- managed.cfg.client_secret   (OIDC Client Secret)
- managed.cfg.app_domain      (Application Domain for ManageIQ)
- managed.cfg.mgmt_domain     (Domain for the parent management application)

These configurations get defined as httpd pod environment variables:

- MANAGED_CFG_CLIENT_ID
- MANAGED_CFG_CLIENT_SECRET
- MANAGED_CFG_APP_DOMAIN
- MANAGED_CFG_MGMT_DOMAIN

Parent managing application can rewire and reconfigure all OIDC client registrations against an identity provider and then provide the updated parameters via the HttpdAuthConfig secret.

Upon updating these pod environment variables, the HTTPD pod will automatically be restarted by Openshift for Apache to honor the new OIDC configuration.
</strike>

