### PR TITLE
Rely on make docker-build for consistency

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -106,26 +106,7 @@ popd
 
 if [ -z "$NO_OPERATOR" ]; then
   pushd "$OPERATOR_DIR"
-    echo "Building manageiq-operator manifest..."
-    echo "$(date +"%Y%m%d%H%M%S")-$(git rev-parse HEAD)" > ./BUILD
-    cat ./BUILD
-    echo
-
-    image_build_args="--image-build-args --pull"
-    image_builder=""
-
-    if [ "$ARCH" = "s390x" ]; then
-      # HACK: Using buildah as, under the covers, this uses --format docker,
-      # which is needed to build v2 manifest builds. Normally, we'd pass
-      # --format docker as above as another arg to image-build-args, however,
-      # there is a bug in operator-sdk v0.18.2 where it cannot accept multiple
-      # args in image-build-args.
-      #
-      # See also https://github.com/operator-framework/operator-sdk/blob/v0.18.2/cmd/operator-sdk/build/cmd.go#L75-L99
-      image_builder="--image-builder buildah"
-    fi
-
-    cmd="operator-sdk build $REPO/manageiq-operator:$TAG $image_build_args $image_builder"
+    cmd="IMG=$REPO/manageiq-operator:$TAG make build"
     echo "Building manageiq-operator: $cmd"
     $cmd
   popd

--- a/manageiq-operator/Makefile
+++ b/manageiq-operator/Makefile
@@ -119,7 +119,8 @@ run: manifests generate fmt vet ## Run a controller from your host.
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
 	echo "$(date +"%Y%m%d%H%M%S")-$(git rev-parse HEAD)" > ./BUILD
-	docker build -t ${IMG} .
+	cat ./BUILD
+	docker build -t ${IMG} . --pull --format docker
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
- After upgrading to operator-sdk 1.x we use make, not operator-sdk to build the operator image
- Also move options to Makefile

Fixes: `must run command in project root dir: project structure requires build/Dockerfile`