### PR TITLE
Enable SSL on the API and UI pods when certificates exist

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/application.go
+++ b/manageiq-operator/pkg/helpers/miq-components/application.go
@@ -27,6 +27,11 @@ func ApplicationUiHttpdConfigMap(cr *miqv1alpha1.ManageIQ, scheme *runtime.Schem
 
 		protocol := "http"
 
+		if certSecret := InternalCertificatesSecret(cr, client); certSecret.Data["ui_crt"] != nil && certSecret.Data["ui_key"] != nil {
+			protocol = "https"
+			configMap.Data["ssl_config"] = appHttpdSslConfig()
+		}
+
 		configMap.Data["manageiq-http.conf"] = uiHttpdConfig(protocol)
 
 		return nil
@@ -52,6 +57,11 @@ func ApplicationApiHttpdConfigMap(cr *miqv1alpha1.ManageIQ, scheme *runtime.Sche
 		addBackupLabel(cr.Spec.BackupLabelName, &configMap.ObjectMeta)
 
 		protocol := "http"
+
+		if certSecret := InternalCertificatesSecret(cr, client); certSecret.Data["api_crt"] != nil && certSecret.Data["api_key"] != nil {
+			protocol = "https"
+			configMap.Data["ssl_config"] = appHttpdSslConfig()
+		}
 
 		configMap.Data["manageiq-http.conf"] = apiHttpdConfig(protocol)
 

--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -164,7 +164,15 @@ func HttpdConfigMap(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, client cli
 		addAppLabel(cr.Spec.AppName, &configMap.ObjectMeta)
 
 		uiHttpProtocol, uiWebSocketProtocol := "http", "ws"
+		if certSecret := InternalCertificatesSecret(cr, client); certSecret.Data["ui_crt"] != nil && certSecret.Data["ui_key"] != nil {
+			uiHttpProtocol, uiWebSocketProtocol = "https", "wss"
+		}
+
 		apiHttpProtocol := "http"
+		if certSecret := InternalCertificatesSecret(cr, client); certSecret.Data["api_crt"] != nil && certSecret.Data["api_key"] != nil {
+			apiHttpProtocol = "https"
+		}
+
 		configMap.Data["application.conf"] = httpdApplicationConf(cr.Spec.ApplicationDomain, uiHttpProtocol, uiWebSocketProtocol, apiHttpProtocol)
 		configMap.Data["authentication.conf"] = httpdAuthenticationConf(&cr.Spec)
 

--- a/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
@@ -481,6 +481,15 @@ RequestHeader set X_FORWARDED_PROTO 'https'
 `
 }
 
+func appHttpdSslConfig() string {
+	return `
+SSLEngine on
+SSLCertificateFile "/etc/pki/tls/certs/server.crt"
+SSLCertificateKeyFile "/etc/pki/tls/private/server.key"
+RequestHeader set X_FORWARDED_PROTO 'https'
+`
+}
+
 func httpdSslProxyConfig() string {
 	return `
 SSLProxyEngine on

--- a/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
@@ -316,6 +316,14 @@ func OrchestratorDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, cl
 
 		addInternalRootCertificate(cr, deployment, client)
 
+		certSecret := InternalCertificatesSecret(cr, client)
+		if certSecret.Data["api_crt"] != nil && certSecret.Data["api_key"] != nil {
+			deployment.Spec.Template.Spec.Containers[0].Env = addOrUpdateEnvVar(deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "API_SSL_SECRET_NAME", Value: cr.Spec.InternalCertificatesSecret})
+		}
+		if certSecret.Data["ui_crt"] != nil && certSecret.Data["ui_key"] != nil {
+			deployment.Spec.Template.Spec.Containers[0].Env = addOrUpdateEnvVar(deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "UI_SSL_SECRET_NAME", Value: cr.Spec.InternalCertificatesSecret})
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
Part of: https://github.com/ManageIQ/manageiq-pods/issues/724
Depends on: https://github.com/ManageIQ/manageiq/pull/21527

~~WIP because I want to do a little bit more testing once https://github.com/ManageIQ/manageiq/pull/21527 is merged~~