### PR TITLE
Initial pass at CR migrations

### DIFF
--- a/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/crds/manageiq.org_manageiqs_crd.yaml
@@ -179,6 +179,11 @@ spec:
             memcachedSlabPageSize:
               description: 'Memcached max item size (default: 1m, min: 1k, max: 1024m)'
               type: string
+            migrationsRan:
+              description: A list of CR data migrations that have been run
+              items:
+                type: string
+              type: array
             oidcAuthIntrospectionURL:
               description: URL for OIDC authentication introspection Only used with
                 the openid-connect authentication type. If not specified, the operator

--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/manifests/manageiq.org_manageiqs_crd.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/manifests/manageiq.org_manageiqs_crd.yaml
@@ -179,6 +179,11 @@ spec:
             memcachedSlabPageSize:
               description: 'Memcached max item size (default: 1m, min: 1k, max: 1024m)'
               type: string
+            migrationsRan:
+              description: A list of CR data migrations that have been run
+              items:
+                type: string
+              type: array
             oidcAuthIntrospectionURL:
               description: URL for OIDC authentication introspection Only used with
                 the openid-connect authentication type. If not specified, the operator

--- a/manageiq-operator/go.sum
+++ b/manageiq-operator/go.sum
@@ -71,10 +71,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/OneOfOne/xxhash v1.2.6/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
-github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
@@ -124,7 +122,6 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash v0.0.0-20181017004759-096ff4a8a059/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
-github.com/cespare/xxhash/v2 v2.1.0 h1:yTUvW7Vhb89inJ+8irsUqiWjh8iT6sQPZiQzI6ReGkA=
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -262,7 +259,6 @@ github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwds
 github.com/go-openapi/jsonpointer v0.17.2/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.18.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
-github.com/go-openapi/jsonpointer v0.19.3 h1:gihV7YNZK1iK6Tgwwsxo2rJbD1GTbdm72325Bq8FI3w=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/jsonreference v0.17.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
@@ -283,7 +279,6 @@ github.com/go-openapi/spec v0.17.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsd
 github.com/go-openapi/spec v0.17.2/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
 github.com/go-openapi/spec v0.18.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
 github.com/go-openapi/spec v0.19.2/go.mod h1:sCxk3jxKgioEJikev4fgkNmwS+3kuYdJtcsZsD5zxMY=
-github.com/go-openapi/spec v0.19.4 h1:ixzUSnHTd6hCemgtAJgluaTSGYpLNpJY4mA2DIkdOAo=
 github.com/go-openapi/spec v0.19.4/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.17.2/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
@@ -295,7 +290,6 @@ github.com/go-openapi/swag v0.17.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/
 github.com/go-openapi/swag v0.17.2/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/kXLo40Tg=
 github.com/go-openapi/swag v0.18.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/kXLo40Tg=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
-github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tFY=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/validate v0.17.2/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
@@ -348,7 +342,6 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -375,7 +368,6 @@ github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTV
 github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
-github.com/gophercloud/gophercloud v0.2.0 h1:lD2Bce2xBAMNNcFZ0dObTpXkGLlVIb33RPVUNVpw6ic=
 github.com/gophercloud/gophercloud v0.2.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/gophercloud v0.3.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/gophercloud v0.6.0 h1:Xb2lcqZtml1XjgYZxbeayEemq7ASbeTp09m36gQFpEU=
@@ -463,7 +455,6 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
-github.com/json-iterator/go v1.1.7 h1:KfgG9LzI+pYjr4xvmz/5H4FXjokeP+rlHLhv3iH62Fo=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
@@ -573,7 +564,6 @@ github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.10.1 h1:q/mM8GF/n0shIN8SaAZ0V+jnLPzen6WIVZdiwrRlMlo=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0 h1:JAKSXpt1YjtLA7YpPiqO9ss6sNXEsPfSGdwN0UHqzrw=
@@ -581,7 +571,6 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.8.1 h1:C5Dqfs/LeauYDX0jJXIe2SWmwCbGzx9yF8C8xy3Lh34=
@@ -624,7 +613,6 @@ github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rK
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -642,7 +630,6 @@ github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod 
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.2.0/go.mod h1:XMU6Z2MjaRKVu/dC1qupJI9SiNkDYzz3xecMgSW/F+U=
-github.com/prometheus/client_golang v1.2.1 h1:JnMpQc6ppsNgw9QPAGF6Dod479itz7lvlsMzzNayLOI=
 github.com/prometheus/client_golang v1.2.1/go.mod h1:XMU6Z2MjaRKVu/dC1qupJI9SiNkDYzz3xecMgSW/F+U=
 github.com/prometheus/client_golang v1.5.1 h1:bdHYieyGlH+6OLEk2YQha8THib30KP0/yD0YH9m6xcA=
 github.com/prometheus/client_golang v1.5.1/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
@@ -650,7 +637,6 @@ github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -660,7 +646,6 @@ github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7q
 github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
-github.com/prometheus/common v0.7.0 h1:L+1lyG48J1zAQXA3RBX/nG/B3gjlHq0zTt2tlbJLyCY=
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
 github.com/prometheus/common v0.9.1 h1:KOMtN28tlbam3/7ZKEYKHhKoJZYYj3gMH4uc62x7X7U=
 github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
@@ -672,7 +657,6 @@ github.com/prometheus/procfs v0.0.0-20190425082905-87a4384529e0/go.mod h1:TjEm7z
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
-github.com/prometheus/procfs v0.0.5 h1:3+auTFlqw+ZaQYJARz6ArODtkaIwtvBTx3N2NehQlL8=
 github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.0.6/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
@@ -784,21 +768,18 @@ go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
-go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/automaxprocs v1.2.0/go.mod h1:YfO3fm683kQpzETxlTGZhGIVmXAhaw3gxeBADbpZtnU=
 go.uber.org/multierr v0.0.0-20180122172545-ddea229ff1df/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
-go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee h1:0mgffUl7nfd+FpvXMVz4IDEaUSmT1ysygQC7qYo7sG4=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v0.0.0-20180814183419-67bc79d13d15/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
-go.uber.org/zap v1.10.0 h1:ORx85nbTijNz8ljznvCMR1ZBIPKFn3jQrag10X2AsuM=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.14.1 h1:nYDKopTbvAPq/NrUVZwT15y2lpROBiLLyoRTbXOYWOo=
 go.uber.org/zap v1.14.1/go.mod h1:Mb2vm2krFEG5DV0W9qcHBYFtp/Wku1cvYaqPsS/WYfc=
@@ -876,7 +857,6 @@ golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191002035440-2ec189313ef0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271 h1:N66aaryRB3Ax92gH0v3hp1QYZ3zWWCCUR/j8Ifh45Ss=
 golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191112182307-2180aed22343/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
@@ -987,7 +967,6 @@ golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e h1:qCZ8SbsZMjT0OuDPCEBxgLZic4NMj8Gj4vNXiTVRAaA=
 golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
-golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
@@ -1072,7 +1051,6 @@ gopkg.in/yaml.v2 v2.1.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
@@ -1093,7 +1071,6 @@ howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCU
 k8s.io/api v0.0.0-20190620084959-7cf5895f2711/go.mod h1:TBhBqb1AWbBQbW3XRusr7n7E4v2+5ZY8r8sAMnyFC5A=
 k8s.io/api v0.0.0-20190813020757-36bff7324fb7/go.mod h1:3Iy+myeAORNCLgjd/Xu9ebwN7Vh59Bw0vh9jhoX+V58=
 k8s.io/api v0.0.0-20190918155943-95b840bb6a1f/go.mod h1:uWuOHnjmNrtQomJrvEBg0c0HRNyQ+8KTEERVsK0PW48=
-k8s.io/api v0.0.0-20191016110408-35e52d86657a h1:VVUE9xTCXP6KUPMf92cQmN88orz600ebexcRRaBTepQ=
 k8s.io/api v0.0.0-20191016110408-35e52d86657a/go.mod h1:/L5qH+AD540e7Cetbui1tuJeXdmNhO8jM6VkXeDdDhQ=
 k8s.io/api v0.0.0-20191115095533-47f6de673b26/go.mod h1:iA/8arsvelvo4IDqIhX4IbjTEKBGgvsf2OraTuRtLFU=
 k8s.io/api v0.16.7/go.mod h1:oUAiGRgo4t+5yqcxjOu5LoHT3wJ8JSbgczkaFYS5L7I=

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/manageiq_types.go
@@ -189,6 +189,10 @@ type ManageIQSpec struct {
 	// +optional
 	MemcachedSlabPageSize string `json:"memcachedSlabPageSize,omitempty"`
 
+	// A list of CR data migrations that have been run
+	// +optional
+	MigrationsRan []string `json:"migrationsRan,omitempty"`
+
 	// Secret containing the trusted CA certificate file(s) for the OIDC server.
 	// Only used with the openid-connect authentication type
 	// +optional

--- a/manageiq-operator/pkg/apis/manageiq/v1alpha1/zz_generated.deepcopy.go
+++ b/manageiq-operator/pkg/apis/manageiq/v1alpha1/zz_generated.deepcopy.go
@@ -99,6 +99,11 @@ func (in *ManageIQSpec) DeepCopyInto(out *ManageIQSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.MigrationsRan != nil {
+		in, out := &in.MigrationsRan, &out.MigrationsRan
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	miqv1alpha1 "github.com/ManageIQ/manageiq-pods/manageiq-operator/pkg/apis/manageiq/v1alpha1"
+	cr_migration "github.com/ManageIQ/manageiq-pods/manageiq-operator/pkg/helpers/cr_migration"
 
 	miqtool "github.com/ManageIQ/manageiq-pods/manageiq-operator/pkg/helpers/miq-components"
 	appsv1 "k8s.io/api/apps/v1"
@@ -131,6 +132,11 @@ func (r *ReconcileManageIQ) Reconcile(request reconcile.Request) (reconcile.Resu
 	err := r.client.Get(context.TODO(), request.NamespacedName, miqInstance)
 	if errors.IsNotFound(err) {
 		return reconcile.Result{}, nil
+	}
+
+	logger.Info("Migrating the CR...")
+	if e := r.migrateCR(miqInstance); e != nil {
+		return reconcile.Result{}, e
 	}
 
 	logger.Info("Reconciling the CR...")
@@ -568,6 +574,17 @@ func (r *ReconcileManageIQ) generateSecrets(cr *miqv1alpha1.ManageIQ) error {
 				logger.Info("OIDC CA Secret has been reconciled", "component", "operator", "result", result)
 			}
 		}
+	}
+
+	return nil
+}
+
+func (r *ReconcileManageIQ) migrateCR(cr *miqv1alpha1.ManageIQ) error {
+	manageiq, mutateFunc := cr_migration.Migrate(cr)
+	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, manageiq, mutateFunc); err != nil {
+		return err
+	} else if result != controllerutil.OperationResultNone {
+		logger.Info("CR has been migrated", "component", "app", "result", result)
 	}
 
 	return nil

--- a/manageiq-operator/pkg/helpers/cr_migration/20210503163000_initial_migration.go
+++ b/manageiq-operator/pkg/helpers/cr_migration/20210503163000_initial_migration.go
@@ -1,0 +1,114 @@
+package cr_migration
+
+import (
+	miqv1alpha1 "github.com/ManageIQ/manageiq-pods/manageiq-operator/pkg/apis/manageiq/v1alpha1"
+)
+
+func migrate20210503163000(cr *miqv1alpha1.ManageIQ) *miqv1alpha1.ManageIQ {
+	migrationId := "20210503163000"
+	for _, migration := range cr.Spec.MigrationsRan {
+		if migration == migrationId {
+			return cr
+		}
+	}
+
+	if cr.Spec.HttpdCpuLimit == "1000m" || cr.Spec.HttpdCpuLimit == "500m" {
+		cr.Spec.HttpdCpuLimit = ""
+	}
+
+	if cr.Spec.HttpdCpuRequest == "50m" || cr.Spec.HttpdCpuRequest == "500m" {
+		cr.Spec.HttpdCpuRequest = ""
+	}
+
+	if cr.Spec.HttpdMemoryLimit == "200Mi" || cr.Spec.HttpdMemoryLimit == "8192Mi" {
+		cr.Spec.HttpdMemoryLimit = ""
+	}
+
+	if cr.Spec.HttpdMemoryRequest == "100Mi" || cr.Spec.HttpdMemoryRequest == "512Mi" {
+		cr.Spec.HttpdMemoryRequest = ""
+	}
+
+	if cr.Spec.KafkaCpuLimit == "250m" {
+		cr.Spec.KafkaCpuLimit = ""
+	}
+
+	if cr.Spec.KafkaCpuRequest == "250m" {
+		cr.Spec.KafkaCpuRequest = ""
+	}
+
+	if cr.Spec.KafkaMemoryLimit == "1024Mi" {
+		cr.Spec.KafkaMemoryLimit = ""
+	}
+
+	if cr.Spec.KafkaMemoryRequest == "256Mi" {
+		cr.Spec.KafkaMemoryRequest = ""
+	}
+
+	if cr.Spec.MemcachedCpuLimit == "1000m" || cr.Spec.MemcachedCpuLimit == "200m" {
+		cr.Spec.MemcachedCpuLimit = ""
+	}
+
+	if cr.Spec.MemcachedCpuRequest == "50m" || cr.Spec.MemcachedCpuRequest == "200m" {
+		cr.Spec.MemcachedCpuRequest = ""
+	}
+
+	if cr.Spec.MemcachedMemoryLimit == "200Mi" || cr.Spec.MemcachedMemoryLimit == "256Mi" {
+		cr.Spec.MemcachedMemoryLimit = ""
+	}
+
+	if cr.Spec.MemcachedMemoryRequest == "100Mi" || cr.Spec.MemcachedMemoryRequest == "64Mi" {
+		cr.Spec.MemcachedMemoryRequest = ""
+	}
+
+	if cr.Spec.OrchestratorCpuLimit == "1000m" {
+		cr.Spec.OrchestratorCpuLimit = ""
+	}
+
+	if cr.Spec.OrchestratorCpuRequest == "200m" || cr.Spec.OrchestratorCpuRequest == "1000m" {
+		cr.Spec.OrchestratorCpuRequest = ""
+	}
+
+	if cr.Spec.OrchestratorMemoryLimit == "2048Mi" || cr.Spec.OrchestratorMemoryLimit == "1638Mi" {
+		cr.Spec.OrchestratorMemoryLimit = ""
+	}
+
+	if cr.Spec.OrchestratorMemoryRequest == "1024Mi" || cr.Spec.OrchestratorMemoryRequest == "6144Mi" {
+		cr.Spec.OrchestratorMemoryRequest = ""
+	}
+
+	if cr.Spec.PostgresqlCpuLimit == "1000m" || cr.Spec.PostgresqlCpuLimit == "500m" {
+		cr.Spec.PostgresqlCpuLimit = ""
+	}
+
+	if cr.Spec.PostgresqlCpuRequest == "500m" {
+		cr.Spec.PostgresqlCpuRequest = ""
+	}
+
+	if cr.Spec.PostgresqlMemoryLimit == "8192Mi" {
+		cr.Spec.PostgresqlMemoryLimit = ""
+	}
+
+	if cr.Spec.PostgresqlMemoryRequest == "2048Mi" || cr.Spec.PostgresqlMemoryRequest == "8192Mi" {
+		cr.Spec.PostgresqlMemoryRequest = ""
+	}
+
+	if cr.Spec.ZookeeperCpuLimit == "250m" {
+		cr.Spec.ZookeeperCpuLimit = ""
+	}
+
+	if cr.Spec.ZookeeperCpuRequest == "250m" {
+		cr.Spec.ZookeeperCpuRequest = ""
+	}
+
+	if cr.Spec.ZookeeperMemoryLimit == "256Mi" {
+		cr.Spec.ZookeeperMemoryLimit = ""
+	}
+
+	if cr.Spec.ZookeeperMemoryRequest == "256Mi" {
+		cr.Spec.ZookeeperMemoryRequest = ""
+	}
+
+	cr.Spec.MigrationsRan = append(cr.Spec.MigrationsRan, migrationId)
+
+	return cr
+}

--- a/manageiq-operator/pkg/helpers/cr_migration/20210504113000_migrate_image_names.go
+++ b/manageiq-operator/pkg/helpers/cr_migration/20210504113000_migrate_image_names.go
@@ -30,6 +30,33 @@ func migrate20210504113000(cr *miqv1alpha1.ManageIQ) *miqv1alpha1.ManageIQ {
 	cr.Spec.HttpdImageNamespace = ""
 	cr.Spec.HttpdImageTag = ""
 
+	// Prefer KafkaImage rather than KafkaImageName and KafkaImageTag
+	if cr.Spec.KafkaImage == "" && cr.Spec.KafkaImageName != "" && cr.Spec.KafkaImageTag != "" {
+		cr.Spec.KafkaImage = cr.Spec.KafkaImageName + ":" + cr.Spec.KafkaImageTag
+	}
+	cr.Spec.KafkaImageName = ""
+	cr.Spec.KafkaImageTag = ""
+
+	// Prefer MemcachedImage rather than MemcachedImageName and MemcachedImageTag
+	if cr.Spec.MemcachedImage == "" && cr.Spec.MemcachedImageName != "" && cr.Spec.MemcachedImageTag != "" {
+		cr.Spec.MemcachedImage = cr.Spec.MemcachedImageName + ":" + cr.Spec.MemcachedImageTag
+	}
+	cr.Spec.MemcachedImageName = ""
+	cr.Spec.MemcachedImageTag = ""
+
+	// Prefer PostgresqlImage rather than PostgresqlImageName and PostgresqlImageTag
+	if cr.Spec.PostgresqlImage == "" && cr.Spec.PostgresqlImageName != "" && cr.Spec.PostgresqlImageTag != "" {
+		cr.Spec.PostgresqlImage = cr.Spec.PostgresqlImageName + ":" + cr.Spec.PostgresqlImageTag
+	}
+	cr.Spec.PostgresqlImageName = ""
+	cr.Spec.PostgresqlImageTag = ""
+
+	// Prefer ZookeeperImage rather than ZookeeperImageName and ZookeeperImageTag
+	if cr.Spec.ZookeeperImage == "" && cr.Spec.ZookeeperImageName != "" && cr.Spec.ZookeeperImageTag != "" {
+		cr.Spec.ZookeeperImage = cr.Spec.ZookeeperImageName + ":" + cr.Spec.ZookeeperImageTag
+	}
+	cr.Spec.ZookeeperImageName = ""
+	cr.Spec.ZookeeperImageTag = ""
 
 	cr.Spec.MigrationsRan = append(cr.Spec.MigrationsRan, migrationId)
 

--- a/manageiq-operator/pkg/helpers/cr_migration/20210504113000_migrate_image_names.go
+++ b/manageiq-operator/pkg/helpers/cr_migration/20210504113000_migrate_image_names.go
@@ -1,0 +1,37 @@
+package cr_migration
+
+import (
+	miqv1alpha1 "github.com/ManageIQ/manageiq-pods/manageiq-operator/pkg/apis/manageiq/v1alpha1"
+	miqtool "github.com/ManageIQ/manageiq-pods/manageiq-operator/pkg/helpers/miq-components"
+)
+
+func migrate20210504113000(cr *miqv1alpha1.ManageIQ) *miqv1alpha1.ManageIQ {
+	migrationId := "20210504113000"
+	for _, migration := range cr.Spec.MigrationsRan {
+		if migration == migrationId {
+			return cr
+		}
+	}
+
+	// Prefer HttpdImage rather than HttpdImageNamespace and HttpdImageTag
+	if cr.Spec.HttpdImage == "" && cr.Spec.HttpdImageNamespace != "" && cr.Spec.HttpdImageTag != "" {
+		privileged := miqtool.PrivilegedHttpd(cr.Spec.HttpdAuthenticationType)
+		var image string
+
+		if privileged {
+			image = "httpd-init"
+		} else {
+			image = "httpd"
+		}
+
+		cr.Spec.HttpdImage = cr.Spec.HttpdImageNamespace + "/" + image + ":" + cr.Spec.HttpdImageTag
+	}
+
+	cr.Spec.HttpdImageNamespace = ""
+	cr.Spec.HttpdImageTag = ""
+
+
+	cr.Spec.MigrationsRan = append(cr.Spec.MigrationsRan, migrationId)
+
+	return cr
+}

--- a/manageiq-operator/pkg/helpers/cr_migration/20210504113000_migrate_image_names.go
+++ b/manageiq-operator/pkg/helpers/cr_migration/20210504113000_migrate_image_names.go
@@ -44,6 +44,14 @@ func migrate20210504113000(cr *miqv1alpha1.ManageIQ) *miqv1alpha1.ManageIQ {
 	cr.Spec.MemcachedImageName = ""
 	cr.Spec.MemcachedImageTag = ""
 
+	// Prefer OrchestratorImage rather than OrchestratorImageNamespace, OrchestratorImageName and OrchestratorImageTag
+	if cr.Spec.OrchestratorImage == "" && cr.Spec.OrchestratorImageNamespace != "" && cr.Spec.OrchestratorImageName != "" && cr.Spec.OrchestratorImageTag != "" {
+		cr.Spec.OrchestratorImage = cr.Spec.OrchestratorImageNamespace + "/" + cr.Spec.OrchestratorImageName + ":" + cr.Spec.OrchestratorImageTag
+	}
+	cr.Spec.OrchestratorImageName = ""
+	cr.Spec.OrchestratorImageNamespace = ""
+	cr.Spec.OrchestratorImageTag = ""
+
 	// Prefer PostgresqlImage rather than PostgresqlImageName and PostgresqlImageTag
 	if cr.Spec.PostgresqlImage == "" && cr.Spec.PostgresqlImageName != "" && cr.Spec.PostgresqlImageTag != "" {
 		cr.Spec.PostgresqlImage = cr.Spec.PostgresqlImageName + ":" + cr.Spec.PostgresqlImageTag

--- a/manageiq-operator/pkg/helpers/cr_migration/cr_migration.go
+++ b/manageiq-operator/pkg/helpers/cr_migration/cr_migration.go
@@ -8,6 +8,7 @@ import (
 func Migrate(cr *miqv1alpha1.ManageIQ) (*miqv1alpha1.ManageIQ, controllerutil.MutateFn) {
 	f := func() error {
 		cr = migrate20210503163000(cr)
+		cr = migrate20210504113000(cr)
 
 		return nil
 	}

--- a/manageiq-operator/pkg/helpers/cr_migration/cr_migration.go
+++ b/manageiq-operator/pkg/helpers/cr_migration/cr_migration.go
@@ -1,0 +1,16 @@
+package cr_migration
+
+import (
+	miqv1alpha1 "github.com/ManageIQ/manageiq-pods/manageiq-operator/pkg/apis/manageiq/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func Migrate(cr *miqv1alpha1.ManageIQ) (*miqv1alpha1.ManageIQ, controllerutil.MutateFn) {
+	f := func() error {
+		cr = migrate20210503163000(cr)
+
+		return nil
+	}
+
+	return cr, f
+}

--- a/manageiq-operator/pkg/helpers/miq-components/cr.go
+++ b/manageiq-operator/pkg/helpers/miq-components/cr.go
@@ -89,14 +89,6 @@ func httpdAuthenticationType(cr *miqv1alpha1.ManageIQ) string {
 	}
 }
 
-func httpdImageNamespace(cr *miqv1alpha1.ManageIQ) string {
-	if cr.Spec.HttpdImageNamespace == "" {
-		return "manageiq"
-	} else {
-		return cr.Spec.HttpdImageNamespace
-	}
-}
-
 func httpdImage(cr *miqv1alpha1.ManageIQ) string {
 	if cr.Spec.HttpdImage != "" {
 		return cr.Spec.HttpdImage
@@ -111,7 +103,15 @@ func httpdImage(cr *miqv1alpha1.ManageIQ) string {
 		image = "httpd"
 	}
 
-	return cr.Spec.HttpdImageNamespace + "/" + image + ":" + cr.Spec.HttpdImageTag
+	return httpdImageNamespace(cr) + "/" + image + ":" + httpdImageTag(cr)
+}
+
+func httpdImageNamespace(cr *miqv1alpha1.ManageIQ) string {
+	if cr.Spec.HttpdImageNamespace == "" {
+		return "manageiq"
+	} else {
+		return cr.Spec.HttpdImageNamespace
+	}
 }
 
 func httpdImageTag(cr *miqv1alpha1.ManageIQ) string {
@@ -363,8 +363,6 @@ func ManageCR(cr *miqv1alpha1.ManageIQ, c *client.Client) (*miqv1alpha1.ManageIQ
 		cr.Spec.EnforceWorkerResourceConstraints = &varEnforceWorkerResourceConstraints
 		cr.Spec.HttpdAuthenticationType = httpdAuthenticationType(cr)
 		cr.Spec.HttpdImage = httpdImage(cr)
-		cr.Spec.HttpdImageNamespace = httpdImageNamespace(cr)
-		cr.Spec.HttpdImageTag = httpdImageTag(cr)
 		cr.Spec.ImagePullSecret = imagePullSecretName(cr, *c)
 		cr.Spec.KafkaImage = kafkaImage(cr)
 		cr.Spec.KafkaImageName = kafkaImageName(cr)

--- a/manageiq-operator/pkg/helpers/miq-components/cr.go
+++ b/manageiq-operator/pkg/helpers/miq-components/cr.go
@@ -220,7 +220,7 @@ func memcachedSlabPageSize(cr *miqv1alpha1.ManageIQ) string {
 
 func orchestratorImage(cr *miqv1alpha1.ManageIQ) string {
 	if cr.Spec.OrchestratorImage == "" {
-		return cr.Spec.OrchestratorImageNamespace + "/" + cr.Spec.OrchestratorImageName + ":" + cr.Spec.OrchestratorImageTag
+		return orchestratorImageNamespace(cr) + "/" + orchestratorImageName(cr) + ":" + orchestratorImageTag(cr)
 	} else {
 		return cr.Spec.OrchestratorImage
 	}
@@ -371,9 +371,6 @@ func ManageCR(cr *miqv1alpha1.ManageIQ, c *client.Client) (*miqv1alpha1.ManageIQ
 		cr.Spec.MemcachedMaxMemory = memcachedMaxMemory(cr)
 		cr.Spec.MemcachedSlabPageSize = memcachedSlabPageSize(cr)
 		cr.Spec.OrchestratorImage = orchestratorImage(cr)
-		cr.Spec.OrchestratorImageName = orchestratorImageName(cr)
-		cr.Spec.OrchestratorImageNamespace = orchestratorImageNamespace(cr)
-		cr.Spec.OrchestratorImageTag = orchestratorImageTag(cr)
 		cr.Spec.OrchestratorInitialDelay = orchestratorInitialDelay(cr)
 		cr.Spec.PostgresqlImage = postgresqlImage(cr)
 		cr.Spec.PostgresqlMaxConnections = postgresqlMaxConnections(cr)

--- a/manageiq-operator/pkg/helpers/miq-components/cr.go
+++ b/manageiq-operator/pkg/helpers/miq-components/cr.go
@@ -140,7 +140,7 @@ func imagePullSecretName(cr *miqv1alpha1.ManageIQ, client client.Client) string 
 
 func kafkaImage(cr *miqv1alpha1.ManageIQ) string {
 	if cr.Spec.KafkaImage == "" {
-		return cr.Spec.KafkaImageName + ":" + cr.Spec.KafkaImageTag
+		return kafkaImageName(cr) + ":" + kafkaImageTag(cr)
 	} else {
 		return cr.Spec.KafkaImage
 	}
@@ -172,7 +172,7 @@ func kafkaVolumeCapacity(cr *miqv1alpha1.ManageIQ) string {
 
 func memcachedImage(cr *miqv1alpha1.ManageIQ) string {
 	if cr.Spec.MemcachedImage == "" {
-		return cr.Spec.MemcachedImageName + ":" + cr.Spec.MemcachedImageTag
+		return memcachedImageName(cr) + ":" + memcachedImageTag(cr)
 	} else {
 		return cr.Spec.MemcachedImage
 	}
@@ -260,7 +260,7 @@ func orchestratorInitialDelay(cr *miqv1alpha1.ManageIQ) string {
 
 func postgresqlImage(cr *miqv1alpha1.ManageIQ) string {
 	if cr.Spec.PostgresqlImage == "" {
-		return cr.Spec.PostgresqlImageName + ":" + cr.Spec.PostgresqlImageTag
+		return postgresqlImageName(cr) + ":" + postgresqlImageTag(cr)
 	} else {
 		return cr.Spec.PostgresqlImage
 	}
@@ -315,7 +315,7 @@ func serverGuid(cr *miqv1alpha1.ManageIQ, c *client.Client) string {
 
 func zookeeperImage(cr *miqv1alpha1.ManageIQ) string {
 	if cr.Spec.ZookeeperImage == "" {
-		return cr.Spec.ZookeeperImageName + ":" + cr.Spec.ZookeeperImageTag
+		return zookeeperImageName(cr) + ":" + zookeeperImageTag(cr)
 	} else {
 		return cr.Spec.ZookeeperImage
 	}
@@ -365,12 +365,8 @@ func ManageCR(cr *miqv1alpha1.ManageIQ, c *client.Client) (*miqv1alpha1.ManageIQ
 		cr.Spec.HttpdImage = httpdImage(cr)
 		cr.Spec.ImagePullSecret = imagePullSecretName(cr, *c)
 		cr.Spec.KafkaImage = kafkaImage(cr)
-		cr.Spec.KafkaImageName = kafkaImageName(cr)
-		cr.Spec.KafkaImageTag = kafkaImageTag(cr)
 		cr.Spec.KafkaVolumeCapacity = kafkaVolumeCapacity(cr)
 		cr.Spec.MemcachedImage = memcachedImage(cr)
-		cr.Spec.MemcachedImageName = memcachedImageName(cr)
-		cr.Spec.MemcachedImageTag = memcachedImageTag(cr)
 		cr.Spec.MemcachedMaxConnection = memcachedMaxConnection(cr)
 		cr.Spec.MemcachedMaxMemory = memcachedMaxMemory(cr)
 		cr.Spec.MemcachedSlabPageSize = memcachedSlabPageSize(cr)
@@ -380,14 +376,10 @@ func ManageCR(cr *miqv1alpha1.ManageIQ, c *client.Client) (*miqv1alpha1.ManageIQ
 		cr.Spec.OrchestratorImageTag = orchestratorImageTag(cr)
 		cr.Spec.OrchestratorInitialDelay = orchestratorInitialDelay(cr)
 		cr.Spec.PostgresqlImage = postgresqlImage(cr)
-		cr.Spec.PostgresqlImageName = postgresqlImageName(cr)
-		cr.Spec.PostgresqlImageTag = postgresqlImageTag(cr)
 		cr.Spec.PostgresqlMaxConnections = postgresqlMaxConnections(cr)
 		cr.Spec.PostgresqlSharedBuffers = postgresqlSharedBuffers(cr)
 		cr.Spec.ServerGuid = serverGuid(cr, c)
 		cr.Spec.ZookeeperImage = zookeeperImage(cr)
-		cr.Spec.ZookeeperImageName = zookeeperImageName(cr)
-		cr.Spec.ZookeeperImageTag = zookeeperImageTag(cr)
 		cr.Spec.ZookeeperVolumeCapacity = zookeeperVolumeCapacity(cr)
 
 		addBackupLabel(backupLabelName(cr), &cr.ObjectMeta)

--- a/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
@@ -192,8 +192,10 @@ func updateOrchestratorEnv(cr *miqv1alpha1.ManageIQ, c *corev1.Container) {
 
 	// If any of the images were not provided, add the orchestrator namespace and tag
 	if cr.Spec.BaseWorkerImage == "" || cr.Spec.WebserverWorkerImage == "" || cr.Spec.UIWorkerImage == "" {
-		c.Env = addOrUpdateEnvVar(c.Env, corev1.EnvVar{Name: "CONTAINER_IMAGE_NAMESPACE", Value: cr.Spec.OrchestratorImageNamespace})
-		c.Env = addOrUpdateEnvVar(c.Env, corev1.EnvVar{Name: "CONTAINER_IMAGE_TAG", Value: cr.Spec.OrchestratorImageTag})
+		string1 := strings.Split(cr.Spec.OrchestratorImage, ":")
+		string2 := strings.Split(string1[0], "/")
+		c.Env = addOrUpdateEnvVar(c.Env, corev1.EnvVar{Name: "CONTAINER_IMAGE_NAMESPACE", Value: string2[0]})
+		c.Env = addOrUpdateEnvVar(c.Env, corev1.EnvVar{Name: "CONTAINER_IMAGE_TAG", Value: string1[1]})
 	}
 
 	if cr.Spec.BaseWorkerImage != "" {
@@ -230,7 +232,8 @@ func OrchestratorDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, cl
 		return nil, nil, err
 	}
 	pullPolicy := corev1.PullIfNotPresent
-	if strings.Contains(cr.Spec.OrchestratorImageTag, "latest") {
+
+	if s := strings.Split(cr.Spec.OrchestratorImage, ":"); strings.Contains(s[1], "latest") {
 		pullPolicy = corev1.PullAlways
 	}
 


### PR DESCRIPTION
Based on discussions in https://github.com/ManageIQ/manageiq-pods/issues/676

Notes: (not sure if these should be handled here or in a followup)
- Currently uses the CR object, not unstructured JSON
- `MigrationsRan` are currently stored in `Spec` rather than `Status`, for some reason I couldn't get that working.