### PR TITLE
Only allow valid authentication types in the CRs

### DIFF
--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -80,6 +80,7 @@ spec:
                 internal, external, active-directory, saml, openid-connect Note: external,
                 active-directory, and saml require an httpd container with elevated
                 privileges'
+              pattern: \A(active-directory|external|internal|openid-connect|saml)\z
               type: string
             httpdCpuLimit:
               description: 'Httpd deployment CPU limit (default: no limit)'

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/0.0.1/manageiq.org_manageiqs_crd.yaml
@@ -80,6 +80,7 @@ spec:
                 internal, external, active-directory, saml, openid-connect Note: external,
                 active-directory, and saml require an httpd container with elevated
                 privileges'
+              pattern: \A(active-directory|external|internal|openid-connect|saml)\z
               type: string
             httpdCpuLimit:
               description: 'Httpd deployment CPU limit (default: no limit)'

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -72,6 +72,7 @@ type ManageIQSpec struct {
 	// Options: internal, external, active-directory, saml, openid-connect
 	// Note: external, active-directory, and saml require an httpd container with elevated privileges
 	// +optional
+	// +kubebuilder:validation:Pattern=\A(active-directory|external|internal|openid-connect|saml)\z
 	HttpdAuthenticationType string `json:"httpdAuthenticationType"`
 	// URL for the OIDC provider
 	// Only used with the openid-connect authentication type

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -178,10 +178,7 @@ func (r *ReconcileManageIQ) generateDefaultServiceAccount(cr *miqv1alpha1.Manage
 }
 
 func (r *ReconcileManageIQ) generateHttpdResources(cr *miqv1alpha1.ManageIQ) error {
-	privileged, err := miqtool.PrivilegedHttpd(cr.Spec.HttpdAuthenticationType)
-	if err != nil {
-		return err
-	}
+	privileged := miqtool.PrivilegedHttpd(cr.Spec.HttpdAuthenticationType)
 
 	if privileged {
 		httpdServiceAccount, mutateFunc := miqtool.HttpdServiceAccount(cr, r.scheme)

--- a/manageiq-operator/pkg/helpers/miq-components/cr.go
+++ b/manageiq-operator/pkg/helpers/miq-components/cr.go
@@ -97,11 +97,12 @@ func httpdImageTag(cr *miqv1alpha1.ManageIQ) string {
 	}
 }
 
-func httpdImage(cr *miqv1alpha1.ManageIQ, privileged bool) string {
+func httpdImage(cr *miqv1alpha1.ManageIQ) string {
 	if cr.Spec.HttpdImage != "" {
 		return cr.Spec.HttpdImage
 	}
 
+	privileged := PrivilegedHttpd(cr.Spec.HttpdAuthenticationType)
 	var image string
 
 	if privileged {
@@ -354,13 +355,7 @@ func ManageCR(cr *miqv1alpha1.ManageIQ, c *client.Client) (*miqv1alpha1.ManageIQ
 		cr.Spec.HttpdAuthenticationType = httpdAuthenticationType(cr)
 		cr.Spec.HttpdImageNamespace = httpdImageNamespace(cr)
 		cr.Spec.HttpdImageTag = httpdImageTag(cr)
-
-		privileged, err := PrivilegedHttpd(cr.Spec.HttpdAuthenticationType)
-		if err != nil {
-			return err
-		}
-
-		cr.Spec.HttpdImage = httpdImage(cr, privileged)
+		cr.Spec.HttpdImage = httpdImage(cr)
 		cr.Spec.ImagePullSecret = imagePullSecretName(cr, *c)
 		cr.Spec.KafkaImageName = kafkaImageName(cr)
 		cr.Spec.KafkaImageTag = kafkaImageTag(cr)


### PR DESCRIPTION
- Move enforcement to the CRD OpenAPI schema
- Move privileged checking in the CR into the httpdImage function since there is no more error case
- Clean up unnecessary error checking

Based on https://github.com/ManageIQ/manageiq-pods/pull/680#discussion_r574648175