### PR TITLE
Add app label to the operator pod

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/operator.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/operator.go
@@ -17,6 +17,8 @@ func ManageOperator(cr *miqv1alpha1.ManageIQ, client client.Client) (*appsv1.Dep
 	deployment := operatorDeployment(cr, client)
 
 	f := func() error {
+		addAppLabel(cr.Spec.AppName, &deployment.ObjectMeta)
+		addAppLabel(cr.Spec.AppName, &deployment.Spec.Template.ObjectMeta)
 		addBackupLabel(cr.Spec.BackupLabelName, &deployment.ObjectMeta)
 
 		return nil


### PR DESCRIPTION
This will apply the default-deny network policy to the operator pod

Before:
$ curl http://ip_of_operator_pod:8080/abc
404 page not found

After:
$ curl http://ip_of_operator_pod:8080/abc
no response
