### PR TITLE
Add format docker for s390x builds using podman

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -85,6 +85,11 @@ pushd $IMAGE_DIR
     cmd+=" --build-arg RELEASE_BUILD=true"
   fi
 
+  if [ "$ARCH" = "s390x" ]; then
+    # --format docker is needed to ensure the builds are built with docker v2 manifests
+    cmd+=" --format docker"
+  fi
+
   echo "Building manageiq-base: $cmd"
   $cmd manageiq-base
 
@@ -95,6 +100,12 @@ pushd $IMAGE_DIR
                       --build-arg FROM_TAG=$TAG \
                       --build-arg RPM_PREFIX=$RPM_PREFIX \
                       $image"
+
+    if [ "$ARCH" = "s390x" ]; then
+      # --format docker is needed to ensure the builds are built with docker v2 manifests
+      cmd+=" --format docker"
+    fi
+
     echo "Building $image: $cmd"
     $cmd
   done
@@ -108,7 +119,21 @@ if [ -z "$NO_OPERATOR" ]; then
     cat ./build/_output/BUILD
     echo
 
-    cmd="operator-sdk build --image-build-args --pull $REPO/manageiq-operator:$TAG"
+    image_build_args="--image-build-args --pull"
+    image_builder=""
+
+    if [ "$ARCH" = "s390x" ]; then
+      # HACK: Using buildah as, under the covers, this uses --format docker,
+      # which is needed to build v2 manifest builds. Normally, we'd pass
+      # --format docker as above as another arg to image-build-args, however,
+      # there is a bug in operator-sdk v0.18.2 where it cannot accept multiple
+      # args in image-build-args.
+      #
+      # See also https://github.com/operator-framework/operator-sdk/blob/v0.18.2/cmd/operator-sdk/build/cmd.go#L75-L99
+      image_builder="--image-builder buildah"
+    fi
+
+    cmd="operator-sdk build $REPO/manageiq-operator:$TAG $image_build_args $image_builder"
     echo "Building manageiq-operator: $cmd"
     $cmd
   popd


### PR DESCRIPTION
<!-- 1. Describe what this PR does and why you think it is needed -->

This fixes issues where the images created by podman on s390x are not in v2 image format, which causes issues later when we create multi-arch image manifests.

<!--
2. If this issue fixes an existing issue, please specify in `Fixes #<id>` format
(See https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Tell the bot to mark this with an appropriate label (e.g. bug, enhancement, etc)
e.g. `@miq-bot add-label bug`
-->

@miq-bot add-label bug

I think we also have to update the operator-sdk build, but I'm really not sure how.