### PR TITLE
Add sensible defaults for DATABASE_URL when env vars do not exist

### DIFF
--- a/images/manageiq-base/container-assets/container_env
+++ b/images/manageiq-base/container-assets/container_env
@@ -10,8 +10,13 @@ function urlescape() {
 
 safeuser=$(urlescape ${DATABASE_USER})
 safepass=$(urlescape ${DATABASE_PASSWORD})
+if [ -n "$safeuser" -a -n "$safepass" ]; then
+  safeuserinfo="${safeuser}:${safepass}@"
+else
+  safeuserinfo=""
+fi
 
-database_url="postgresql://${safeuser}:${safepass}@${DATABASE_HOSTNAME}:${DATABASE_PORT}/${DATABASE_NAME}?encoding=utf8&pool=5&wait_timeout=5&sslmode=${DATABASE_SSL_MODE:-prefer}"
+database_url="postgresql://${safeuserinfo}${DATABASE_HOSTNAME:-localhost}:${DATABASE_PORT:-5432}/${DATABASE_NAME:-db_unknown}?encoding=utf8&pool=5&wait_timeout=5&sslmode=${DATABASE_SSL_MODE:-prefer}"
 [[ -f /.postgresql/root.crt ]] && database_url="$database_url&sslrootcert=/.postgresql/root.crt"
 
 export DATABASE_URL=$database_url


### PR DESCRIPTION
<!-- 1. Describe what this PR does and why you think it is needed -->

When running the docker images directly with something like
`docker run --entrypoint /bin/bash ...`, the values in container_env end
up creating an invalid DATABASE_URL. For diagnostic purposes where you
might want to run Rails console, but don't need the database, this
invalid DATABASE_URL prevents it from starting.

The changes here ensure a valid DATABASE_URL is created allowing usage
of Rails console even if the actual database cannot be connected to.

<!--
2. If this issue fixes an existing issue, please specify in `Fixes #<id>` format
(See https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Tell the bot to mark this with an appropriate label (e.g. bug, enhancement, etc)
e.g. `@miq-bot add-label bug`
-->

@jrafanie Please review.

Before:

```
$ docker bash manageiq/manageiq-ui-worker:latest-najdorf
$$ vmdb
$$ source container_env
$$ echo $DATABASE_URL
postgresql://:@:/?encoding=utf8&pool=5&wait_timeout=5&sslmode=prefer
$$ bin/rails c
/usr/share/ruby/irb/completion.rb:18: warning: already initialized constant IRB::InputCompletor::ReservedWords
/usr/share/gems/gems/irb-1.2.6/lib/irb/completion.rb:18: warning: previous definition of ReservedWords was here
/usr/share/ruby/irb/completion.rb:39: warning: already initialized constant IRB::InputCompletor::BASIC_WORD_BREAK_CHARACTERS
/usr/share/gems/gems/irb-1.2.6/lib/irb/completion.rb:39: warning: previous definition of BASIC_WORD_BREAK_CHARACTERS was here
/usr/share/ruby/irb/completion.rb:41: warning: already initialized constant IRB::InputCompletor::CompletionProc
/usr/share/gems/gems/irb-1.2.6/lib/irb/completion.rb:41: warning: previous definition of CompletionProc was here
/usr/share/ruby/irb/completion.rb:268: warning: already initialized constant IRB::InputCompletor::PerfectMatchedProc
/usr/share/gems/gems/irb-1.2.6/lib/irb/completion.rb:268: warning: previous definition of PerfectMatchedProc was here
/usr/share/ruby/irb/completion.rb:294: warning: already initialized constant IRB::InputCompletor::Operators
/usr/share/gems/gems/irb-1.2.6/lib/irb/completion.rb:294: warning: previous definition of Operators was here
Traceback (most recent call last):
	62: from bin/rails:4:in `<main>'
	61: from /opt/IBM/infrastructure-management-gemset/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	60: from /opt/IBM/infrastructure-management-gemset/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	59: from /opt/IBM/infrastructure-management-gemset/gems/railties-6.0.5.1/lib/rails/commands.rb:18:in `<main>'
	58: from /opt/IBM/infrastructure-management-gemset/gems/railties-6.0.5.1/lib/rails/command.rb:46:in `invoke'
	57: from /opt/IBM/infrastructure-management-gemset/gems/railties-6.0.5.1/lib/rails/command/base.rb:69:in `perform'
	56: from /opt/IBM/infrastructure-management-gemset/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	55: from /opt/IBM/infrastructure-management-gemset/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	54: from /opt/IBM/infrastructure-management-gemset/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	53: from /opt/IBM/infrastructure-management-gemset/gems/railties-6.0.5.1/lib/rails/commands/console/console_command.rb:101:in `perform'
	52: from /opt/IBM/infrastructure-management-gemset/gems/railties-6.0.5.1/lib/rails/command/actions.rb:14:in `require_application_and_environment!'
	51: from /opt/IBM/infrastructure-management-gemset/gems/railties-6.0.5.1/lib/rails/command/actions.rb:22:in `require_application!'
	50: from /opt/IBM/infrastructure-management-gemset/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	49: from /opt/IBM/infrastructure-management-gemset/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	48: from /var/www/miq/vmdb/config/application.rb:31:in `<main>'
        ...
/usr/share/ruby/uri/generic.rb:208:in `initialize': the scheme postgresql does not accept registry part: :@: (or bad hostname?) (URI::InvalidURIError)
```

After:

```
$ docker bash manageiq/manageiq-ui-worker:latest-najdorf
$$ vmdb
$$ source container_env
$$ echo $DATABASE_URL
postgresql://localhost:5432/db_unknown?encoding=utf8&pool=5&wait_timeout=5&sslmode=prefer
$$ bin/rails c
{"@timestamp":"2022-08-11T18:24:25.090949 ","hostname":"43e2bba514f8","pid":29,"tid":"8ea8","service":"evm","level":"info","message":"MIQ(Vmdb::Loggers.apply_config) Log level for azure has been changed to [WARN]"}
{"@timestamp":"2022-08-11T18:24:25.091304 ","hostname":"43e2bba514f8","pid":29,"tid":"8ea8","service":"evm","level":"info","message":"MIQ(Vmdb::Loggers.apply_config) Log level for vim has been changed to [WARN]"}
{"@timestamp":"2022-08-11T18:24:25.485657 ","hostname":"43e2bba514f8","pid":29,"tid":"8ea8","service":"evm","level":"info","message":"MIQ(ManageIQ::Session.configure_session_store) Using session_store: ActionDispatch::Session::MemCacheStore"}
{"@timestamp":"2022-08-11T18:24:25.665066 ","hostname":"43e2bba514f8","pid":29,"tid":"8ea8","service":"api","level":"info","message":"Initializing Environment for API"}
{"@timestamp":"2022-08-11T18:24:25.665247 ","hostname":"43e2bba514f8","pid":29,"tid":"8ea8","service":"api","level":"info","message":""}
{"@timestamp":"2022-08-11T18:24:25.665357 ","hostname":"43e2bba514f8","pid":29,"tid":"8ea8","service":"api","level":"info","message":"Static Configuration"}
{"@timestamp":"2022-08-11T18:24:25.665514 ","hostname":"43e2bba514f8","pid":29,"tid":"8ea8","service":"api","level":"info","message":"  module                  : api"}
{"@timestamp":"2022-08-11T18:24:25.665608 ","hostname":"43e2bba514f8","pid":29,"tid":"8ea8","service":"api","level":"info","message":"  name                    : API"}
{"@timestamp":"2022-08-11T18:24:25.665722 ","hostname":"43e2bba514f8","pid":29,"tid":"8ea8","service":"api","level":"info","message":"  description             : REST API"}
{"@timestamp":"2022-08-11T18:24:25.665806 ","hostname":"43e2bba514f8","pid":29,"tid":"8ea8","service":"api","level":"info","message":""}
{"@timestamp":"2022-08-11T18:24:25.665864 ","hostname":"43e2bba514f8","pid":29,"tid":"8ea8","service":"api","level":"info","message":"Dynamic Configuration"}
{"@timestamp":"2022-08-11T18:24:25.669959 ","hostname":"43e2bba514f8","pid":29,"tid":"8ea8","service":"api","level":"info","message":"  token_ttl               : 10.minutes"}
{"@timestamp":"2022-08-11T18:24:25.670166 ","hostname":"43e2bba514f8","pid":29,"tid":"8ea8","service":"api","level":"info","message":"  authentication_timeout  : 30.seconds"}
{"@timestamp":"2022-08-11T18:24:25.670305 ","hostname":"43e2bba514f8","pid":29,"tid":"8ea8","service":"api","level":"info","message":"  max_results_per_page    : 1000"}
{"@timestamp":"2022-08-11T18:24:25.670498 ","hostname":"43e2bba514f8","pid":29,"tid":"8ea8","service":"evm","level":"info","message":"MIQ(Vmdb::Initializer.init) Initializing Application: Program Name: bin/rails, PID: 29, ENV['EVMSERVER']: "}
{"@timestamp":"2022-08-11T18:24:25.671771 ","hostname":"43e2bba514f8","pid":29,"tid":"8ea8","service":"evm","level":"err","message":"MIQ(Vmdb::Initializer.log_db_not_connectable) Cannot connect to the database!"}
** Cannot connect to the database!
Loading production environment (Rails 6.0.5.1)
irb(main):001:0>
```

After (w/env vars present):

```
$$ export DATABASE_USER=test
$$ export DATABASE_PASSWORD=smartvm
$$ export DATABASE_HOSTNAME=postgresql_service
$$ export DATABASE_PORT=5432
$$ export DATABASE_NAME=vmdb_production
$$ export DATABASE_SSL_MODE=strict
$$ vmdb
$$ source container_env
$$ echo $DATABASE_URL
postgresql://test:smartvm@postgresql_service:5432/vmdb_production?encoding=utf8&pool=5&wait_timeout=5&sslmode=strict
$$ bin/rails c
Traceback (most recent call last):
	62: from bin/rails:4:in `<main>'
	61: from /opt/IBM/infrastructure-management-gemset/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	60: from /opt/IBM/infrastructure-management-gemset/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	59: from /opt/IBM/infrastructure-management-gemset/gems/railties-6.0.5.1/lib/rails/commands.rb:18:in `<main>'
	58: from /opt/IBM/infrastructure-management-gemset/gems/railties-6.0.5.1/lib/rails/command.rb:46:in `invoke'
	57: from /opt/IBM/infrastructure-management-gemset/gems/railties-6.0.5.1/lib/rails/command/base.rb:69:in `perform'
	56: from /opt/IBM/infrastructure-management-gemset/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	55: from /opt/IBM/infrastructure-management-gemset/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	54: from /opt/IBM/infrastructure-management-gemset/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	53: from /opt/IBM/infrastructure-management-gemset/gems/railties-6.0.5.1/lib/rails/commands/console/console_command.rb:101:in `perform'
	52: from /opt/IBM/infrastructure-management-gemset/gems/railties-6.0.5.1/lib/rails/command/actions.rb:14:in `require_application_and_environment!'
	51: from /opt/IBM/infrastructure-management-gemset/gems/railties-6.0.5.1/lib/rails/command/actions.rb:22:in `require_application!'
	50: from /opt/IBM/infrastructure-management-gemset/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	49: from /opt/IBM/infrastructure-management-gemset/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	48: from /var/www/miq/vmdb/config/application.rb:31:in `<main>'
	...
/usr/share/ruby/uri/generic.rb:208:in `initialize': the scheme postgresql does not accept registry part: test:smartvm@postgresql_service:5432 (or bad hostname?) (URI::InvalidURIError)
```

Failure is expected here because `postgresql_service` is not reachable.  To show reachability, I'll change to `localhost`:

```
$$ export DATABASE_HOSTNAME=localhost
$$ source container_env
$$  echo $DATABASE_URL
postgresql://test:smartvm@localhost:5432/vmdb_production?encoding=utf8&pool=5&wait_timeout=5&sslmode=strict
$$ bin/rails c
{"@timestamp":"2022-08-11T18:35:07.175745 ","hostname":"6e9f02b85f58","pid":41,"tid":"8ea8","service":"evm","level":"info","message":"MIQ(Vmdb::Loggers.apply_config) Log level for azure has been changed to [WARN]"}
{"@timestamp":"2022-08-11T18:35:07.176277 ","hostname":"6e9f02b85f58","pid":41,"tid":"8ea8","service":"evm","level":"info","message":"MIQ(Vmdb::Loggers.apply_config) Log level for vim has been changed to [WARN]"}
{"@timestamp":"2022-08-11T18:35:07.623565 ","hostname":"6e9f02b85f58","pid":41,"tid":"8ea8","service":"evm","level":"info","message":"MIQ(ManageIQ::Session.configure_session_store) Using session_store: ActionDispatch::Session::MemCacheStore"}
{"@timestamp":"2022-08-11T18:35:07.834505 ","hostname":"6e9f02b85f58","pid":41,"tid":"8ea8","service":"api","level":"info","message":"Initializing Environment for API"}
{"@timestamp":"2022-08-11T18:35:07.834665 ","hostname":"6e9f02b85f58","pid":41,"tid":"8ea8","service":"api","level":"info","message":""}
{"@timestamp":"2022-08-11T18:35:07.834809 ","hostname":"6e9f02b85f58","pid":41,"tid":"8ea8","service":"api","level":"info","message":"Static Configuration"}
{"@timestamp":"2022-08-11T18:35:07.835026 ","hostname":"6e9f02b85f58","pid":41,"tid":"8ea8","service":"api","level":"info","message":"  module                  : api"}
{"@timestamp":"2022-08-11T18:35:07.835148 ","hostname":"6e9f02b85f58","pid":41,"tid":"8ea8","service":"api","level":"info","message":"  name                    : API"}
{"@timestamp":"2022-08-11T18:35:07.835243 ","hostname":"6e9f02b85f58","pid":41,"tid":"8ea8","service":"api","level":"info","message":"  description             : REST API"}
{"@timestamp":"2022-08-11T18:35:07.835391 ","hostname":"6e9f02b85f58","pid":41,"tid":"8ea8","service":"api","level":"info","message":""}
{"@timestamp":"2022-08-11T18:35:07.835493 ","hostname":"6e9f02b85f58","pid":41,"tid":"8ea8","service":"api","level":"info","message":"Dynamic Configuration"}
{"@timestamp":"2022-08-11T18:35:07.841820 ","hostname":"6e9f02b85f58","pid":41,"tid":"8ea8","service":"api","level":"info","message":"  token_ttl               : 10.minutes"}
{"@timestamp":"2022-08-11T18:35:07.842036 ","hostname":"6e9f02b85f58","pid":41,"tid":"8ea8","service":"api","level":"info","message":"  authentication_timeout  : 30.seconds"}
{"@timestamp":"2022-08-11T18:35:07.842141 ","hostname":"6e9f02b85f58","pid":41,"tid":"8ea8","service":"api","level":"info","message":"  max_results_per_page    : 1000"}
{"@timestamp":"2022-08-11T18:35:07.842268 ","hostname":"6e9f02b85f58","pid":41,"tid":"8ea8","service":"evm","level":"info","message":"MIQ(Vmdb::Initializer.init) Initializing Application: Program Name: bin/rails, PID: 41, ENV['EVMSERVER']: "}
{"@timestamp":"2022-08-11T18:35:07.843255 ","hostname":"6e9f02b85f58","pid":41,"tid":"8ea8","service":"evm","level":"err","message":"MIQ(Vmdb::Initializer.log_db_not_connectable) Cannot connect to the database!"}
** Cannot connect to the database!
Loading production environment (Rails 6.0.5.1)
irb(main):001:0>
```