### PR TITLE
Drop nodejs from podified as it's a build dependency now

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -51,7 +51,6 @@ RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install 
     dnf -y install \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
       https://rpm.manageiq.org/release/15-oparin/el8/noarch/manageiq-release-15.0-1.el8.noarch.rpm && \
-    dnf -y module enable nodejs:14 && \
     dnf -y module enable ruby:2.7 && \
     if [[ "$RELEASE_BUILD" != "true" ]]; then dnf config-manager --enable manageiq-15-oparin-nightly; fi && \
     dnf config-manager --setopt=ubi-8-*.exclude=dracut*,net-snmp*,perl-*,redhat-release* --save && \


### PR DESCRIPTION
For https://github.com/ManageIQ/manageiq-ui-classic/issues/8300

NOTE: See https://github.com/ManageIQ/manageiq-ui-classic/issues/8300 for the breakdown of required PRs.