### PR TITLE
Exclude dracut from ubi8 repo to avoid conflicts

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -44,7 +44,7 @@ RUN dnf -y --disableplugin=subscription-manager install \
     dnf -y --disableplugin=subscription-manager module enable nodejs:12 && \
     dnf -y --disableplugin=subscription-manager module enable ruby:2.6 && \
     if [[ "$RELEASE_BUILD" != "true" ]]; then dnf config-manager --enable manageiq-12-lasker-nightly; fi && \
-    dnf config-manager --setopt=ubi-8-*.exclude=net-snmp*,redhat-release* --save && \
+    dnf config-manager --setopt=ubi-8-*.exclude=dracut*,net-snmp*,redhat-release* --save && \
     if [[ "$LOCAL_RPM" = "true" ]]; then /create_local_yum_repo.sh; fi && \
     dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
       ${RPM_PREFIX}-pods          \


### PR DESCRIPTION
dracut was updated in UBI8 repo recently, and now it's causing a conflict with what's in CentOS.

```
Error:
 Problem: package dracut-network-049-95.git20200804.el8.x86_64 requires dracut = 049-95.git20200804.el8, but none of the providers can be installed
  - cannot install both dracut-049-95.git20200804.el8_3.4.x86_64 and dracut-049-95.git20200804.el8.x86_64
  - cannot install the best update candidate for package dracut-network-049-95.git20200804.el8.x86_64
  - cannot install the best update candidate for package dracut-049-95.git20200804.el8.x86_64
```

dracut (and net-snmp) seems to cause conflicts often, this should probably be kept excluded all the time.