### PR TITLE
 Use podman if available, fall back to docker 

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -40,7 +40,7 @@ BASE_DIR=${BASE_DIR:-$PWD}
 IMAGE_DIR="$BASE_DIR/images"
 OPERATOR_DIR="$BASE_DIR/manageiq-operator"
 
-HAS_PODMAN="$(which podman &>/dev/null && echo "true")"
+CONTAINER_COMMAND="$(which podman &>/dev/null && echo "podman" || echo "docker")"
 
 set -e
 
@@ -51,22 +51,30 @@ if [ -n "$REBUILD_RPM" ]; then
   if [ -n "$RPM_BUILD_OPTIONS" ]; then
     options+=" -v $PWD/$RPM_BUILD_OPTIONS:/root/OPTIONS"
   fi
-  docker pull $RPM_BUILD_IMAGE
-  cmd="docker run -it --rm $options $RPM_BUILD_IMAGE build"
+
+  $CONTAINER_COMMAND pull $RPM_BUILD_IMAGE
+  cmd="$CONTAINER_COMMAND run -it --rm $options $RPM_BUILD_IMAGE build"
   echo "Building RPMs locally: $cmd"
   $cmd
 fi
 
 pushd $IMAGE_DIR
-  cmd="docker build --tag $REPO/manageiq-base:$TAG \
-                    --pull \
-                    --build-arg BUILD_REF=$BUILD_REF \
-                    --build-arg BUILD_ORG=$BUILD_ORG \
-                    --build-arg GIT_AUTH=$GIT_AUTH \
-                    --build-arg GIT_HOST=$GIT_HOST \
-                    --build-arg CORE_REPO_NAME=$CORE_REPO_NAME \
-                    --build-arg ARCH=$ARCH \
-                    --build-arg RPM_PREFIX=$RPM_PREFIX"
+  cmd="$CONTAINER_COMMAND build"
+
+  # --format docker is needed for podman to ensure the builds are built with docker v2 manifests
+  if [ "$CONTAINER_COMMAND" == "podman" ]; then
+    cmd+=" --format docker"
+  fi
+
+  cmd+=" --tag $REPO/manageiq-base:$TAG \
+         --pull \
+         --build-arg BUILD_REF=$BUILD_REF \
+         --build-arg BUILD_ORG=$BUILD_ORG \
+         --build-arg GIT_AUTH=$GIT_AUTH \
+         --build-arg GIT_HOST=$GIT_HOST \
+         --build-arg CORE_REPO_NAME=$CORE_REPO_NAME \
+         --build-arg ARCH=$ARCH \
+         --build-arg RPM_PREFIX=$RPM_PREFIX"
 
   if [ -n "$NO_CACHE" ]; then
     cmd+=" --no-cache"
@@ -80,26 +88,22 @@ pushd $IMAGE_DIR
     cmd+=" --build-arg RELEASE_BUILD=true"
   fi
 
-  # --format docker is needed for podman to ensure the builds are built with docker v2 manifests
-  if [ -n "$HAS_PODMAN" ]; then
-    cmd+=" --format docker"
-  fi
-
   echo "Building manageiq-base: $cmd"
   $cmd manageiq-base
 
   build_images="manageiq-base-worker manageiq-orchestrator manageiq-webserver-worker manageiq-ui-worker"
   for image in $build_images; do
-    cmd="docker build --tag $REPO/$image:$TAG \
-                      --build-arg FROM_REPO=$REPO \
-                      --build-arg FROM_TAG=$TAG \
-                      --build-arg RPM_PREFIX=$RPM_PREFIX \
-                      $image"
+    cmd="$CONTAINER_COMMAND build"
 
-    # --format docker is needed for podman to ensure the builds are built with docker v2 manifests
-    if [ -n "$HAS_PODMAN" ]; then
+    if [ "$CONTAINER_COMMAND" == "podman" ]; then
       cmd+=" --format docker"
     fi
+
+    cmd+=" --tag $REPO/$image:$TAG \
+           --build-arg FROM_REPO=$REPO \
+           --build-arg FROM_TAG=$TAG \
+           --build-arg RPM_PREFIX=$RPM_PREFIX \
+           $image"
 
     echo "Building $image: $cmd"
     $cmd
@@ -121,7 +125,12 @@ if [ -n "$PUSH" ]; then
   fi
 
   for image in $push_images; do
-    cmd="docker push $REPO/$image:$TAG"
+    cmd="$CONTAINER_COMMAND push $REPO/$image:$TAG"
+
+    if [ "$CONTAINER_COMMAND" == "podman" ]; then
+      cmd+=" --format docker"
+    fi
+
     echo "Pushing: $cmd"
     $cmd
   done

--- a/manageiq-operator/Makefile
+++ b/manageiq-operator/Makefile
@@ -122,11 +122,11 @@ docker-build: test ## Build docker image with the manager.
 	echo "$(shell date +"%Y%m%d%H%M%S")-$(shell git rev-parse HEAD)" > ./BUILD
 	cat ./BUILD
 	# --format docker is needed for podman to ensure the builds are built with docker v2 manifests
-	docker build -t ${IMG} . --pull $(shell which podman &>/dev/null && echo "--format docker")
+	$(shell which podman &>/dev/null && echo "podman" || echo "docker") build -t ${IMG} . --pull $(shell which podman &>/dev/null && echo "--format docker")
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+	$(shell which podman &>/dev/null && echo "podman" || echo "docker") push ${IMG}
 
 ##@ Deployment
 


### PR DESCRIPTION
If both podman and docker executables are installed (GHA ubuntu-latest), we were adding `--format docker` and sending it to docker which is a problem since that's not an option on Docker.
