### PR TITLE
Clean more files after dnf installing

### DIFF
--- a/images/manageiq-base-worker/Dockerfile
+++ b/images/manageiq-base-worker/Dockerfile
@@ -7,6 +7,7 @@ COPY container-assets/ /vddk/
 
 RUN /vddk/extract-vmware-vddk
 
+################################################################################
 
 FROM ${FROM_REPO}/manageiq-base:${FROM_TAG}
 MAINTAINER ManageIQ https://manageiq.org
@@ -20,10 +21,5 @@ COPY container-assets/manageiq_liveness_check /usr/local/bin
 COPY --from=vddk /vddk/vmware-vix-disklib-distrib/ /usr/lib/vmware-vix-disklib/
 COPY container-assets/install-vmware-vddk /tmp/
 RUN /tmp/install-vmware-vddk
-
-RUN source /etc/default/evm && \
-    /usr/bin/generate_rpm_manifest.sh && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
 
 CMD ["entrypoint"]

--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -9,6 +9,8 @@ ARG GIT_AUTH
 RUN mkdir build && \
     if [[ -n "$GIT_AUTH" ]]; then GIT_HOST=${GIT_AUTH}@${GIT_HOST}; fi && curl -L https://${GIT_HOST}/${BUILD_ORG}/${CORE_REPO_NAME}-appliance-build/tarball/${BUILD_REF} | tar vxz -C build --strip 1
 
+################################################################################
+
 FROM registry.access.redhat.com/ubi8/ubi
 MAINTAINER ManageIQ https://manageiq.org
 
@@ -33,8 +35,13 @@ LABEL name="manageiq-base" \
 RUN chmod -R g+w /etc/pki/ca-trust && \
     chmod -R g+w /usr/share/pki/ca-trust-legacy
 
+# Install dumb-init to be used as the entrypoint
+RUN curl -L -o /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_${ARCH} && \
+    chmod +x /usr/bin/dumb-init
+
 COPY rpms/* /tmp/rpms/
 COPY container-assets/create_local_yum_repo.sh /
+COPY container-assets/clean_dnf_rpm /usr/local/bin/
 
 RUN curl -L https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo > /etc/yum.repos.d/ansible-runner.repo
 
@@ -56,30 +63,25 @@ RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install 
     dnf config-manager --setopt=ubi-8-*.exclude=dracut*,net-snmp*,perl-*,redhat-release* --save && \
     if [[ "$LOCAL_RPM" = "true" ]]; then /create_local_yum_repo.sh; fi && \
     dnf -y --setopt=tsflags=nodocs install \
-      ${RPM_PREFIX}-pods          \
-      python3-devel               \
-      &&                          \
-    dnf clean all && \
-    rm -rf /var/cache/dnf && \
+      ${RPM_PREFIX}-pods \
+      python3-devel && \
+    clean_dnf_rpm && \
     chgrp -R 0 $APP_ROOT && \
     chmod -R g=u $APP_ROOT
+
+# Add in the container_env file now that the APP_ROOT is created from the RPM
+ADD container-assets/container_env ${APP_ROOT}
 
 # Install python packages the same way the appliance does
 COPY --from=appliance_build build/kickstarts/partials/post/python_modules.ks.erb /tmp/python_modules
 RUN bash /tmp/python_modules && \
     rm -f /tmp/python_modules && \
     rm -rf /root/.cache/pip && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
+    clean_dnf_rpm
 
-ADD container-assets/container_env ${APP_ROOT}
-
-RUN curl -L -o /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_${ARCH} && \
-    chmod +x /usr/bin/dumb-init
-
+# Build the RPM manifest
 RUN source /etc/default/evm && \
     /usr/bin/generate_rpm_manifest.sh && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
+    clean_dnf_rpm
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--single-child", "--"]

--- a/images/manageiq-base/container-assets/clean_dnf_rpm
+++ b/images/manageiq-base/container-assets/clean_dnf_rpm
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Cleanup dnf
+dnf clean all
+rm -rf /var/cache/dnf
+rm -rf /var/lib/dnf/history*
+rm -rf /var/log/dnf*.log
+rm -rf /var/log/hawkey.log
+
+# Cleanup rpm
+rm -rf /var/lib/rpm/__db.*

--- a/images/manageiq-orchestrator/Dockerfile
+++ b/images/manageiq-orchestrator/Dockerfile
@@ -9,9 +9,4 @@ LABEL name="manageiq-orchestrator" \
 
 COPY container-assets/entrypoint /usr/local/bin
 
-RUN source /etc/default/evm && \
-    /usr/bin/generate_rpm_manifest.sh && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
-
 CMD ["entrypoint"]

--- a/images/manageiq-ui-worker/Dockerfile
+++ b/images/manageiq-ui-worker/Dockerfile
@@ -6,10 +6,3 @@ MAINTAINER ManageIQ https://manageiq.org
 
 LABEL name="manageiq-ui-worker" \
       summary="ManageIQ user interface worker image"
-
-RUN source /etc/default/evm && \
-    /usr/bin/generate_rpm_manifest.sh && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
-
-RUN rm -rf /tmp/rpms /create_local_yum_repo.sh /etc/yum.repos.d/local_rpm.repo

--- a/images/manageiq-webserver-worker/Dockerfile
+++ b/images/manageiq-webserver-worker/Dockerfile
@@ -9,23 +9,24 @@ ARG RPM_PREFIX=manageiq
 LABEL name="manageiq-webserver-worker" \
       summary="ManageIQ web server worker image"
 
-RUN dnf -y --setopt=tsflags=nodocs install ${RPM_PREFIX}-ui && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
-
 COPY container-assets/service-worker-entrypoint /usr/local/bin
 
-RUN rm -f /etc/httpd/conf.d/* && \
-    sed -i '/^Listen 80/d' /etc/httpd/conf/httpd.conf
+RUN dnf -y --setopt=tsflags=nodocs install \
+      ${RPM_PREFIX}-ui && \
+    clean_dnf_rpm && \
+    # Remove httpd default settings
+    rm -f /etc/httpd/conf.d/* && \
+    sed -i '/^Listen 80/d' /etc/httpd/conf/httpd.conf && \
+    # Configure httpd to run without root privileges
+    chgrp root /var/run/httpd && \
+    chmod g+rwx /var/run/httpd && \
+    chgrp root /var/log/httpd && \
+    chmod g+rwx /var/log/httpd
 
-# Configure httpd to run without root privileges
-RUN chgrp root /var/run/httpd && chmod g+rwx /var/run/httpd && \
-    chgrp root /var/log/httpd && chmod g+rwx /var/log/httpd
-
+# Build the RPM manifest
 RUN source /etc/default/evm && \
     /usr/bin/generate_rpm_manifest.sh && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
+    clean_dnf_rpm
 
 EXPOSE 3000
 EXPOSE 4000


### PR DESCRIPTION
This change reduces the UI worker image size from 2.063GB to 2.018GB
(44MB, 2.1%)

- Add the removal of dnf logs, dnf history, and rpm __db lock files.
  This eliminates roughly 2-6MB per invocation.
- Move the cleaning of dnf and rpm assets into a script, which makes it
  easier to use across layers and images.
- Remove redundant rebuild of the rpm manifests, since ther are
  unnecessary unless rpm changes are made.
- Collapse the modifications of the httpd package into the same layer as
  when it's installed.

Part of #736

EDIT: I forgot to mention this also has significant time savings as well.  Locally, the rpm manifest generation steps can take  ~100s (1m40s) x 5 images = ~500s (8m20s).  After this PR, there are only 2 calls, so that's 200s (3m20s) for a savings of ~5min per build