### PR TITLE
Add Zookeeper network policy

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/network_policies.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/network_policies.go
@@ -217,6 +217,35 @@ func NetworkPolicyAllowPostgres(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme
 	return networkPolicy, f
 }
 
+func NetworkPolicyAllowZookeeper(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, c *client.Client) (*networkingv1.NetworkPolicy, controllerutil.MutateFn) {
+	networkPolicy := newNetworkPolicy(cr, "allow-zookeeper")
+
+	f := func() error {
+		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
+			return err
+		}
+		addAppLabel(cr.Spec.AppName, &networkPolicy.ObjectMeta)
+		setIngressPolicyType(networkPolicy)
+
+		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"name": "zookeeper"}
+
+		ensureIngressRule(networkPolicy)
+		setFirstIngressTCPPort(networkPolicy, 2181)
+		if len(networkPolicy.Spec.Ingress[0].From) != 1 {
+			networkPolicy.Spec.Ingress[0].From = []networkingv1.NetworkPolicyPeer{
+				networkingv1.NetworkPolicyPeer{},
+			}
+		}
+
+		networkPolicy.Spec.Ingress[0].From[0].PodSelector = &metav1.LabelSelector{}
+		networkPolicy.Spec.Ingress[0].From[0].PodSelector.MatchLabels = map[string]string{"name": "kafka"}
+
+		return nil
+	}
+
+	return networkPolicy, f
+}
+
 func newNetworkPolicy(cr *miqv1alpha1.ManageIQ, name string) *networkingv1.NetworkPolicy {
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/manageiq-operator/controllers/manageiq_controller.go
+++ b/manageiq-operator/controllers/manageiq_controller.go
@@ -514,6 +514,13 @@ func (r *ManageIQReconciler) generateNetworkPolicies(cr *miqv1alpha1.ManageIQ) e
 		logger.Info("NetworkPolicy allow postgres has been reconciled", "component", "network_policy", "result", result)
 	}
 
+	networkPolicyAllowZookeeper, mutateFunc := miqtool.NetworkPolicyAllowZookeeper(cr, r.Scheme, &r.Client)
+	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, networkPolicyAllowZookeeper, mutateFunc); err != nil {
+		return err
+	} else if result != controllerutil.OperationResultNone {
+		logger.Info("NetworkPolicy allow zookeeper has been reconciled", "component", "network_policy", "result", result)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
- this network policy is required in order to allow the kafka and zookeeper pods to communicate

```
[2022-09-28 20:38:56,491] INFO Initiating client connection, connectString=zookeeper:2181 sessionTimeout=18000 watcher=kafka.zookeeper.ZooKeeperClient$ZooKeeperClientWatcher$@1d470d0 (org.apache.zookeeper.ZooKeeper)
[2022-09-28 20:38:56,496] INFO jute.maxbuffer value is 4194304 Bytes (org.apache.zookeeper.ClientCnxnSocket)
[2022-09-28 20:38:56,502] INFO zookeeper.request.timeout value is 0. feature enabled=false (org.apache.zookeeper.ClientCnxn)
[2022-09-28 20:38:56,504] INFO [ZooKeeperClient Kafka server] Waiting until connected. (kafka.zookeeper.ZooKeeperClient)
[2022-09-28 20:38:56,514] INFO Opening socket connection to server zookeeper/172.30.71.190:2181. (org.apache.zookeeper.ClientCnxn)
[2022-09-28 20:38:56,522] INFO Socket connection established, initiating session, client: /10.254.17.128:47984, server: zookeeper/172.30.71.190:2181 (org.apache.zookeeper.ClientCnxn)
[2022-09-28 20:38:56,594] INFO Session establishment complete on server zookeeper/172.30.71.190:2181, session id = 0x1000b24dae00000, negotiated timeout = 18000 (org.apache.zookeeper.ClientCnxn)
[2022-09-28 20:38:56,599] INFO [ZooKeeperClient Kafka server] Connected. (kafka.zookeeper.ZooKeeperClient)
```

Ref:
- https://github.com/ManageIQ/manageiq/issues/22132

@miq-bot add_label enhancement
@miq-bot add_reviewer @agrare, @Fryguy 