### PR TITLE
Honor the Env's OPERATOR_NAME when determining the operator lock name.

### DIFF
--- a/manageiq-operator/cmd/manager/main.go
+++ b/manageiq-operator/cmd/manager/main.go
@@ -84,7 +84,11 @@ func main() {
 
 	ctx := context.TODO()
 	// Become the leader before proceeding
-	err = leader.Become(ctx, "manageiq-operator-lock")
+	operatorName := os.Getenv("OPERATOR_NAME")
+	if operatorName == "" {
+		operatorName = "manageiq-operator"
+	}
+	err = leader.Become(ctx, operatorName+"-lock")
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)

--- a/manageiq-operator/cmd/manager/main.go
+++ b/manageiq-operator/cmd/manager/main.go
@@ -88,7 +88,8 @@ func main() {
 	if operatorName == "" {
 		operatorName = "manageiq-operator"
 	}
-	err = leader.Become(ctx, operatorName+"-lock")
+	lockName := operatorName + "-lock"
+	err = leader.Become(ctx, lockName)
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)


### PR DESCRIPTION
Honor the Pod's environment variable OPERATOR_NAME when choosing the lock name for the operator. 
