### PR TITLE
Add permission to edit routes

### DIFF
--- a/manageiq-operator/deploy/olm-catalog/manageiq-operator/manifests/manageiq-operator.clusterserviceversion.yaml
+++ b/manageiq-operator/deploy/olm-catalog/manageiq-operator/manifests/manageiq-operator.clusterserviceversion.yaml
@@ -137,7 +137,7 @@ spec:
         - apiGroups:
           - route.openshift.io
           resources:
-          - routes/custom-host
+          - '*'
           verbs:
           - '*'
         serviceAccountName: manageiq-operator

--- a/manageiq-operator/deploy/role.yaml
+++ b/manageiq-operator/deploy/role.yaml
@@ -71,6 +71,6 @@ rules:
 - apiGroups:
   - route.openshift.io
   resources:
-  - routes/custom-host
+  - '*'
   verbs:
   - '*'


### PR DESCRIPTION
I missed this in #745 

Results in:
```
{"level":"info","ts":1647532952.510238,"logger":"controller_manageiq","msg":"Deployment has been reconciled","component":"httpd","result":"updated"}
E0317 16:02:32.516949       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.2/tools/cache/reflector.go:125: Failed to list *v1.Route: routes.route.openshift.io is forbidden: User "system:serviceaccount:manageiq:manageiq-operator" cannot list resource "routes" in API group "route.openshift.io" in the namespace "manageiq"
```