### PR TITLE
OPERATOR_NAME is no longer used

### DIFF
--- a/manageiq-operator/config/manager/manager.yaml
+++ b/manageiq-operator/config/manager/manager.yaml
@@ -26,8 +26,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "manageiq-operator"
           resources:
             requests:
               memory: 60Mi


### PR DESCRIPTION
It was used for leader election lock naming in older versions of the operator-sdk.
Dropped by https://github.com/ManageIQ/manageiq-pods/pull/831/files#diff-963be88783f1e1465a03f13199442714132415353ddb038a0f52f6442dde70ceL87-L97
