### PR TITLE
Changes to configure init-container

### DIFF
--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -228,15 +228,6 @@ func (r *ReconcileManageIQ) generateHttpdResources(cr *miqv1alpha1.ManageIQ) err
 		logger.Info("ConfigMap has been reconciled", "component", "httpd", "result", result)
 	}
 
-	if cr.Spec.HttpdAuthenticationType != "internal" && cr.Spec.HttpdAuthenticationType != "openid-connect" {
-		httpdAuthConfigMap, mutateFunc := miqtool.HttpdAuthConfigMap(cr, r.scheme)
-		if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, httpdAuthConfigMap, mutateFunc); err != nil {
-			return err
-		} else if result != controllerutil.OperationResultNone {
-			logger.Info("ConfigMap has been reconciled", "component", "httpd-auth", "result", result)
-		}
-	}
-
 	if httpdAuthConfig, mutateFunc := miqtool.HttpdAuthConfig(r.client, cr, r.scheme); httpdAuthConfig != nil {
 		if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, httpdAuthConfig, mutateFunc); err != nil {
 			return err

--- a/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
@@ -5,15 +5,6 @@ import (
 	miqv1alpha1 "github.com/ManageIQ/manageiq-pods/manageiq-operator/pkg/apis/manageiq/v1alpha1"
 )
 
-// auth-configuration.conf
-func httpdAuthConfigurationConf() string {
-	return `
-# External Authentication Configuration File
-#
-# For details on usage please see https://github.com/ManageIQ/manageiq-pods/blob/master/README.md#configuring-external-authentication
-`
-}
-
 // application.conf
 func httpdApplicationConf(applicationDomain string) string {
 	s := `


### PR DESCRIPTION
Why this PR:
The operator creates a deployment for httpd using the httpd-init container. Currently operator is not able to configure the httpd-init container a working configuration.

Some thing that did not work nice with the init container:
- https://github.com/ManageIQ/container-httpd-init/blob/4e1e474d72334d8b9221633ee6d52b9020ea93ed/container-assets/initialize-httpd-auth.sh#L17 is using an environment HTTPD_AUTH_TYPE
Made a change to include the HTTPD_AUTH_TYPE as an environment variable
- https://github.com/ManageIQ/container-httpd-init/blob/master/container-assets/initialize-httpd-auth.sh#L4 expect the `auth-configuration.conf` in `/etc/httpd/auth-conf.d`.  
The operator just creates an dummy file that cannot be changed by the operator: https://github.com/ManageIQ/manageiq-pods/blob/4dd38aac04ca8e9c7e61f6d62b49f2b81c0d7202/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go#L9-L15 

There is also option to create a config in `/etc/httpd/user-conf.d` but that is not being used by the httpd-init container. This PR mount the user config `/etc/httpd/auth-conf.d` so it is picked up by the httpd-init container.

After the PR you can perform the following actions to configure the httpd-init container correctly.
```bash
$cat auth-configuration.conf
file = httpd-auth        /etc/pam.d/httpd-auth        644
file = sssd.conf         /etc/sssd/sssd.conf          600
file = ca.cer            /etc/openldap/certs/ca.cer   644

$cat httpd-auth
auth    required pam_sss.so
account required pam_sss.so

$oc create secret generic my-httpd-config-secret \
  --from-file=auth-configuration.conf \
  --from-file=httpd-auth=httpd-auth \
  --from-file=ca.cer=ca.cer \
  --from-file=sssd.conf=sssd.conf

#specify my-httpd-config-secret in you crd
$cat miq.yml
apiVersion: manageiq.org/v1alpha1
kind: ManageIQ
metadata:
  name: miq
spec:
  <snip>
  httpdAuthenticationType: external
  httpdAuthConfig: my-httpd-config-secret 
```

Note. 
I am well aware this is just one solution that is working for me now. I am open to change the solution. For example we could be changing the `httpd-init` container to look at `/etc/httpd/user-conf.d` as well, or generate the sssd.conf from the crd. 