### PR TITLE
Fix core apigroup definition issues

### DIFF
--- a/manageiq-operator/config/rbac/role.yaml
+++ b/manageiq-operator/config/rbac/role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: manageiq-operator
 rules:
 - apiGroups:
-  - ''
+  - ""
   resources:
   - configmaps
   - events

--- a/manageiq-operator/controllers/manageiq_controller.go
+++ b/manageiq-operator/controllers/manageiq_controller.go
@@ -43,10 +43,12 @@ type ManageIQReconciler struct {
 	Scheme *runtime.Scheme
 }
 
+//+kubebuilder:rbac:namespace=changeme,groups="",resources=configmaps;events;persistentvolumeclaims;pods;pods/finalizers;secrets;serviceaccounts;services;services/finalizers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:namespace=changeme,groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:namespace=changeme,groups=apps,resources=deployments/finalizers,resourceNames=manageiq-operator,verbs=update
 //+kubebuilder:rbac:namespace=changeme,groups=apps,resources=deployments/scale,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:namespace=changeme,groups=apps,resources=replicasets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:namespace=changeme,groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update;delete
 //+kubebuilder:rbac:namespace=changeme,groups=extensions,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:namespace=changeme,groups=extensions,resources=deployments/scale,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:namespace=changeme,groups=extensions,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
@@ -59,14 +61,6 @@ type ManageIQReconciler struct {
 //+kubebuilder:rbac:namespace=changeme,groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:namespace=changeme,groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:namespace=changeme,groups=route.openshift.io,resources=*,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:namespace=changeme,groups='',resources=configmaps,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:namespace=changeme,groups='',resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:namespace=changeme,groups='',resources=pods,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:namespace=changeme,groups='',resources=pods/finalizers,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:namespace=changeme,groups='',resources=secrets,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:namespace=changeme,groups='',resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:namespace=changeme,groups='',resources=services,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:namespace=changeme,groups='',resources=services/finalizers,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/spec/manageiq-operator/crd_spec.rb
+++ b/spec/manageiq-operator/crd_spec.rb
@@ -3,8 +3,9 @@ describe "Generate CRDs" do
   it "doesn't change any tracked files" do
     # TODO: Figure out how to make this generate the correct data.
     #       We are running a namespaced operator, but don't want to specify the namespace name in files
-    #       since that's up to the person installing the app.  Also, don't unnecessarily explode the roles.
+    #       since that's up to the person installing the app.
     # AwesomeSpawn.run!("make manifests", :chdir => ROOT.join("manageiq-operator"))
+
     AwesomeSpawn.run!("make generate", :chdir => ROOT.join("manageiq-operator"))
 
     expect(AwesomeSpawn.run!("git diff").output).to be_empty, "Files differ after generating CRDs"


### PR DESCRIPTION
- Single quotes are not YAML dumped correctly, use double quotes instead
- Prevent role explosion by listing them all on the same line

The only remaining issues with `make manifests` are:
- It adds creationTimestamp: null
- It tries to add a namespace
- It changes the role name