### PR TITLE
Limit the scope of the default-deny network policy

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/network_policies.go
+++ b/manageiq-operator/pkg/helpers/miq-components/network_policies.go
@@ -21,6 +21,8 @@ func NetworkPolicyDefaultDeny(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) 
 		addAppLabel(cr.Spec.AppName, &networkPolicy.ObjectMeta)
 		setIngressPolicyType(networkPolicy)
 
+		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"app": cr.Spec.AppName}
+
 		return nil
 	}
 


### PR DESCRIPTION
Only applies to pods labeled with the AppName defined in the CR