### PR TITLE
Clear caches better for smaller images

### DIFF
--- a/images/manageiq-base-worker/Dockerfile
+++ b/images/manageiq-base-worker/Dockerfile
@@ -21,6 +21,9 @@ COPY --from=vddk /vddk/vmware-vix-disklib-distrib/ /usr/lib/vmware-vix-disklib/
 COPY container-assets/install-vmware-vddk /tmp/
 RUN /tmp/install-vmware-vddk
 
-RUN source /etc/default/evm && /usr/bin/generate_rpm_manifest.sh
+RUN source /etc/default/evm && \
+    /usr/bin/generate_rpm_manifest.sh && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 CMD ["entrypoint"]

--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -50,21 +50,27 @@ RUN dnf -y --disableplugin=subscription-manager install \
       ${RPM_PREFIX}-pods          \
       python3-devel               \
       &&                          \
-    dnf -y --disableplugin=subscription-manager upgrade && \
-    dnf clean all
+    dnf clean all && \
+    rm -rf /var/cache/dnf && \
+    chgrp -R 0 $APP_ROOT && \
+    chmod -R g=u $APP_ROOT
 
 # Install python packages the same way the appliance does
 COPY --from=0 build/kickstarts/partials/post/python_modules.ks.erb /tmp/python_modules
-RUN bash /tmp/python_modules && rm -f /tmp/python_modules
-
-RUN chgrp -R 0 $APP_ROOT && \
-    chmod -R g=u $APP_ROOT
+RUN bash /tmp/python_modules && \
+    rm -f /tmp/python_modules && \
+    rm -rf /root/.cache/pip && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 ADD container-assets/container_env ${APP_ROOT}
 
 RUN curl -L -o /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_${ARCH} && \
     chmod +x /usr/bin/dumb-init
 
-RUN source /etc/default/evm && /usr/bin/generate_rpm_manifest.sh
+RUN source /etc/default/evm && \
+    /usr/bin/generate_rpm_manifest.sh && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--single-child", "--"]

--- a/images/manageiq-orchestrator/Dockerfile
+++ b/images/manageiq-orchestrator/Dockerfile
@@ -9,6 +9,9 @@ LABEL name="manageiq-orchestrator" \
 
 COPY container-assets/entrypoint /usr/local/bin
 
-RUN source /etc/default/evm && /usr/bin/generate_rpm_manifest.sh
+RUN source /etc/default/evm && \
+    /usr/bin/generate_rpm_manifest.sh && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 CMD ["entrypoint"]

--- a/images/manageiq-ui-worker/Dockerfile
+++ b/images/manageiq-ui-worker/Dockerfile
@@ -16,6 +16,9 @@ RUN sed -i '/^Listen 80/d' /etc/httpd/conf/httpd.conf
 
 COPY container-assets/manageiq-http.conf /etc/httpd/conf.d
 
-RUN source /etc/default/evm && /usr/bin/generate_rpm_manifest.sh
+RUN source /etc/default/evm && \
+    /usr/bin/generate_rpm_manifest.sh && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 RUN rm -rf /tmp/rpms /create_local_yum_repo.sh /etc/yum.repos.d/local_rpm.repo

--- a/images/manageiq-webserver-worker/Dockerfile
+++ b/images/manageiq-webserver-worker/Dockerfile
@@ -9,8 +9,13 @@ ARG RPM_PREFIX=manageiq
 LABEL name="manageiq-webserver-worker" \
       summary="ManageIQ web server worker image"
 
-RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install ${RPM_PREFIX}-ui && dnf clean all
+RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install ${RPM_PREFIX}-ui && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
-RUN source /etc/default/evm && /usr/bin/generate_rpm_manifest.sh
+RUN source /etc/default/evm && \
+    /usr/bin/generate_rpm_manifest.sh && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 EXPOSE 3000


### PR DESCRIPTION
These changes cause the base-worker image to drop from 2.2GB to 1.99GB
(~200MB / 9%) and the ui-worker image to drop from 2.51GB to 2.18GB
(~330MB / 13%).

Notable savings are:
- When running the generate_rpm_manifest, the dnf commands fill the
  cache, which wasn't being cleaned. This particulary affects the
  manifest run immediately after installing manageiq-ui dropping that
  layer size from 123MB to 6.6MB.
- When installing the pythin dependencies, we run dnf install, which
  wasn't being cleaned. This layer dropped from 604MB to 435MB
- The chgrp commands are done in a separate layer from the layer that
  installs those files, causing an extra 39MB layer which is
  unnecessary.
