### PR TITLE
Pull httpd from UBI (not CentOS) Appstream repo

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -39,9 +39,12 @@ COPY container-assets/create_local_yum_repo.sh /
 RUN curl -L https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo > /etc/yum.repos.d/ansible-runner.repo
 
 RUN dnf -y remove *subscription-manager* && \
-    if [ ${ARCH} != "s390x" ] ; then dnf -y install \
+    if [ ${ARCH} != "s390x" ] ; then \
+      dnf -y install \
         http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-2.el8.noarch.rpm \
-        http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm; fi && \
+        http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm && \
+      dnf config-manager --setopt=appstream*.exclude=*httpd* --save \
+    ; fi && \
     dnf -y install \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
       https://rpm.manageiq.org/release/14-najdorf/el8/noarch/manageiq-release-14.0-2.el8.noarch.rpm && \


### PR DESCRIPTION
This should ensure that we get the latest versions sooner.

Copy from https://github.com/ManageIQ/container-httpd/pull/67