### PR TITLE
[WIP] Add a startup_check script

### DIFF
--- a/images/manageiq-base-worker/container-assets/manageiq_startup_check
+++ b/images/manageiq-base-worker/container-assets/manageiq_startup_check
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# We're alive if the heartbeat_file exists and has a unix time
+# "newer" / greater than the current time.
+started_file="${APP_ROOT}/tmp/worker.started"
+if [[ ! -f ${started_file} ]]; then
+  exit 1
+fi


### PR DESCRIPTION
Add a script that can be called by a k8s startup probe which checks the worker's tmp/worker.started file

Depends on:
- [ ] https://github.com/ManageIQ/manageiq/pull/21765