### PR TITLE
Update base image to UBI 8.4, change appliance_build stage to latest

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.3 as appliance_build
+FROM registry.access.redhat.com/ubi8/ubi:latest as appliance_build
 
 ARG BUILD_REF=master
 ARG BUILD_ORG=ManageIQ
@@ -9,7 +9,7 @@ ARG GIT_AUTH
 RUN mkdir build && \
     if [[ -n "$GIT_AUTH" ]]; then GIT_HOST=${GIT_AUTH}@${GIT_HOST}; fi && curl -L https://${GIT_HOST}/${BUILD_ORG}/${CORE_REPO_NAME}-appliance-build/tarball/${BUILD_REF} | tar vxz -C build --strip 1
 
-FROM registry.access.redhat.com/ubi8/ubi:8.3
+FROM registry.access.redhat.com/ubi8/ubi:8.4
 MAINTAINER ManageIQ https://manageiq.org
 
 ARG ARCH=x86_64


### PR DESCRIPTION
`appliance_build` stage version doesn't matter, just keep it up to date.  Unfortunately ubi-minimal:latest doesn't include tar, so we can't use it there.