### PR TITLE
Expand LimitRequestFieldSize in the internal httpd

### DIFF
--- a/images/manageiq-ui-worker/container-assets/manageiq-http.conf
+++ b/images/manageiq-ui-worker/container-assets/manageiq-http.conf
@@ -10,6 +10,12 @@ ServerTokens Prod
 RewriteEngine On
 Options SymLinksIfOwnerMatch
 
+# LimitRequestFieldSize: Expand this to a large number to allow pass-through.
+#   This does not introduce a potential DoS, because the value is validated by
+#   the httpd container first.  However, if a user changes this value in the
+#   httpd container, we need to be able to accomodate that value here also.
+LimitRequestFieldSize 524288
+
 <VirtualHost *:3000>
   DocumentRoot /var/www/miq/vmdb/public
 


### PR DESCRIPTION
LimitRequestFieldSize: Expand this to a large number to allow pass-through.
This does not introduce a potential DoS, because the value is validated by
the httpd container first.  However, if a user changes this value in the
httpd container, we need to be able to accomodate that value here also.

512K was chosen as the size because that is also the maximum limit of
the OIDCCacheShmEntrySizeMax value for OIDC.

@bdunne Please review.