### PR TITLE
Move from  module mod_auth_kerb to mod_auth_gssapi

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
@@ -291,7 +291,6 @@ func httpdAuthLoadModulesConf() string {
 LoadModule authnz_pam_module            modules/mod_authnz_pam.so
 LoadModule intercept_form_submit_module modules/mod_intercept_form_submit.so
 LoadModule lookup_identity_module       modules/mod_lookup_identity.so
-LoadModule auth_kerb_module             modules/mod_auth_kerb.so
 `
 }
 


### PR DESCRIPTION
The httpd-init container is failing with


```
h-4.4# systemctl status httpd
● httpd.service - The Apache HTTP Server
   Loaded: loaded (/usr/lib/systemd/system/httpd.service; enabled; vendor preset: disabled)
  Drop-In: /etc/systemd/system/httpd.service.d
           └─environment.conf
   Active: failed (Result: exit-code) since Tue 2021-03-09 11:13:42 UTC; 33s ago
     Docs: man:httpd.service(8)
  Process: 58 ExecStart=/usr/sbin/httpd $OPTIONS -DFOREGROUND (code=exited, status=1/FAILURE)
 Main PID: 58 (code=exited, status=1/FAILURE)
Mar 09 11:13:42 httpd-5696d5d749-d6s9k systemd[1]: Starting The Apache HTTP Server...
Mar 09 11:13:42 httpd-5696d5d749-d6s9k httpd[58]: httpd: Syntax error on line 356 of /etc/httpd/conf/httpd.conf: Syntax error on line 6 of /etc/httpd/conf.d/authentication.conf: Cannot load modules/mod_auth_kerb.so into server: /etc/httpd/modules/mod_auth_kerb.so: cannot open shared object file: No such file or directory
Mar 09 11:13:42 httpd-5696d5d749-d6s9k systemd[1]: httpd.service: Main process exited, code=exited, status=1/FAILURE
Mar 09 11:13:42 httpd-5696d5d749-d6s9k systemd[1]: httpd.service: Failed with result 'exit-code'.
Mar 09 11:13:42 httpd-5696d5d749-d6s9k systemd[1]: Failed to start The Apache HTTP Server.
```

The config is missing an update done for moving to mod_aut_gssapi. (https://github.com/ManageIQ/manageiq-appliance/pull/206)

@miq-bot add-label bug
