### PR TITLE
Fix typo

### DIFF
--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -64,7 +64,7 @@ namespace :release do
     build_script = root.join("bin", "build")
     content = build_script.read
     content.sub!(/^(TAG=).+$/, "\\1latest-#{branch}")
-    content.sub!(/(BUILD_REF:-)\w+(\})/, "\\1#{branch}]\\2")
+    content.sub!(/(BUILD_REF:-)\w+(\})/, "\\1#{branch}\\2")
     build_script.write(content)
 
     # Modify bin/remove_images


### PR DESCRIPTION
Forward-port of https://github.com/ManageIQ/manageiq-pods/pull/779

Introduced in 40d83bdb5361f0caaa4b96893b240a7e8593a204

Presented as:
[1/2] STEP 6/7: ARG GIT_AUTH
--> Using cache 0a3b98757153fa94ceb77db0b738ea8a9332c96b95303bf16fd8bfa411357b5b
--> 0a3b9875715
[1/2] STEP 7/7: RUN mkdir build &&     if [[ -n "$GIT_AUTH" ]]; then GIT_HOST=${GIT_AUTH}@${GIT_HOST}; fi && curl -L https://${GIT_HOST}/${BUILD_ORG}/${CORE_REPO_NAME}-appliance-build/tarball/${BUILD_REF} | tar vxz -C build --strip 1
curl: (3) [globbing] unmatched close brace/bracket in column 68

gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
(cherry picked from commit 833450b69269c7b57f5012ad923e4c7a59e1079e)
