### PR TITLE
Fasterer liveness check

### DIFF
--- a/images/manageiq-base-worker/container-assets/manageiq_liveness_check
+++ b/images/manageiq-base-worker/container-assets/manageiq_liveness_check
@@ -1,4 +1,27 @@
 #!/bin/bash
 
-[[ -s /etc/default/evm ]] && source /etc/default/evm
-ruby ${APP_ROOT}/lib/workers/bin/heartbeat_check.rb --heartbeat-file=${APP_ROOT}/tmp/worker.hb
+# hb_file needs to either exist or only contain a time in unix time
+# TODO: Simplify: only write unix time in file (don't rely on mtime)
+hb_file="${APP_ROOT}/tmp/worker.hb"
+if [[ -f ${hb_file} ]]; then
+  current_time=$(date +%s)
+  custom_timeout=$(cat ${hb_file})
+  if [[ -z $custom_timeout ]]; then
+    # TODO: This goes away if we always write unix time in hb file
+    # mtime=$(stat -f "%m" ${hb_file}) # for testing on mac
+    mtime=$(stat -c "%Y" ${hb_file})   # for linux
+
+    # TODO: this hardcoded timeout goes away if we always write unix time in hb file
+    timeout=$((${mtime} + 120))
+  else
+    timeout=$custom_timeout
+  fi
+
+  if [ $current_time -le $timeout ]; then
+    exit 0
+  else
+    exit 1
+  fi
+else
+  exit 1
+fi

--- a/images/manageiq-base-worker/container-assets/manageiq_liveness_check
+++ b/images/manageiq-base-worker/container-assets/manageiq_liveness_check
@@ -1,27 +1,15 @@
 #!/bin/bash
 
-# hb_file needs to either exist or only contain a time in unix time
-# TODO: Simplify: only write unix time in file (don't rely on mtime)
-hb_file="${APP_ROOT}/tmp/worker.hb"
-if [[ -f ${hb_file} ]]; then
-  current_time=$(date +%s)
-  custom_timeout=$(cat ${hb_file})
-  if [[ -z $custom_timeout ]]; then
-    # TODO: This goes away if we always write unix time in hb file
-    # mtime=$(stat -f "%m" ${hb_file}) # for testing on mac
-    mtime=$(stat -c "%Y" ${hb_file})   # for linux
+# We're alive if the heartbeat_file exists and has a unix time
+# "newer" / greater than the current time.
+heartbeat_file="${APP_ROOT}/tmp/worker.hb"
+if [[ ! -f ${heartbeat_file} ]]; then
+  exit 1
+fi
 
-    # TODO: this hardcoded timeout goes away if we always write unix time in hb file
-    timeout=$((${mtime} + 120))
-  else
-    timeout=$custom_timeout
-  fi
+current_time=$(date +%s)
+not_responsive_threshold=$(cat ${heartbeat_file})
 
-  if [ $current_time -le $timeout ]; then
-    exit 0
-  else
-    exit 1
-  fi
-else
+if [ $current_time -gt $not_responsive_threshold ]; then
   exit 1
 fi


### PR DESCRIPTION
Replace [heartbeat_check.rb and friends](https://github.com/ManageIQ/manageiq/blob/c43b2093199bb6942318c3102371b79c03f95473/lib/workers/bin/heartbeat_check.rb) with a simple shell script that assumes the heartbeat file now contains a timeout in unix time seconds since epoch.

Depends on the core change to write these files in unix time. 

- [x] Must be merged with this [core change](https://github.com/ManageIQ/manageiq/pull/21079)

Preliminary results:

### BEFORE
kasparov-1 environment running mostly idle

```
$ oc adm top pods
NAME                                 CPU(cores)   MEMORY(bytes)
1-event-handler-5dd956d75f-fr25h     74m          227Mi
1-generic-5865997d56-2xzrt           54m          322Mi
1-generic-5865997d56-fzwvz           72m          348Mi
1-priority-576657869b-9r4qf          71m          317Mi
1-priority-576657869b-swgdp          61m          297Mi
1-remote-console-5dff596449-ll2j5    35m          199Mi
1-reporting-755b878d7b-jpbzd         59m          189Mi
1-reporting-755b878d7b-vg7c6         59m          229Mi
1-schedule-dd5945764-vvfpb           78m          278Mi
1-ui-7654578488-t9s85                49m          361Mi
1-web-service-cdfc455b7-gbq5x        63m          336Mi
httpd-b89bbdff6-js9qv                1m           20Mi
manageiq-operator-769b4b48bb-dljm9   0m           30Mi
memcached-84987cbdf5-g42zs           0m           8Mi
orchestrator-fc86cbf66-vjzrj         21m          339Mi
postgresql-867fcb7d8-b65xn           9m           274Mi
```

### AFTER
Master, mostly idle.  Compare the CPU column with the same column above:

```
$ oc adm top pods
NAME                                 CPU(cores)   MEMORY(bytes)
1-event-handler-6fb6ff5995-drzw4     3m           177Mi
1-generic-7c87dc84f8-6xgxk           4m           228Mi
1-generic-7c87dc84f8-skp5p           3m           212Mi
1-priority-5df7c8b7f4-hl8jk          12m          228Mi
1-priority-5df7c8b7f4-rgfcl          12m          214Mi
1-remote-console-6f478b75b6-gxh7m    1m           186Mi
1-reporting-79799898-ct72b           5m           177Mi
1-reporting-79799898-knrmb           9m           177Mi
1-schedule-5d569cb977-qtrbr          2m           215Mi
1-ui-74f785fb99-w7q5j                2m           276Mi
1-web-service-5d47b5b5c8-tvjfv       8m           263Mi
httpd-b89bbdff6-tpp5r                0m           14Mi
manageiq-operator-57b78b6c6b-5jrjx   0m           23Mi
memcached-84987cbdf5-qxpjb           0m           1Mi
orchestrator-7f96f4964d-c8vng        16m          345Mi
postgresql-867fcb7d8-sz247           9m           196Mi
```