### PR TITLE
Add HTTPD configs for the remote console worker

### DIFF
--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -529,6 +529,13 @@ func (r *ReconcileManageIQ) generateNetworkPolicies(cr *miqv1alpha1.ManageIQ) er
 		logger.Info("NetworkPolicy allow httpd-api has been reconciled", "component", "network_policy", "result", result)
 	}
 
+	networkPolicyAllowHttpdRemoteConsole, mutateFunc := miqtool.NetworkPolicyAllowHttpdRemoteConsole(cr, r.scheme)
+	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, networkPolicyAllowHttpdRemoteConsole, mutateFunc); err != nil {
+		return err
+	} else if result != controllerutil.OperationResultNone {
+		logger.Info("NetworkPolicy allow httpd-remote-console has been reconciled", "component", "network_policy", "result", result)
+	}
+
 	networkPolicyAllowHttpdUi, mutateFunc := miqtool.NetworkPolicyAllowHttpdUi(cr, r.scheme)
 	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, networkPolicyAllowHttpdUi, mutateFunc); err != nil {
 		return err

--- a/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
+++ b/manageiq-operator/pkg/controller/manageiq/manageiq_controller.go
@@ -747,5 +747,12 @@ func (r *ReconcileManageIQ) manageApplicationResources(cr *miqv1alpha1.ManageIQ)
 		logger.Info("ConfigMap has been reconciled", "component", "application api", "result", result)
 	}
 
+	configMap, mutateFunc = miqtool.ApplicationRemoteConsoleHttpdConfigMap(cr, r.scheme, r.client)
+	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, configMap, mutateFunc); err != nil {
+		return err
+	} else if result != controllerutil.OperationResultNone {
+		logger.Info("ConfigMap has been reconciled", "component", "application remote console", "result", result)
+	}
+
 	return nil
 }

--- a/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/pkg/helpers/miq-components/orchestrator.go
@@ -320,6 +320,9 @@ func OrchestratorDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, cl
 		if certSecret.Data["api_crt"] != nil && certSecret.Data["api_key"] != nil {
 			deployment.Spec.Template.Spec.Containers[0].Env = addOrUpdateEnvVar(deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "API_SSL_SECRET_NAME", Value: cr.Spec.InternalCertificatesSecret})
 		}
+		if certSecret.Data["remote_console_crt"] != nil && certSecret.Data["remote_console_key"] != nil {
+			deployment.Spec.Template.Spec.Containers[0].Env = addOrUpdateEnvVar(deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "REMOTE_CONSOLE_SSL_SECRET_NAME", Value: cr.Spec.InternalCertificatesSecret})
+		}
 		if certSecret.Data["ui_crt"] != nil && certSecret.Data["ui_key"] != nil {
 			deployment.Spec.Template.Spec.Containers[0].Env = addOrUpdateEnvVar(deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "UI_SSL_SECRET_NAME", Value: cr.Spec.InternalCertificatesSecret})
 		}

--- a/tools/cert_generator.rb
+++ b/tools/cert_generator.rb
@@ -74,4 +74,5 @@ c.generate_cert("memcached")
 c.generate_cert("postgresql")
 
 c.generate_cert("api", application_domain)
+c.generate_cert("remote-console", application_domain)
 c.generate_cert("ui", application_domain)


### PR DESCRIPTION
Part of: https://github.com/ManageIQ/manageiq-pods/issues/829

Also, allow traffic from httpd to the remote console workers