### PR TITLE
Remove ovirt-release repo

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -44,8 +44,7 @@ RUN dnf -y remove subscription-manager* && \
         http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm; fi && \
     dnf -y install \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
-      https://rpm.manageiq.org/release/14-najdorf/el8/noarch/manageiq-release-14.0-2.el8.noarch.rpm \
-      https://resources.ovirt.org/pub/yum-repo/ovirt-release44.rpm && \
+      https://rpm.manageiq.org/release/14-najdorf/el8/noarch/manageiq-release-14.0-2.el8.noarch.rpm && \
     rm -f /etc/yum.repos.d/ovirt-4.4-dependencies.repo && \
     dnf -y module enable nodejs:12 && \
     dnf -y module enable ruby:2.7 && \


### PR DESCRIPTION
With the merge of https://github.com/ManageIQ/manageiq-rpm_build/pull/208
and https://github.com/ManageIQ/manageiq-rpm_build/pull/213, there is no
longer a need to pull in the ovirt-release repo.

@bdunne Please review. cc @jrafanie 