### PR TITLE
Fix postgresql secret labeling

### DIFF
--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -340,7 +340,7 @@ func (r *ReconcileManageIQ) generatePostgresqlResources(cr *miqv1alpha1.ManageIQ
 		logger.Info("Secret has been reconciled", "component", "postgresql", "result", result)
 	}
 
-	hostName := getSecretKeyValue(r.client, cr.Namespace, cr.Spec.DatabaseSecret, "hostname")
+	hostName := string(secret.Data["hostname"])
 	if hostName != "postgresql" {
 		logger.Info("External PostgreSQL Database selected, skipping postgresql service reconciliation", "hostname", hostName)
 		return nil

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -334,7 +334,7 @@ func (r *ReconcileManageIQ) generateMemcachedResources(cr *miqv1alpha1.ManageIQ)
 
 func (r *ReconcileManageIQ) generatePostgresqlResources(cr *miqv1alpha1.ManageIQ) error {
 	hostName := getSecretKeyValue(r.client, cr.Namespace, cr.Spec.DatabaseSecret, "hostname")
-	if hostName != "" {
+	if hostName != "postgresql" {
 		logger.Info("External PostgreSQL Database selected, skipping postgresql service reconciliation", "hostname", hostName)
 		return nil
 	}


### PR DESCRIPTION
Ensure that the postgresql secret (whether created by the operator or installer) is managed by the operator with backup and app labels added and controller reference set.

Built on top of #732