### PR TITLE
Remove ovirt-4.4-dependencies.repo

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -39,9 +39,9 @@ COPY container-assets/create_local_yum_repo.sh /
 RUN curl -L https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo > /etc/yum.repos.d/ansible-runner.repo
 
 RUN if [ ${ARCH} != "s390x" ] ; then dnf -y --disableplugin=subscription-manager install \
-      http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-2.el8.noarch.rpm \
-      http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm; fi && \
-      dnf -y --disableplugin=subscription-manager install \
+        http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-2.el8.noarch.rpm \
+        http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm; fi && \
+    dnf -y --disableplugin=subscription-manager install \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
       https://rpm.manageiq.org/release/14-najdorf/el8/noarch/manageiq-release-14.0-1.el8.noarch.rpm \
       https://resources.ovirt.org/pub/yum-repo/ovirt-release44.rpm && \


### PR DESCRIPTION
The ovirt-4.4-dependencies.repo brings in a lot of repos, some of which
have old RPMs which have security issues, in particular pyyaml 5.1.2.
We only really need the ovirt-4.4.repo in order to bring in
ovirt-ansible-collection, python3-ovirt-engine-sdk4 and
v2v-conversion-host-ansible.  Removing ovirt-4.4-dependencies.repo
allows many dependencies to install from baseos and appstream which
should be more secure.

@bdunne Please review.
cc @agrare

