### PR TITLE
Replace postgresqlSecretName default value logic in cr.go like others

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/cr.go
+++ b/manageiq-operator/pkg/helpers/miq-components/cr.go
@@ -25,6 +25,14 @@ func backupLabelName(cr *miqv1alpha1.ManageIQ) string {
 	}
 }
 
+func databaseSecret(cr *miqv1alpha1.ManageIQ) string {
+	if cr.Spec.DatabaseSecret == "" {
+		return "postgresql-secrets"
+	} else {
+		return cr.Spec.DatabaseSecret
+	}
+}
+
 func enableApplicationLocalLogin(cr *miqv1alpha1.ManageIQ) bool {
 	if cr.Spec.EnableApplicationLocalLogin == nil {
 		return true
@@ -347,6 +355,7 @@ func ManageCR(cr *miqv1alpha1.ManageIQ, c *client.Client) (*miqv1alpha1.ManageIQ
 		cr.Spec.AppName = appName(cr)
 		cr.Spec.BackupLabelName = backupLabelName(cr)
 		cr.Spec.DatabaseRegion = databaseRegion(cr)
+		cr.Spec.DatabaseSecret = databaseSecret(cr)
 		cr.Spec.DatabaseVolumeCapacity = databaseVolumeCapacity(cr)
 		cr.Spec.DeployMessagingService = &varDeployMessagingService
 		cr.Spec.EnableApplicationLocalLogin = &varEnableApplicationLocalLogin

--- a/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
@@ -162,20 +162,20 @@ func addMessagingEnv(cr *miqv1alpha1.ManageIQ, c *corev1.Container) {
 func addPostgresConfig(cr *miqv1alpha1.ManageIQ, d *appsv1.Deployment, client client.Client) {
 	d.Spec.Template.Spec.Containers[0].Env = append(d.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "DATABASE_REGION", Value: cr.Spec.DatabaseRegion})
 
-	d.Spec.Template.Spec.Containers[0].Env = append(d.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "DATABASE_HOSTNAME", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: postgresqlSecretName(cr)}, Key: "hostname"}}})
-	d.Spec.Template.Spec.Containers[0].Env = append(d.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "DATABASE_NAME", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: postgresqlSecretName(cr)}, Key: "dbname"}}})
-	d.Spec.Template.Spec.Containers[0].Env = append(d.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "DATABASE_PASSWORD", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: postgresqlSecretName(cr)}, Key: "password"}}})
-	d.Spec.Template.Spec.Containers[0].Env = append(d.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "DATABASE_PORT", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: postgresqlSecretName(cr)}, Key: "port"}}})
-	d.Spec.Template.Spec.Containers[0].Env = append(d.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "DATABASE_USER", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: postgresqlSecretName(cr)}, Key: "username"}}})
+	d.Spec.Template.Spec.Containers[0].Env = append(d.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "DATABASE_HOSTNAME", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: cr.Spec.DatabaseSecret}, Key: "hostname"}}})
+	d.Spec.Template.Spec.Containers[0].Env = append(d.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "DATABASE_NAME", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: cr.Spec.DatabaseSecret}, Key: "dbname"}}})
+	d.Spec.Template.Spec.Containers[0].Env = append(d.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "DATABASE_PASSWORD", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: cr.Spec.DatabaseSecret}, Key: "password"}}})
+	d.Spec.Template.Spec.Containers[0].Env = append(d.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "DATABASE_PORT", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: cr.Spec.DatabaseSecret}, Key: "port"}}})
+	d.Spec.Template.Spec.Containers[0].Env = append(d.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "DATABASE_USER", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: cr.Spec.DatabaseSecret}, Key: "username"}}})
 
 	pgSecret := postgresqlSecret(cr, client)
 	if pgSecret.Data["sslmode"] != nil {
-		d.Spec.Template.Spec.Containers[0].Env = append(d.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "DATABASE_SSL_MODE", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: postgresqlSecretName(cr)}, Key: "sslmode"}}})
+		d.Spec.Template.Spec.Containers[0].Env = append(d.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "DATABASE_SSL_MODE", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: cr.Spec.DatabaseSecret}, Key: "sslmode"}}})
 	}
 	if pgSecret.Data["rootcertificate"] != nil {
 		d.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{corev1.VolumeMount{Name: "pg-root-certificate", MountPath: "/.postgresql", ReadOnly: true}}
 
-		secret := corev1.SecretVolumeSource{SecretName: postgresqlSecretName(cr), Items: []corev1.KeyToPath{corev1.KeyToPath{Key: "rootcertificate", Path: "root.crt"}}}
+		secret := corev1.SecretVolumeSource{SecretName: cr.Spec.DatabaseSecret, Items: []corev1.KeyToPath{corev1.KeyToPath{Key: "rootcertificate", Path: "root.crt"}}}
 		d.Spec.Template.Spec.Volumes = []corev1.Volume{corev1.Volume{Name: "pg-root-certificate", VolumeSource: corev1.VolumeSource{Secret: &secret}}}
 	}
 }

--- a/manageiq-operator/pkg/helpers/miq-components/postgresql.go
+++ b/manageiq-operator/pkg/helpers/miq-components/postgresql.go
@@ -25,7 +25,7 @@ func DefaultPostgresqlSecret(cr *miqv1alpha1.ManageIQ) *corev1.Secret {
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      postgresqlSecretName(cr),
+			Name:      cr.Spec.DatabaseSecret,
 			Namespace: cr.ObjectMeta.Namespace,
 		},
 		StringData: secretData,
@@ -37,17 +37,8 @@ func DefaultPostgresqlSecret(cr *miqv1alpha1.ManageIQ) *corev1.Secret {
 	return secret
 }
 
-func postgresqlSecretName(cr *miqv1alpha1.ManageIQ) string {
-	secretName := "postgresql-secrets"
-	if cr.Spec.DatabaseSecret != "" {
-		secretName = cr.Spec.DatabaseSecret
-	}
-
-	return secretName
-}
-
 func postgresqlSecret(cr *miqv1alpha1.ManageIQ, client client.Client) *corev1.Secret {
-	secretKey := types.NamespacedName{Namespace: cr.Namespace, Name: postgresqlSecretName(cr)}
+	secretKey := types.NamespacedName{Namespace: cr.Namespace, Name: cr.Spec.DatabaseSecret}
 	secret := &corev1.Secret{}
 	client.Get(context.TODO(), secretKey, secret)
 
@@ -173,7 +164,7 @@ func PostgresqlDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*ap
 				Name: "POSTGRESQL_USER",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: postgresqlSecretName(cr)},
+						LocalObjectReference: corev1.LocalObjectReference{Name: cr.Spec.DatabaseSecret},
 						Key:                  "username",
 					},
 				},
@@ -182,7 +173,7 @@ func PostgresqlDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*ap
 				Name: "POSTGRESQL_PASSWORD",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: postgresqlSecretName(cr)},
+						LocalObjectReference: corev1.LocalObjectReference{Name: cr.Spec.DatabaseSecret},
 						Key:                  "password",
 					},
 				},
@@ -191,7 +182,7 @@ func PostgresqlDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*ap
 				Name: "POSTGRESQL_DATABASE",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: postgresqlSecretName(cr)},
+						LocalObjectReference: corev1.LocalObjectReference{Name: cr.Spec.DatabaseSecret},
 						Key:                  "dbname",
 					},
 				},


### PR DESCRIPTION
For consistency, move this logic into cr.go and rename it to match the CR parameter name.