### PR TITLE
If there is a HttpdAuthConfig, add the backup label to it

### DIFF
--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -237,6 +237,14 @@ func (r *ReconcileManageIQ) generateHttpdResources(cr *miqv1alpha1.ManageIQ) err
 		}
 	}
 
+	if httpdAuthConfig, mutateFunc := miqtool.HttpdAuthConfig(r.client, cr, r.scheme); httpdAuthConfig != nil {
+		if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, httpdAuthConfig, mutateFunc); err != nil {
+			return err
+		} else if result != controllerutil.OperationResultNone {
+			logger.Info("Secret has been reconciled", "component", "httpd-auth", "result", result)
+		}
+	}
+
 	uiService, mutateFunc := miqtool.UIService(cr, r.scheme)
 	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, uiService, mutateFunc); err != nil {
 		return err

--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -145,6 +145,24 @@ func HttpdAuthConfigMap(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*core
 	return configMap, f
 }
 
+func HttpdAuthConfig(client client.Client, cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*corev1.Secret, controllerutil.MutateFn) {
+	if cr.Spec.HttpdAuthConfig == "" {
+		return nil, nil
+	}
+
+	secret := &corev1.Secret{}
+	if secretErr := client.Get(context.TODO(), types.NamespacedName{Namespace: cr.Namespace, Name: cr.Spec.HttpdAuthConfig}, secret); secretErr != nil {
+		return nil, nil
+	}
+
+	f := func() error {
+		addBackupLabel(cr.Spec.BackupLabelName, &secret.ObjectMeta)
+		return nil
+	}
+
+	return secret, f
+}
+
 func PrivilegedHttpd(authType string) bool {
 	switch authType {
 	case "internal", "openid-connect":


### PR DESCRIPTION
Otherwise it will not be there for a restore and will cause problems deploying the httpd pod