### PR TITLE
Don't attempt to pull rpm* packages from ubi-8 repos

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -44,7 +44,7 @@ RUN dnf -y --disableplugin=subscription-manager install \
     dnf -y --disableplugin=subscription-manager module enable nodejs:12 && \
     dnf -y --disableplugin=subscription-manager module enable ruby:2.6 && \
     if [[ "$RELEASE_BUILD" != "true" ]]; then dnf config-manager --enable manageiq-13-morphy-nightly; fi && \
-    dnf config-manager --setopt=ubi-8-*.exclude=dracut*,net-snmp*,redhat-release* --save && \
+    dnf config-manager --setopt=ubi-8-*.exclude=dracut*,net-snmp*,redhat-release*,rpm* --save && \
     if [[ "$LOCAL_RPM" = "true" ]]; then /create_local_yum_repo.sh; fi && \
     dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
       ${RPM_PREFIX}-pods          \


### PR DESCRIPTION
For some reason we get a conflict that dnf can't resolve with only some of the rpms available at 4.14.3-13:
```
Problem: package rpm-sign-4.14.3-4.el8.ppc64le requires rpm-build-libs(ppc-64) = 4.14.3-4.el8, but none of the providers can be installed
  - package rpm-build-libs-4.14.3-4.el8.ppc64le requires rpm-libs(ppc-64) = 4.14.3-4.el8, but none of the providers can be installed
  - package rpm-libs-4.14.3-4.el8.ppc64le requires rpm = 4.14.3-4.el8, but none of the providers can be installed
  - cannot install both rpm-4.14.3-13.el8.ppc64le and rpm-4.14.3-4.el8.ppc64le
  - package rpm-build-4.14.3-13.el8.ppc64le requires rpm = 4.14.3-13.el8, but none of the providers can be installed
  - cannot install the best candidate for the job
  - conflicting requests
```