### PR TITLE
Pull mod_ssl from UBI, not CentOS Appstream

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -43,7 +43,7 @@ RUN dnf -y remove *subscription-manager* && \
       dnf -y install \
         http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-2.el8.noarch.rpm \
         http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm && \
-      dnf config-manager --setopt=appstream*.exclude=*httpd* --save \
+      dnf config-manager --setopt=appstream*.exclude=*httpd*,mod_ssl --save \
     ; fi && \
     dnf -y install \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \


### PR DESCRIPTION
Copy of https://github.com/ManageIQ/container-httpd/pull/74