### PR TITLE
Adding support for optional Image References

### DIFF
--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -88,7 +88,7 @@ spec:
               description: 'Httpd deployment CPU request (default: no request)'
               type: string
             httpdImage:
-              description: 'Image string used for the httpd deployment (default: <HttpdImageNamespace>:<HttpdImageTag>)'
+              description: 'Image string used for the httpd deployment (default: <HttpdImageNamespace>/httpd[-init]:<HttpdImageTag>)'
               type: string
             httpdImageNamespace:
               description: 'Image namespace used for the httpd deployment (default:
@@ -199,7 +199,7 @@ spec:
               type: string
             orchestratorImage:
               description: 'Image string used for the orchestrator deployment (default:
-                <OrchestratorImageName>:<OrchestratorImageTag>)'
+                <OrchestratorImageNamespace>/<OrchestratorImageName>:<OrchestratorImageTag>)'
               type: string
             orchestratorImageName:
               description: 'Image name used for the orchestrator deployment (default:

--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -88,8 +88,7 @@ spec:
               description: 'Httpd deployment CPU request (default: no request)'
               type: string
             httpdImage:
-              description: Image string used for the httpd deployment By default HttpdImageNamespace:HttpdImageTag
-                takes effect
+              description: 'Image string used for the httpd deployment (default: <HttpdImageNamespace>:<HttpdImageTag>)'
               type: string
             httpdImageNamespace:
               description: 'Image namespace used for the httpd deployment (default:
@@ -120,8 +119,7 @@ spec:
               description: 'Kafka deployment CPU limit (default: no limit)'
               type: string
             kafkaImage:
-              description: Image string used for the kafka deployment By default KafkaImageName:KafkaImageTag
-                takes effect
+              description: 'Image string used for the kafka deployment (default: <KafkaImageName>:<KafkaImageTag>)'
               type: string
             kafkaImageName:
               description: 'Image used for the kafka deployment (default: docker.io/bitnami/kafka)'
@@ -149,8 +147,8 @@ spec:
               description: 'Memcached deployment CPU request (default: no request)'
               type: string
             memcachedImage:
-              description: Image string used for the memcached deployment By default
-                MemcachedImageName:MemcachedImageTag takes effect
+              description: 'Image string used for the memcached deployment (default:
+                <MemcachedImageName>:<MemcachedImageTag>)'
               type: string
             memcachedImageName:
               description: 'Image used for the memcached deployment (default: manageiq/memcached)'
@@ -200,8 +198,8 @@ spec:
               description: 'Orchestrator deployment CPU request (default: no request)'
               type: string
             orchestratorImage:
-              description: Image string used for the orchestrator deployment By default
-                OrchestratorImageName:OrchestratorImageTag takes effect
+              description: 'Image string used for the orchestrator deployment (default:
+                <OrchestratorImageName>:<OrchestratorImageTag>)'
               type: string
             orchestratorImageName:
               description: 'Image name used for the orchestrator deployment (default:
@@ -232,8 +230,8 @@ spec:
               description: 'PostgreSQL deployment CPU request (default: no request)'
               type: string
             postgresqlImage:
-              description: Image string used for the postgresql deployment By default
-                PostgresqlImageName:PostGresqlImageTag takes effect
+              description: 'Image string used for the postgresql deployment (default:
+                <PostgresqlImageName>:<PostgresqlImageTag>)'
               type: string
             postgresqlImageName:
               description: 'Image used for the postgresql deployment (Default: docker.io/manageiq/postgresql)'
@@ -279,8 +277,8 @@ spec:
               description: 'Zookeeper deployment CPU limit (default: no limit)'
               type: string
             zookeeperImage:
-              description: Image string used for the zookeeper deployment By default
-                ZookeeperImageName:ZookeeperImageTag takes effect
+              description: 'Image string used for the zookeeper deployment (default:
+                <ZookeeperImageName>:<ZookeeperImageTag>)'
               type: string
             zookeeperImageName:
               description: 'Image used for the zookeeper deployment (default: docker.io/bitnami/zookeeper)'

--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -87,6 +87,10 @@ spec:
             httpdCpuRequest:
               description: 'Httpd deployment CPU request (default: no request)'
               type: string
+            httpdImage:
+              description: Image string used for the httpd deployment By default HttpdImageNamespace:HttpdImageTag
+                takes effect
+              type: string
             httpdImageNamespace:
               description: 'Image namespace used for the httpd deployment (default:
                 manageiq) Note: the exact image will be determined by the authentication
@@ -115,6 +119,10 @@ spec:
             kafkaCpulimit:
               description: 'Kafka deployment CPU limit (default: no limit)'
               type: string
+            kafkaImage:
+              description: Image string used for the kafka deployment By default KafkaImageName:KafkaImageTag
+                takes effect
+              type: string
             kafkaImageName:
               description: 'Image used for the kafka deployment (default: docker.io/bitnami/kafka)'
               type: string
@@ -139,6 +147,10 @@ spec:
               type: string
             memcachedCpuRequest:
               description: 'Memcached deployment CPU request (default: no request)'
+              type: string
+            memcachedImage:
+              description: Image string used for the memcached deployment By default
+                MemcachedImageName:MemcachedImageTag takes effect
               type: string
             memcachedImageName:
               description: 'Image used for the memcached deployment (default: manageiq/memcached)'
@@ -187,6 +199,10 @@ spec:
             orchestratorCpuRequest:
               description: 'Orchestrator deployment CPU request (default: no request)'
               type: string
+            orchestratorImage:
+              description: Image string used for the orchestrator deployment By default
+                OrchestratorImageName:OrchestratorImageTag takes effect
+              type: string
             orchestratorImageName:
               description: 'Image name used for the orchestrator deployment (default:
                 manageiq-orchestrator)'
@@ -214,6 +230,10 @@ spec:
               type: string
             postgresqlCpuRequest:
               description: 'PostgreSQL deployment CPU request (default: no request)'
+              type: string
+            postgresqlImage:
+              description: Image string used for the postgresql deployment By default
+                PostgresqlImageName:PostGresqlImageTag takes effect
               type: string
             postgresqlImageName:
               description: 'Image used for the postgresql deployment (Default: docker.io/manageiq/postgresql)'
@@ -257,6 +277,10 @@ spec:
               type: string
             zookeeperCpulimit:
               description: 'Zookeeper deployment CPU limit (default: no limit)'
+              type: string
+            zookeeperImage:
+              description: Image string used for the zookeeper deployment By default
+                ZookeeperImageName:ZookeeperImageTag takes effect
               type: string
             zookeeperImageName:
               description: 'Image used for the zookeeper deployment (default: docker.io/bitnami/zookeeper)'

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -88,7 +88,7 @@ spec:
               description: 'Httpd deployment CPU request (default: no request)'
               type: string
             httpdImage:
-              description: 'Image string used for the httpd deployment (default: <HttpdImageNamespace>:<HttpdImageTag>)'
+              description: 'Image string used for the httpd deployment (default: <HttpdImageNamespace>/httpd[-init]:<HttpdImageTag>)'
               type: string
             httpdImageNamespace:
               description: 'Image namespace used for the httpd deployment (default:
@@ -199,7 +199,7 @@ spec:
               type: string
             orchestratorImage:
               description: 'Image string used for the orchestrator deployment (default:
-                <OrchestratorImageName>:<OrchestratorImageTag>)'
+                <OrchestratorImageNamespace>/<OrchestratorImageName>:<OrchestratorImageTag>)'
               type: string
             orchestratorImageName:
               description: 'Image name used for the orchestrator deployment (default:

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -88,8 +88,7 @@ spec:
               description: 'Httpd deployment CPU request (default: no request)'
               type: string
             httpdImage:
-              description: Image string used for the httpd deployment By default HttpdImageNamespace:HttpdImageTag
-                takes effect
+              description: 'Image string used for the httpd deployment (default: <HttpdImageNamespace>:<HttpdImageTag>)'
               type: string
             httpdImageNamespace:
               description: 'Image namespace used for the httpd deployment (default:
@@ -120,8 +119,7 @@ spec:
               description: 'Kafka deployment CPU limit (default: no limit)'
               type: string
             kafkaImage:
-              description: Image string used for the kafka deployment By default KafkaImageName:KafkaImageTag
-                takes effect
+              description: 'Image string used for the kafka deployment (default: <KafkaImageName>:<KafkaImageTag>)'
               type: string
             kafkaImageName:
               description: 'Image used for the kafka deployment (default: docker.io/bitnami/kafka)'
@@ -149,8 +147,8 @@ spec:
               description: 'Memcached deployment CPU request (default: no request)'
               type: string
             memcachedImage:
-              description: Image string used for the memcached deployment By default
-                MemcachedImageName:MemcachedImageTag takes effect
+              description: 'Image string used for the memcached deployment (default:
+                <MemcachedImageName>:<MemcachedImageTag>)'
               type: string
             memcachedImageName:
               description: 'Image used for the memcached deployment (default: manageiq/memcached)'
@@ -200,8 +198,8 @@ spec:
               description: 'Orchestrator deployment CPU request (default: no request)'
               type: string
             orchestratorImage:
-              description: Image string used for the orchestrator deployment By default
-                OrchestratorImageName:OrchestratorImageTag takes effect
+              description: 'Image string used for the orchestrator deployment (default:
+                <OrchestratorImageName>:<OrchestratorImageTag>)'
               type: string
             orchestratorImageName:
               description: 'Image name used for the orchestrator deployment (default:
@@ -232,8 +230,8 @@ spec:
               description: 'PostgreSQL deployment CPU request (default: no request)'
               type: string
             postgresqlImage:
-              description: Image string used for the postgresql deployment By default
-                PostgresqlImageName:PostGresqlImageTag takes effect
+              description: 'Image string used for the postgresql deployment (default:
+                <PostgresqlImageName>:<PostgresqlImageTag>)'
               type: string
             postgresqlImageName:
               description: 'Image used for the postgresql deployment (Default: docker.io/manageiq/postgresql)'
@@ -279,8 +277,8 @@ spec:
               description: 'Zookeeper deployment CPU limit (default: no limit)'
               type: string
             zookeeperImage:
-              description: Image string used for the zookeeper deployment By default
-                ZookeeperImageName:ZookeeperImageTag takes effect
+              description: 'Image string used for the zookeeper deployment (default:
+                <ZookeeperImageName>:<ZookeeperImageTag>)'
               type: string
             zookeeperImageName:
               description: 'Image used for the zookeeper deployment (default: docker.io/bitnami/zookeeper)'

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -87,6 +87,10 @@ spec:
             httpdCpuRequest:
               description: 'Httpd deployment CPU request (default: no request)'
               type: string
+            httpdImage:
+              description: Image string used for the httpd deployment By default HttpdImageNamespace:HttpdImageTag
+                takes effect
+              type: string
             httpdImageNamespace:
               description: 'Image namespace used for the httpd deployment (default:
                 manageiq) Note: the exact image will be determined by the authentication
@@ -115,6 +119,10 @@ spec:
             kafkaCpulimit:
               description: 'Kafka deployment CPU limit (default: no limit)'
               type: string
+            kafkaImage:
+              description: Image string used for the kafka deployment By default KafkaImageName:KafkaImageTag
+                takes effect
+              type: string
             kafkaImageName:
               description: 'Image used for the kafka deployment (default: docker.io/bitnami/kafka)'
               type: string
@@ -139,6 +147,10 @@ spec:
               type: string
             memcachedCpuRequest:
               description: 'Memcached deployment CPU request (default: no request)'
+              type: string
+            memcachedImage:
+              description: Image string used for the memcached deployment By default
+                MemcachedImageName:MemcachedImageTag takes effect
               type: string
             memcachedImageName:
               description: 'Image used for the memcached deployment (default: manageiq/memcached)'
@@ -187,6 +199,10 @@ spec:
             orchestratorCpuRequest:
               description: 'Orchestrator deployment CPU request (default: no request)'
               type: string
+            orchestratorImage:
+              description: Image string used for the orchestrator deployment By default
+                OrchestratorImageName:OrchestratorImageTag takes effect
+              type: string
             orchestratorImageName:
               description: 'Image name used for the orchestrator deployment (default:
                 manageiq-orchestrator)'
@@ -214,6 +230,10 @@ spec:
               type: string
             postgresqlCpuRequest:
               description: 'PostgreSQL deployment CPU request (default: no request)'
+              type: string
+            postgresqlImage:
+              description: Image string used for the postgresql deployment By default
+                PostgresqlImageName:PostGresqlImageTag takes effect
               type: string
             postgresqlImageName:
               description: 'Image used for the postgresql deployment (Default: docker.io/manageiq/postgresql)'
@@ -257,6 +277,10 @@ spec:
               type: string
             zookeeperCpulimit:
               description: 'Zookeeper deployment CPU limit (default: no limit)'
+              type: string
+            zookeeperImage:
+              description: Image string used for the zookeeper deployment By default
+                ZookeeperImageName:ZookeeperImageTag takes effect
               type: string
             zookeeperImageName:
               description: 'Image used for the zookeeper deployment (default: docker.io/bitnami/zookeeper)'

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -57,7 +57,7 @@ type ManageIQSpec struct {
 	StorageClassName string `json:"storageClassName"`
 
 	// Image string used for the httpd deployment
-	// By default HttpdImageNamespace:HttpdImageTag takes effect
+	// (default: <HttpdImageNamespace>:<HttpdImageTag>)
 	// +optional
 	HttpdImage string `json:"httpdImage"`
 	// Image namespace used for the httpd deployment (default: manageiq)
@@ -117,7 +117,7 @@ type ManageIQSpec struct {
 	HttpdMemoryRequest string `json:"httpdMemoryRequest"`
 
 	// Image string used for the memcached deployment
-	// By default MemcachedImageName:MemcachedImageTag takes effect
+	// (default: <MemcachedImageName>:<MemcachedImageTag>)
 	// +optional
 	MemcachedImage string `json:"memcachedImage"`
 	// Image used for the memcached deployment (default: manageiq/memcached)
@@ -151,7 +151,7 @@ type ManageIQSpec struct {
 	MemcachedSlabPageSize string `json:"memcachedSlabPageSize"`
 
 	// Image string used for the orchestrator deployment
-	// By default OrchestratorImageName:OrchestratorImageTag takes effect
+	// (default: <OrchestratorImageName>:<OrchestratorImageTag>)
 	// +optional
 	OrchestratorImage string `json:"orchestratorImage"`
 	// Image name used for the orchestrator deployment (default: manageiq-orchestrator)
@@ -194,7 +194,7 @@ type ManageIQSpec struct {
 	UIWorkerImage string `json:"uiWorkerImage"`
 
 	// Image string used for the postgresql deployment
-	// By default PostgresqlImageName:PostGresqlImageTag takes effect
+	// (default: <PostgresqlImageName>:<PostgresqlImageTag>)
 	// +optional
 	PostgresqlImage string `json:"postgresqlImage"`
 	// Image used for the postgresql deployment (Default: docker.io/manageiq/postgresql)
@@ -233,7 +233,7 @@ type ManageIQSpec struct {
 	DeployMessagingService *bool `json:"deployMessagingService"`
 
 	// Image string used for the kafka deployment
-	// By default KafkaImageName:KafkaImageTag takes effect
+	// (default: <KafkaImageName>:<KafkaImageTag>)
 	// +optional
 	KafkaImage string `json:"kafkaImage"`
 	// Image used for the kafka deployment (default: docker.io/bitnami/kafka)
@@ -259,7 +259,7 @@ type ManageIQSpec struct {
 	KafkaMemoryRequest string `json:"kafkaMemoryRequest"`
 
 	// Image string used for the zookeeper deployment
-	// By default ZookeeperImageName:ZookeeperImageTag takes effect
+	// (default: <ZookeeperImageName>:<ZookeeperImageTag>)
 	// +optional
 	ZookeeperImage string `json:"zookeeperImage"`
 	// Image used for the zookeeper deployment (default: docker.io/bitnami/zookeeper)

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -56,6 +56,10 @@ type ManageIQSpec struct {
 	// +optional
 	StorageClassName string `json:"storageClassName"`
 
+	// Image string used for the httpd deployment
+	// By default HttpdImageNamespace:HttpdImageTag takes effect
+	// +optional
+	HttpdImage string `json:"httpdImage"`
 	// Image namespace used for the httpd deployment (default: manageiq)
 	// Note: the exact image will be determined by the authentication method selected
 	// +optional
@@ -112,6 +116,10 @@ type ManageIQSpec struct {
 	// +optional
 	HttpdMemoryRequest string `json:"httpdMemoryRequest"`
 
+	// Image string used for the memcached deployment
+	// By default MemcachedImageName:MemcachedImageTag takes effect
+	// +optional
+	MemcachedImage string `json:"memcachedImage"`
 	// Image used for the memcached deployment (default: manageiq/memcached)
 	// +optional
 	MemcachedImageName string `json:"memcachedImageName"`
@@ -142,6 +150,10 @@ type ManageIQSpec struct {
 	// +optional
 	MemcachedSlabPageSize string `json:"memcachedSlabPageSize"`
 
+	// Image string used for the orchestrator deployment
+	// By default OrchestratorImageName:OrchestratorImageTag takes effect
+	// +optional
+	OrchestratorImage string `json:"orchestratorImage"`
 	// Image name used for the orchestrator deployment (default: manageiq-orchestrator)
 	// +optional
 	OrchestratorImageName string `json:"orchestratorImageName"`
@@ -181,6 +193,10 @@ type ManageIQSpec struct {
 	// +optional
 	UIWorkerImage string `json:"uiWorkerImage"`
 
+	// Image string used for the postgresql deployment
+	// By default PostgresqlImageName:PostGresqlImageTag takes effect
+	// +optional
+	PostgresqlImage string `json:"postgresqlImage"`
 	// Image used for the postgresql deployment (Default: docker.io/manageiq/postgresql)
 	// +optional
 	PostgresqlImageName string `json:"postgresqlImageName"`
@@ -216,6 +232,10 @@ type ManageIQSpec struct {
 	// +optional
 	DeployMessagingService *bool `json:"deployMessagingService"`
 
+	// Image string used for the kafka deployment
+	// By default KafkaImageName:KafkaImageTag takes effect
+	// +optional
+	KafkaImage string `json:"kafkaImage"`
 	// Image used for the kafka deployment (default: docker.io/bitnami/kafka)
 	// +optional
 	KafkaImageName string `json:"kafkaImageName"`
@@ -238,6 +258,10 @@ type ManageIQSpec struct {
 	// +optional
 	KafkaMemoryRequest string `json:"kafkaMemoryRequest"`
 
+	// Image string used for the zookeeper deployment
+	// By default ZookeeperImageName:ZookeeperImageTag takes effect
+	// +optional
+	ZookeeperImage string `json:"zookeeperImage"`
 	// Image used for the zookeeper deployment (default: docker.io/bitnami/zookeeper)
 	// +optional
 	ZookeeperImageName string `json:"zookeeperImageName"`

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -57,7 +57,7 @@ type ManageIQSpec struct {
 	StorageClassName string `json:"storageClassName"`
 
 	// Image string used for the httpd deployment
-	// (default: <HttpdImageNamespace>:<HttpdImageTag>)
+	// (default: <HttpdImageNamespace>/httpd[-init]:<HttpdImageTag>)
 	// +optional
 	HttpdImage string `json:"httpdImage"`
 	// Image namespace used for the httpd deployment (default: manageiq)
@@ -151,7 +151,7 @@ type ManageIQSpec struct {
 	MemcachedSlabPageSize string `json:"memcachedSlabPageSize"`
 
 	// Image string used for the orchestrator deployment
-	// (default: <OrchestratorImageName>:<OrchestratorImageTag>)
+	// (default: <OrchestratorImageNamespace>/<OrchestratorImageName>:<OrchestratorImageTag>)
 	// +optional
 	OrchestratorImage string `json:"orchestratorImage"`
 	// Image name used for the orchestrator deployment (default: manageiq-orchestrator)

--- a/manageiq-operator/pkg/helpers/miq-components/cr.go
+++ b/manageiq-operator/pkg/helpers/miq-components/cr.go
@@ -98,19 +98,19 @@ func httpdImageTag(cr *miqv1alpha1.ManageIQ) string {
 }
 
 func httpdImage(cr *miqv1alpha1.ManageIQ, privileged bool) string {
-	if cr.Spec.HttpdImage == "" {
-		var image string
-
-		if privileged {
-			image = "httpd-init"
-		} else {
-			image = "httpd"
-		}
-
-		return cr.Spec.HttpdImageNamespace + "/" + image + ":" + cr.Spec.HttpdImageTag
-	} else {
+	if cr.Spec.HttpdImage != "" {
 		return cr.Spec.HttpdImage
 	}
+
+	var image string
+
+	if privileged {
+		image = "httpd-init"
+	} else {
+		image = "httpd"
+	}
+
+	return cr.Spec.HttpdImageNamespace + "/" + image + ":" + cr.Spec.HttpdImageTag
 }
 
 func imagePullSecretName(cr *miqv1alpha1.ManageIQ, client client.Client) string {

--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -243,22 +243,6 @@ func configureHttpdAuth(spec *miqv1alpha1.ManageIQSpec, podSpec *corev1.PodSpec)
 	}
 }
 
-func httpdImage(imageref string, namespace string, tag string, privileged bool) string {
-	var image string
-
-	if imageref != "" {
-		return imageref
-	}
-
-	if privileged {
-		image = "httpd-init"
-	} else {
-		image = "httpd"
-	}
-
-	return fmt.Sprintf("%s/%s:%s", namespace, image, tag)
-}
-
 func assignHttpdPorts(privileged bool, c *corev1.Container) {
 	httpdPort := corev1.ContainerPort{
 		ContainerPort: 8080,
@@ -277,7 +261,7 @@ func assignHttpdPorts(privileged bool, c *corev1.Container) {
 
 func initializeHttpdContainer(spec *miqv1alpha1.ManageIQSpec, privileged bool, c *corev1.Container) error {
 	c.Name = "httpd"
-	c.Image = httpdImage(spec.HttpdImage, spec.HttpdImageNamespace, spec.HttpdImageTag, privileged)
+	c.Image = spec.HttpdImage
 	c.ImagePullPolicy = corev1.PullIfNotPresent
 	if privileged {
 		c.LivenessProbe = &corev1.Probe{

--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -243,8 +243,13 @@ func configureHttpdAuth(spec *miqv1alpha1.ManageIQSpec, podSpec *corev1.PodSpec)
 	}
 }
 
-func httpdImage(namespace, tag string, privileged bool) string {
+func httpdImage(imageref string, namespace string, tag string, privileged bool) string {
 	var image string
+
+	if imageref != "" {
+		return imageref
+	}
+
 	if privileged {
 		image = "httpd-init"
 	} else {
@@ -272,7 +277,7 @@ func assignHttpdPorts(privileged bool, c *corev1.Container) {
 
 func initializeHttpdContainer(spec *miqv1alpha1.ManageIQSpec, privileged bool, c *corev1.Container) error {
 	c.Name = "httpd"
-	c.Image = httpdImage(spec.HttpdImageNamespace, spec.HttpdImageTag, privileged)
+	c.Image = httpdImage(spec.HttpdImage, spec.HttpdImageNamespace, spec.HttpdImageTag, privileged)
 	c.ImagePullPolicy = corev1.PullIfNotPresent
 	if privileged {
 		c.LivenessProbe = &corev1.Probe{

--- a/manageiq-operator/pkg/helpers/miq-components/kafka.go
+++ b/manageiq-operator/pkg/helpers/miq-components/kafka.go
@@ -174,9 +174,14 @@ func KafkaDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*appsv1.
 		"app":  cr.Spec.AppName,
 	}
 
+	kafkaImage := cr.Spec.KafkaImage
+	if kafkaImage == "" {
+		kafkaImage = cr.Spec.KafkaImageName + ":" + cr.Spec.KafkaImageTag
+	}
+
 	container := corev1.Container{
 		Name:            "kafka",
-		Image:           cr.Spec.KafkaImageName + ":" + cr.Spec.KafkaImageTag,
+		Image:           kafkaImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Ports: []corev1.ContainerPort{
 			corev1.ContainerPort{
@@ -279,9 +284,14 @@ func ZookeeperDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*app
 		"app":  cr.Spec.AppName,
 	}
 
+	zookeeperImage := cr.Spec.ZookeeperImage
+	if zookeeperImage == "" {
+		zookeeperImage = cr.Spec.ZookeeperImageName + ":" + cr.Spec.ZookeeperImageTag
+	}
+
 	container := corev1.Container{
 		Name:            "zookeeper",
-		Image:           cr.Spec.ZookeeperImageName + ":" + cr.Spec.ZookeeperImageTag,
+		Image:           zookeeperImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Ports: []corev1.ContainerPort{
 			corev1.ContainerPort{

--- a/manageiq-operator/pkg/helpers/miq-components/kafka.go
+++ b/manageiq-operator/pkg/helpers/miq-components/kafka.go
@@ -174,14 +174,9 @@ func KafkaDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*appsv1.
 		"app":  cr.Spec.AppName,
 	}
 
-	kafkaImage := cr.Spec.KafkaImage
-	if kafkaImage == "" {
-		kafkaImage = cr.Spec.KafkaImageName + ":" + cr.Spec.KafkaImageTag
-	}
-
 	container := corev1.Container{
 		Name:            "kafka",
-		Image:           kafkaImage,
+		Image:           cr.Spec.KafkaImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Ports: []corev1.ContainerPort{
 			corev1.ContainerPort{
@@ -284,14 +279,9 @@ func ZookeeperDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*app
 		"app":  cr.Spec.AppName,
 	}
 
-	zookeeperImage := cr.Spec.ZookeeperImage
-	if zookeeperImage == "" {
-		zookeeperImage = cr.Spec.ZookeeperImageName + ":" + cr.Spec.ZookeeperImageTag
-	}
-
 	container := corev1.Container{
 		Name:            "zookeeper",
-		Image:           zookeeperImage,
+		Image:           cr.Spec.ZookeeperImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Ports: []corev1.ContainerPort{
 			corev1.ContainerPort{

--- a/manageiq-operator/pkg/helpers/miq-components/memcached.go
+++ b/manageiq-operator/pkg/helpers/miq-components/memcached.go
@@ -11,14 +11,9 @@ import (
 )
 
 func NewMemcachedDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*appsv1.Deployment, controllerutil.MutateFn, error) {
-	memcachedImage := cr.Spec.MemcachedImage
-	if memcachedImage == "" {
-		memcachedImage = cr.Spec.MemcachedImageName + ":" + cr.Spec.MemcachedImageTag
-	}
-
 	container := corev1.Container{
 		Name:            "memcached",
-		Image:           memcachedImage,
+		Image:           cr.Spec.MemcachedImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Ports: []corev1.ContainerPort{
 			corev1.ContainerPort{

--- a/manageiq-operator/pkg/helpers/miq-components/memcached.go
+++ b/manageiq-operator/pkg/helpers/miq-components/memcached.go
@@ -11,9 +11,14 @@ import (
 )
 
 func NewMemcachedDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*appsv1.Deployment, controllerutil.MutateFn, error) {
+	memcachedImage := cr.Spec.MemcachedImage
+	if memcachedImage == "" {
+		memcachedImage = cr.Spec.MemcachedImageName + ":" + cr.Spec.MemcachedImageTag
+	}
+
 	container := corev1.Container{
 		Name:            "memcached",
-		Image:           cr.Spec.MemcachedImageName + ":" + cr.Spec.MemcachedImageTag,
+		Image:           memcachedImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Ports: []corev1.ContainerPort{
 			corev1.ContainerPort{

--- a/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
@@ -213,9 +213,14 @@ func OrchestratorDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, cl
 		"app":  cr.Spec.AppName,
 	}
 
+	orchestratorImage := cr.Spec.OrchestratorImage
+	if orchestratorImage == "" {
+		orchestratorImage = cr.Spec.OrchestratorImageNamespace + "/" + cr.Spec.OrchestratorImageName + ":" + cr.Spec.OrchestratorImageTag
+	}
+
 	container := corev1.Container{
 		Name:            "orchestrator",
-		Image:           cr.Spec.OrchestratorImageNamespace + "/" + cr.Spec.OrchestratorImageName + ":" + cr.Spec.OrchestratorImageTag,
+		Image:           orchestratorImage,
 		ImagePullPolicy: pullPolicy,
 		LivenessProbe: &corev1.Probe{
 			Handler: corev1.Handler{

--- a/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
@@ -213,14 +213,9 @@ func OrchestratorDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, cl
 		"app":  cr.Spec.AppName,
 	}
 
-	orchestratorImage := cr.Spec.OrchestratorImage
-	if orchestratorImage == "" {
-		orchestratorImage = cr.Spec.OrchestratorImageNamespace + "/" + cr.Spec.OrchestratorImageName + ":" + cr.Spec.OrchestratorImageTag
-	}
-
 	container := corev1.Container{
 		Name:            "orchestrator",
-		Image:           orchestratorImage,
+		Image:           cr.Spec.OrchestratorImage,
 		ImagePullPolicy: pullPolicy,
 		LivenessProbe: &corev1.Probe{
 			Handler: corev1.Handler{

--- a/manageiq-operator/pkg/helpers/miq-components/postgresql.go
+++ b/manageiq-operator/pkg/helpers/miq-components/postgresql.go
@@ -149,14 +149,9 @@ func PostgresqlDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*ap
 	}
 	var initialDelaySecs int32 = 60
 
-	postgresqlImage := cr.Spec.PostgresqlImage
-	if postgresqlImage == "" {
-		postgresqlImage = cr.Spec.PostgresqlImageName + ":" + cr.Spec.PostgresqlImageTag
-	}
-
 	container := corev1.Container{
 		Name:            "postgresql",
-		Image:           postgresqlImage,
+		Image:           cr.Spec.PostgresqlImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Ports: []corev1.ContainerPort{
 			corev1.ContainerPort{

--- a/manageiq-operator/pkg/helpers/miq-components/postgresql.go
+++ b/manageiq-operator/pkg/helpers/miq-components/postgresql.go
@@ -149,9 +149,14 @@ func PostgresqlDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*ap
 	}
 	var initialDelaySecs int32 = 60
 
+	postgresqlImage := cr.Spec.PostgresqlImage
+	if postgresqlImage == "" {
+		postgresqlImage = cr.Spec.PostgresqlImageName + ":" + cr.Spec.PostgresqlImageTag
+	}
+
 	container := corev1.Container{
 		Name:            "postgresql",
-		Image:           cr.Spec.PostgresqlImageName + ":" + cr.Spec.PostgresqlImageTag,
+		Image:           postgresqlImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Ports: []corev1.ContainerPort{
 			corev1.ContainerPort{


### PR DESCRIPTION
Adding support for optional Image References instead of the ImageName and ImageTag parameter pairs. If not specified,
then the default ImageName:ImageTag image reference is used.

New optional CR parameters:

  - PostgresqlImage
  - HttpdImage
  - OrchestratorImage
  - MemcachedImage
  - KafkaImage
  - ZookeeperImage

Todo:

- [x] Test with Meta operator
