### PR TITLE
Simplify DATABASE_URL generation

### DIFF
--- a/images/manageiq-base/container-assets/container_env
+++ b/images/manageiq-base/container-assets/container_env
@@ -4,19 +4,8 @@ update-ca-trust
 
 [[ -s /etc/default/evm ]] && source /etc/default/evm
 
-function urlescape() {
-  PAYLOAD="$1" ruby --disable-gems -rcgi -e "puts CGI.escape(ENV['PAYLOAD'])"
-}
-
-safeuser=$(urlescape ${DATABASE_USER})
-safepass=$(urlescape ${DATABASE_PASSWORD})
-if [ -n "$safeuser" -a -n "$safepass" ]; then
-  safeuserinfo="${safeuser}:${safepass}@"
-else
-  safeuserinfo=""
-fi
-
-database_url="postgresql://${safeuserinfo}${DATABASE_HOSTNAME:-localhost}:${DATABASE_PORT:-5432}/${DATABASE_NAME:-db_unknown}?encoding=utf8&pool=5&wait_timeout=5&sslmode=${DATABASE_SSL_MODE:-prefer}"
-[[ -f /.postgresql/root.crt ]] && database_url="$database_url&sslrootcert=/.postgresql/root.crt"
-
-export DATABASE_URL=$database_url
+DATABASE_USERINFO=""
+[[ -n "$DATABASE_USER" && -n "$DATABASE_PASSWORD" ]] && DATABASE_USERINFO="$(ruby --disable-gems -rcgi -e "puts \"#{CGI.escape(ENV['DATABASE_USER'])}:#{CGI.escape(ENV['DATABASE_PASSWORD'])}@\"")"
+DATABASE_QUERY="encoding=utf8&pool=5&wait_timeout=5&sslmode=${DATABASE_SSL_MODE:-prefer}"
+[[ -f /.postgresql/root.crt ]] && DATABASE_QUERY="${DATABASE_QUERY}&sslrootcert=/.postgresql/root.crt"
+export DATABASE_URL="postgresql://${DATABASE_USERINFO}${DATABASE_HOSTNAME:-localhost}:${DATABASE_PORT:-5432}/${DATABASE_NAME:-db_unknown}?${DATABASE_QUERY}"


### PR DESCRIPTION
<!-- 1. Describe what this PR does and why you think it is needed -->
This PR simplifies the creation of the DATABASE_URL by only shelling out to Ruby once instead of twice to build the userinfo.

Using the script from https://github.com/ManageIQ/manageiq-pods/issues/695 for timing, this eliminates one of the Ruby runs, dropping the time (for those 2 calls) from ~0.06s to 0.03s

<!--
2. If this issue fixes an existing issue, please specify in `Fixes #<id>` format
(See https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Tell the bot to mark this with an appropriate label (e.g. bug, enhancement, etc)
e.g. `@miq-bot add-label bug`
-->
