### PR TITLE
Remove subscription-manager

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -38,20 +38,21 @@ COPY container-assets/create_local_yum_repo.sh /
 
 RUN curl -L https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo > /etc/yum.repos.d/ansible-runner.repo
 
-RUN if [ ${ARCH} != "s390x" ] ; then dnf -y --disableplugin=subscription-manager install \
+RUN dnf -y remove subscription-manager* && \
+    if [ ${ARCH} != "s390x" ] ; then dnf -y install \
         http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-2.el8.noarch.rpm \
         http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm; fi && \
-    dnf -y --disableplugin=subscription-manager install \
+    dnf -y install \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
       https://rpm.manageiq.org/release/14-najdorf/el8/noarch/manageiq-release-14.0-2.el8.noarch.rpm \
       https://resources.ovirt.org/pub/yum-repo/ovirt-release44.rpm && \
     rm -f /etc/yum.repos.d/ovirt-4.4-dependencies.repo && \
-    dnf -y --disableplugin=subscription-manager module enable nodejs:12 && \
-    dnf -y --disableplugin=subscription-manager module enable ruby:2.7 && \
+    dnf -y module enable nodejs:12 && \
+    dnf -y module enable ruby:2.7 && \
     if [[ "$RELEASE_BUILD" != "true" ]]; then dnf config-manager --enable manageiq-14-najdorf-nightly; fi && \
     dnf config-manager --setopt=ubi-8-*.exclude=dracut*,net-snmp*,perl-*,redhat-release* --save && \
     if [[ "$LOCAL_RPM" = "true" ]]; then /create_local_yum_repo.sh; fi && \
-    dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
+    dnf -y --setopt=tsflags=nodocs install \
       ${RPM_PREFIX}-pods          \
       python3-devel               \
       &&                          \

--- a/images/manageiq-webserver-worker/Dockerfile
+++ b/images/manageiq-webserver-worker/Dockerfile
@@ -9,7 +9,7 @@ ARG RPM_PREFIX=manageiq
 LABEL name="manageiq-webserver-worker" \
       summary="ManageIQ web server worker image"
 
-RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install ${RPM_PREFIX}-ui && \
+RUN dnf -y --setopt=tsflags=nodocs install ${RPM_PREFIX}-ui && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 


### PR DESCRIPTION
- We don't use it
- It's also causing conflicts

```
Error:
 Problem 1: cannot install the best update candidate for package python3-subscription-manager-rhsm-1.28.13-4.el8_4.x86_64
  - nothing provides python3-cloud-what = 1.28.21-3.el8 needed by python3-subscription-manager-rhsm-1.28.21-3.el8.x86_64
 Problem 2: package python3-subscription-manager-rhsm-1.28.13-4.el8_4.x86_64 requires subscription-manager-rhsm-certificates = 1.28.13-4.el8_4, but none of the providers can be installed
  - cannot install both subscription-manager-rhsm-certificates-1.28.21-3.el8.x86_64 and subscription-manager-rhsm-certificates-1.28.13-4.el8_4.x86_64
  - problem with installed package python3-subscription-manager-rhsm-1.28.13-4.el8_4.x86_64
  - cannot install the best update candidate for package subscription-manager-rhsm-certificates-1.28.13-4.el8_4.x86_64
  - nothing provides python3-cloud-what = 1.28.21-3.el8 needed by python3-subscription-manager-rhsm-1.28.21-3.el8.x86_64
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```