### PR TITLE
Ensure images and operator dirs are relative to the base dir

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -11,8 +11,6 @@ CORE_REPO_NAME=${CORE_REPO_NAME:-manageiq}
 GIT_HOST=${GIT_HOST:-github.com}
 GIT_AUTH=${GIT_AUTH:-""}
 
-OPERATOR_DIR=${OPERATOR_DIR:-manageiq-operator}
-
 RPM_BUILD_OPTIONS=${RPM_BUILD_OPTIONS:-""}
 RPM_BUILD_IMAGE=${RPM_BUILD_IMAGE:-"manageiq/rpm_build:$TAG"}
 RPM_PREFIX=${RPM_PREFIX:-"manageiq"}
@@ -20,7 +18,7 @@ RPM_PREFIX=${RPM_PREFIX:-"manageiq"}
 while getopts "t:d:r:hblnops" opt; do
   case $opt in
     b) REBUILD_RPM="true" ;;
-    d) IMAGE_DIR=$OPTARG ;;
+    d) BASE_DIR=$OPTARG ;;
     l) LOCAL_RPM="true" ;;
     n) NO_CACHE="true" ;;
     o) NO_OPERATOR="true" ;;
@@ -28,14 +26,16 @@ while getopts "t:d:r:hblnops" opt; do
     r) REPO=$OPTARG ;;
     s) RELEASE_BUILD="true" ;;
     t) TAG=$OPTARG ;;
-    h) echo "Usage: $0 -d IMAGE_DIR -r IMAGE_REPOSITORY [-hblnops] [ -t IMAGE_TAG ]"; exit 1
+    h) echo "Usage: $0 -d BASE_DIR -r IMAGE_REPOSITORY [-hblnops] [ -t IMAGE_TAG ]"; exit 1
   esac
 done
 
-if [ -z "$IMAGE_DIR" ]; then
-  echo "Required parameter for image directory (-d) is missing"
+if [ -z "$BASE_DIR" ]; then
+  echo "Required parameter for base directory (-d) is missing"
   exit 1
 fi
+IMAGE_DIR="$BASE_DIR/images"
+OPERATOR_DIR="$BASE_DIR/manageiq-operator"
 
 if [ -z "$REPO" ]; then
   echo "Required parameter for repository (-r) is missing"


### PR DESCRIPTION
Without this PR, the operator dir is not relativel to the base dir, and is assuming that `pwd` is the base dir, so when it tries to pushd to it, it fails

Note that this PR changes the meaning of `-d`, so it is a breaking change and will require changes on the build machine.