### PR TITLE
We only need the ruby environment, not full container_env

### DIFF
--- a/images/manageiq-base-worker/container-assets/manageiq_liveness_check
+++ b/images/manageiq-base-worker/container-assets/manageiq_liveness_check
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-source ${APP_ROOT}/container_env
+[[ -s /etc/default/evm ]] && source /etc/default/evm
 ruby ${APP_ROOT}/lib/workers/bin/heartbeat_check.rb --heartbeat-file=${APP_ROOT}/tmp/worker.hb


### PR DESCRIPTION
7d841daecccaacbbe made this work but container_env does expensive URL
escaping of the DATABASE_USER and PASSWORD to build DATABASE_URL which
is not needed in the liveness check. Since all pods run this liveness check
many times per minutes, it has to be as fast as possible.

This drops a few 100ms from the liveness check depending on the environment.