### PR TITLE
Newer versions of podman won't copy from an empty directory

### DIFF
--- a/images/manageiq-base-worker/container-assets/extract-vmware-vddk
+++ b/images/manageiq-base-worker/container-assets/extract-vmware-vddk
@@ -5,3 +5,4 @@ filename=$(ls VMware-*)
 
 # Skip the install if the VDDK library is not found
 [[ -f $filename ]] && tar -zxvf VMware-* || mkdir vmware-vix-disklib-distrib
+touch /vddk/vmware-vix-disklib-distrib/.keep


### PR DESCRIPTION
```
STEP 9: COPY --from=vddk /vddk/vmware-vix-disklib-distrib /usr/lib/vmware-vix-disklib
Error: error building at STEP "COPY --from=vddk /vddk/vmware-vix-disklib-distrib /usr/lib/vmware-vix-disklib": error adding sources [/var/lib/containers/storage/overlay/053d288f78f5120912955cb2f0a356d21a9ddf7561674fe2b1826eca82b4edcd/merged/vddk/vmware-vix-disklib-distrib]: no items matching glob "/var/lib/containers/storage/overlay/053d288f78f5120912955cb2f0a356d21a9ddf7561674fe2b1826eca82b4edcd/merged/vddk/vmware-vix-disklib-distrib" copied (1 filtered out): no such file or directory
```