### PR TITLE
Adding support for custom images

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 	"net/http"
+	"os"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -245,6 +246,12 @@ func configureHttpdAuth(spec *miqv1alpha1.ManageIQSpec, podSpec *corev1.PodSpec)
 
 func httpdImage(namespace, tag string, privileged bool) string {
 	var image string
+
+	envHttpdImage := os.Getenv("HTTPD_IMAGE")
+	if envHttpdImage != "" {
+		return envHttpdImage
+	}
+
 	if privileged {
 		image = "httpd-init"
 	} else {

--- a/manageiq-operator/pkg/helpers/miq-components/kafka.go
+++ b/manageiq-operator/pkg/helpers/miq-components/kafka.go
@@ -7,6 +7,7 @@ import (
 	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"os"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -174,9 +175,14 @@ func KafkaDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*appsv1.
 		"app":  cr.Spec.AppName,
 	}
 
+	kafkaImage := os.Getenv("KAFKA_IMAGE")
+	if kafkaImage == "" {
+		kafkaImage = cr.Spec.KafkaImageName + ":" + cr.Spec.KafkaImageTag
+	}
+
 	container := corev1.Container{
 		Name:            "kafka",
-		Image:           cr.Spec.KafkaImageName + ":" + cr.Spec.KafkaImageTag,
+		Image:           kafkaImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Ports: []corev1.ContainerPort{
 			corev1.ContainerPort{
@@ -279,9 +285,14 @@ func ZookeeperDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*app
 		"app":  cr.Spec.AppName,
 	}
 
+	zookeeperImage := os.Getenv("ZOOKEEPER_IMAGE")
+	if zookeeperImage == "" {
+		zookeeperImage = cr.Spec.ZookeeperImageName + ":" + cr.Spec.ZookeeperImageTag
+	}
+
 	container := corev1.Container{
 		Name:            "zookeeper",
-		Image:           cr.Spec.ZookeeperImageName + ":" + cr.Spec.ZookeeperImageTag,
+		Image:           zookeeperImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Ports: []corev1.ContainerPort{
 			corev1.ContainerPort{


### PR DESCRIPTION
Adding support for custom image specifications via environment variables:
      - HTTPD_IMAGE
      - KAFKA_IMAGE
      - ZOOKEEPER_IMAGE
      - MEMCACHED_IMAGE
      - BASEWORKER_IMAGE
      - WEBSERVERWORKER_IMAGE
      - UIWORKER_IMAGE
      - ORCHESTRATOR_IMAGE
      - POSTGRESQL_IMAGE

Memcached and Postgresql PodSpec now define the default ServiceAccountName

