### PR TITLE
[JANSA] Problems with kafka timeouts errors

### DIFF
--- a/templates/app/kafka.yaml
+++ b/templates/app/kafka.yaml
@@ -96,6 +96,7 @@ objects:
         - name: kafka-data
           persistentVolumeClaim:
             claimName: kafka-data
+        hostname: kafka
 - apiVersion: apps/v1
   kind: Deployment
   metadata:


### PR DESCRIPTION
@miq-bot add-label bug
I've running application on OpenShift, when i choose MESSAGING_TYPE kafka, i can't send messages cause it failed by timeout errors.
I started troubleshoot this problem and found interesting thing.
When we connecting to kafka, we use name of service `kafka` and port `9092`, but when rdkafka creating producer and starting produce messaging connection string changing to <hostname>:9092. By default in OpenShift hostname = podname (kafka-anyuid)

Can anyone check it on Kubernets
And mb check for the same problem

How to reproduce

```ruby
kafka = MiqQueue.messaging_client("metrics_capture")
producer = kafka.send(:producer)
irb(main):006:0> producer = kafka.send(:producer)
=> #<Kafka::Producer:0x00005564e2c4ebf8 @cluster=#<Kafka::Cluster:0x00005564e2c4f170 @logger=#<Logger:0x00005564dc501b08 @level=0, @progname=nil, 
@default_formatter=#<Logger::Formatter:0x00005564dc4cf8b0 @datetime_format=nil>, 
@formatter=nil, @logdev=nil>, 
@seed_brokers=[**#<URI::Generic kafka://localhost:9092>]**,........
```
And check brokers hostnames
After that try to connect from pod with worker to broker hostname:port
