### PR TITLE
Install all httpd dependencies before enabling CentOS repos

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -38,7 +38,10 @@ COPY container-assets/create_local_yum_repo.sh /
 
 RUN curl -L https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo > /etc/yum.repos.d/ansible-runner.repo
 
-RUN dnf -y remove *subscription-manager* && \
+RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
+      httpd \
+      mod_ssl && \
+    dnf -y remove *subscription-manager* && \
     if [ ${ARCH} != "s390x" ] ; then \
       dnf -y install \
         http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-2.el8.noarch.rpm \


### PR DESCRIPTION
Copied from: https://github.com/ManageIQ/container-httpd/pull/75