### PR TITLE
Fix Httpd reconcile

### DIFF
--- a/manageiq-operator/pkg/helpers/miq-components/httpd.go
+++ b/manageiq-operator/pkg/helpers/miq-components/httpd.go
@@ -284,12 +284,6 @@ func getHttpdAuthConfigVersion(client client.Client, namespace string, spec *miq
 	return httpd_auth_config_version
 }
 
-func setManagedHttpdCfgVersion(httpdAuthConfigVersion string, podSpec *corev1.PodSpec) {
-	// This is not used by the pod, it is defined to trigger a redeployment if the secret was updated
-	managedHttpdCfgRevision := corev1.EnvVar{Name: "MANAGED_HTTPD_CFG_VERSION", Value: httpdAuthConfigVersion}
-	podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, managedHttpdCfgRevision)
-}
-
 func addAuthConfigVolume(podSpec *corev1.PodSpec) {
 	volumeMount := corev1.VolumeMount{Name: "httpd-auth-config", MountPath: "/etc/httpd/auth-conf.d"}
 	podSpec.Containers[0].VolumeMounts = addOrUpdateVolumeMount(podSpec.Containers[0].VolumeMounts, volumeMount)
@@ -433,7 +427,6 @@ func HttpdDeployment(client client.Client, cr *miqv1alpha1.ManageIQ, scheme *run
 		},
 	}
 
-	httpdAuthConfigVersion := getHttpdAuthConfigVersion(client, cr.Namespace, &cr.Spec)
 
 	f := func() error {
 		if err := controllerutil.SetControllerReference(cr, deployment, scheme); err != nil {
@@ -459,7 +452,11 @@ func HttpdDeployment(client client.Client, cr *miqv1alpha1.ManageIQ, scheme *run
 		}
 
 		configureHttpdAuth(&cr.Spec, &deployment.Spec.Template.Spec)
-		setManagedHttpdCfgVersion(httpdAuthConfigVersion, &deployment.Spec.Template.Spec)
+
+		// This is not used by the pod, it is defined to trigger a redeployment if the secret was updated
+		httpdAuthConfigVersion := getHttpdAuthConfigVersion(client, cr.Namespace, &cr.Spec)
+		deployment.Spec.Template.Spec.Containers[0].Env = addOrUpdateEnvVar(deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "MANAGED_HTTPD_CFG_VERSION", Value: httpdAuthConfigVersion})
+
 		addInternalCertificate(cr, deployment, client, "httpd", "/root")
 
 		secret := InternalCertificatesSecret(cr, client)


### PR DESCRIPTION
```
{"level":"error","ts":1642705176.2017493,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"manageiq-controller","request":"cp4waiops/im-iminstall","error":"Deployment.apps \"httpd\" is invalid: spec.template.spec.volumes[2].name: Duplicate value: \"user-auth-config\"","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error
	/root/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:258
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:232
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
	/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:211
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
	/root/go/pkg/mod/k8s.io/apimachinery@v0.18.2/pkg/util/wait/wait.go:155
k8s.io/apimachinery/pkg/util/wait.BackoffUntil
	/root/go/pkg/mod/k8s.io/apimachinery@v0.18.2/pkg/util/wait/wait.go:156
k8s.io/apimachinery/pkg/util/wait.JitterUntil
	/root/go/pkg/mod/k8s.io/apimachinery@v0.18.2/pkg/util/wait/wait.go:133
k8s.io/apimachinery/pkg/util/wait.Until
	/root/go/pkg/mod/k8s.io/apimachinery@v0.18.2/pkg/util/wait/wait.go:90"}
```