### PR TITLE
Don't remove subscription-manager on s390x

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir build && \
 FROM registry.access.redhat.com/ubi8/ubi
 MAINTAINER ManageIQ https://manageiq.org
 
-ARG ARCH=x86_64
+ARG ARCH=$(uname -m)
 ARG LOCAL_RPM
 ARG RELEASE_BUILD
 ARG RPM_PREFIX=manageiq
@@ -41,8 +41,8 @@ RUN curl -L https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo 
 RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
       httpd \
       mod_ssl && \
-    dnf -y remove *subscription-manager* && \
     if [ ${ARCH} != "s390x" ] ; then \
+      dnf -y remove *subscription-manager* && \
       dnf -y install \
         http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-2.el8.noarch.rpm \
         http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm && \

--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir build && \
 FROM registry.access.redhat.com/ubi8/ubi
 MAINTAINER ManageIQ https://manageiq.org
 
-ARG ARCH=$(uname -m)
+ARG ARCH=x86_64
 ARG LOCAL_RPM
 ARG RELEASE_BUILD
 ARG RPM_PREFIX=manageiq


### PR DESCRIPTION
Red Hat Enterprise Linux 8 repo will be removed if we remove **subscription-manager** on s390x due to which createrepo_c and other packages were failed to install within manageiq-base image.