### PR TITLE
Avoid installing weak dependencies 

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -45,7 +45,7 @@ COPY container-assets/clean_dnf_rpm /usr/local/bin/
 
 RUN curl -L https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo > /etc/yum.repos.d/ansible-runner.repo
 
-RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
+RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs --setopt=install_weak_deps=False install \
       httpd \
       mod_ssl && \
     if [ ${ARCH} != "s390x" ] ; then \
@@ -62,7 +62,7 @@ RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install 
     if [[ "$RELEASE_BUILD" != "true" ]]; then dnf config-manager --enable manageiq-15-oparin-nightly; fi && \
     dnf config-manager --setopt=ubi-8-*.exclude=dracut*,net-snmp*,perl-*,redhat-release* --save && \
     if [[ "$LOCAL_RPM" = "true" ]]; then /create_local_yum_repo.sh; fi && \
-    dnf -y --setopt=tsflags=nodocs install \
+    dnf -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False install \
       ${RPM_PREFIX}-pods \
       python3-devel && \
     clean_dnf_rpm && \

--- a/images/manageiq-webserver-worker/Dockerfile
+++ b/images/manageiq-webserver-worker/Dockerfile
@@ -11,7 +11,7 @@ LABEL name="manageiq-webserver-worker" \
 
 COPY container-assets/service-worker-entrypoint /usr/local/bin
 
-RUN dnf -y --setopt=tsflags=nodocs install \
+RUN dnf -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False install \
       ${RPM_PREFIX}-ui && \
     clean_dnf_rpm && \
     # Remove httpd default settings


### PR DESCRIPTION
Depends on
- [x] https://github.com/ManageIQ/manageiq-rpm_build/pull/289

The following weak dependencies will end up not being installed.

```
apr-util-bdb
apr-util-openssl
geolite2-city
geolite2-country
libmaxminddb
perl-Digest
perl-Digest-MD5
perl-IO-Socket-IP
perl-IO-Socket-SSL
perl-libnet
perl-Mozilla-CA
perl-Net-SSLeay
perl-URI
python38-pip
python3-jmespath
rubygem-bundler
rubygem-json
rubygem-rdoc
```

This drops the image size roughly from 2.063GB to 1.943GB (120MB, 5.85%).  Of note, the geolite2 packages are somewhat large, so part of #736 

---

Packages sizes sorted by size:

```
56549434  geolite2-city
 7784945  python38-pip
 3424334  geolite2-country
 1714611  rubygem-rdoc
 1359290  rubygem-bundler
 1325271  perl-Net-SSLeay
  618705  perl-IO-Socket-SSL
  277135  perl-libnet
  216452  perl-URI
  119891  python3-jmespath
   99525  perl-IO-Socket-IP
   97777  rubygem-json
   56718  perl-Digest-MD5
   54260  libmaxminddb
   26685  perl-Digest
   20448  apr-util-openssl
   11920  apr-util-bdb
    5716  perl-Mozilla-CA
```
