### PR TITLE
Added labels to image build to address red hat certification failures on application image

### DIFF
--- a/manageiq-operator/build/Dockerfile
+++ b/manageiq-operator/build/Dockerfile
@@ -1,5 +1,10 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
+LABEL name="ManageIQ Operator" \
+      summary="ManageIQ Operator manages the ManageIQ application on an OCP cluster" \
+      vendor="ManageIQ" \
+      description="ManageIQ is a management and automation platform for virtual, private, and hybrid cloud infrastructures."
+
 ENV OPERATOR=/usr/local/bin/manageiq-operator \
     USER_UID=1001 \
     USER_NAME=manageiq-operator


### PR DESCRIPTION
Addresses these failures -
- non_inherited_base_label_name,
- non_inherited_base_label_vendor, 
- non_inherited_base_label_description, 
- non_inherited_base_label_summary
