### PR TITLE
Skip local specs when operator-sdk version doesn't match

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,6 @@ cache:
   - "$HOME/gopath/pkg/mod"
 before_script:
 - eval "$(gimme 1.14)"
-- travis_wait curl -L https://github.com/operator-framework/operator-sdk/releases/download/v0.17.2/operator-sdk-v0.17.2-$(uname -m)-linux-gnu -o /home/travis/bin/operator-sdk && chmod +x /home/travis/bin/operator-sdk
+- OPERATOR_SDK_VERSION=$(grep operator-sdk manageiq-operator/go.mod | cut -d ' ' -f 2)
+- echo "** Downloading operator-sdk $OPERATOR_SDK_VERSION"
+- travis_wait curl -L https://github.com/operator-framework/operator-sdk/releases/download/$OPERATOR_SDK_VERSION/operator-sdk-$OPERATOR_SDK_VERSION-$(uname -m)-linux-gnu -o /home/travis/bin/operator-sdk && chmod +x /home/travis/bin/operator-sdk

--- a/spec/manageiq-operator/crd_spec.rb
+++ b/spec/manageiq-operator/crd_spec.rb
@@ -1,6 +1,10 @@
 require 'awesome_spawn'
 describe "Generate CRDs" do
   it "doesn't change any tracked files" do
+    unless assert_operator_sdk_valid
+      skip("Wrong operator-sdk version installed.  Expected #{expected_operator_sdk_version.inspect}, Found #{operator_sdk_version.inspect}.")
+    end
+
     csv_version = File.read("manageiq-operator/version/version.go").match(/Version\s=\s\"(.+)\"/)[1]
 
     AwesomeSpawn.run!("operator-sdk generate k8s", :chdir => ROOT.join("manageiq-operator"))

--- a/spec/support/operator_sdk_helper.rb
+++ b/spec/support/operator_sdk_helper.rb
@@ -1,0 +1,18 @@
+def expected_operator_sdk_version
+  @expected_operator_sdk_version ||= ROOT.join("manageiq-operator", "go.mod").readlines.grep(/operator-sdk/).first.strip.split(" ").last
+end
+
+def operator_sdk_version
+  return @operator_sdk_version if defined?(@operator_sdk_version)
+
+  version_str = AwesomeSpawn.run!("operator-sdk version").output
+  @operator_sdk_version = version_str.match(/operator-sdk version: "([^"]+)"/)[1]
+rescue
+  @operator_sdk_version = nil
+end
+
+def assert_operator_sdk_valid
+  (operator_sdk_version == expected_operator_sdk_version).tap do |valid|
+    raise "Invalid operator-sdk version: #{operator_sdk_version}" if ENV["CI"] && !valid
+  end
+end


### PR DESCRIPTION
This PR makes the operator-sdk based specs optional for local development.  However, on CI, instead we will _ensure_ that the specs are running with the same operator-sdk version as described in the go.mod.  This way, updating the go.mod will in turn automatically update the specs.