### PR TITLE
Fix default Kafka secret

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/kafka.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/kafka.go
@@ -15,7 +15,7 @@ import (
 )
 
 func ManageKafkaSecret(cr *miqv1alpha1.ManageIQ, client client.Client, scheme *runtime.Scheme) (*corev1.Secret, controllerutil.MutateFn) {
-	secretKey := types.NamespacedName{Namespace: cr.ObjectMeta.Namespace, Name: cr.Spec.DatabaseSecret}
+	secretKey := types.NamespacedName{Namespace: cr.ObjectMeta.Namespace, Name: cr.Spec.KafkaSecret}
 	secret := &corev1.Secret{}
 	secretErr := client.Get(context.TODO(), secretKey, secret)
 	if secretErr != nil {


### PR DESCRIPTION
- incorrectly retrieving database secret key instead of kafka secret key hence default kafka secret was not being created

```
  Warning  Failed                  3h41m (x12 over 3h43m)    kubelet                  Error: secret "kafka-secrets" not found
```

Ref:
- https://github.com/ManageIQ/manageiq/issues/22132

@miq-bot add_label bug
@miq-bot add_reviewer @agrare, @Fryguy 