### PR TITLE
Enforce and default Kafka configuration

### DIFF
--- a/images/manageiq-orchestrator/container-assets/entrypoint
+++ b/images/manageiq-orchestrator/container-assets/entrypoint
@@ -117,6 +117,10 @@ EOS
 check_svc_status ${MEMCACHED_SERVICE_HOST} ${MEMCACHED_SERVICE_PORT}
 check_svc_status ${database_hostname} ${database_port}
 
+if [ -n "$MESSAGING_HOSTNAME" ] && [ -n "$MESSAGING_PORT" ]; then
+  check_svc_status ${MESSAGING_HOSTNAME} ${MESSAGING_PORT}
+fi
+
 check_deployment_status || exit 1
 
 pushd ${APP_ROOT}

--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/cr.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/cr.go
@@ -51,7 +51,7 @@ func databaseVolumeCapacity(cr *miqv1alpha1.ManageIQ) string {
 
 func deployMessagingService(cr *miqv1alpha1.ManageIQ) bool {
 	if cr.Spec.DeployMessagingService == nil {
-		return false
+		return true
 	} else {
 		return *cr.Spec.DeployMessagingService
 	}

--- a/manageiq-operator/api/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/api/v1alpha1/manageiq_types.go
@@ -64,7 +64,7 @@ type ManageIQSpec struct {
 	// +optional
 	DatabaseVolumeCapacity string `json:"databaseVolumeCapacity,omitempty"`
 
-	// Flag to indicate if Kafka and Zookeeper should be deployed (default: false)
+	// Deprecated: Flag to indicate if Kafka and Zookeeper should be deployed (default: true)
 	// +optional
 	DeployMessagingService *bool `json:"deployMessagingService,omitempty"`
 

--- a/manageiq-operator/config/crd/bases/manageiq.org_manageiqs.yaml
+++ b/manageiq-operator/config/crd/bases/manageiq.org_manageiqs.yaml
@@ -68,8 +68,8 @@ spec:
                 description: 'Database volume size (default: 15Gi)'
                 type: string
               deployMessagingService:
-                description: 'Flag to indicate if Kafka and Zookeeper should be deployed
-                  (default: false)'
+                description: 'Deprecated: Flag to indicate if Kafka and Zookeeper
+                  should be deployed (default: true)'
                 type: boolean
               enableApplicationLocalLogin:
                 description: 'Flag to allow logging into the application without SSO


### PR DESCRIPTION
- Enforce Kafka by making the orchestrator wait for Kafka service to be ready (requires Kafka network policy)
- default `deployMessagingService` to true from CR as Kafka will be the default configuration -> this will retain the option to disable Kafka in case things go wrong


Depends on:
- [x] https://github.com/ManageIQ/manageiq-pods/pull/935
- [x] https://github.com/ManageIQ/manageiq-pods/pull/936

Needed for:
- [ ] https://github.com/ManageIQ/manageiq-pods/pull/1005

Ref:
- https://github.com/ManageIQ/manageiq/issues/22225

@miq-bot add_label enhancement
@miq-bot assign @Fryguy 
@miq-bot add_reviewer @agrare 