### PR TITLE
Remove manageiq-appliance-build clone and customization hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,6 @@ Additional options are also available:
   - `-s` Run a release build, using the latest tagged rpm build, excluding nightly rpm builds
   - `-t <tag>` Tag the built images with the specified tag (default: latest)
 
-Additionally the source fork and git ref for manageiq-appliance-build can be set using the following environment variables:
-  - `BUILD_REF`
-  - `BUILD_ORG`
-
-A more complicated example would be to build and push all the images to the quay.io repository "test" using the source from the "feature" branch on the "example" fork:
-
-```bash
-BUILD_ORG=example BUILD_REF=feature ./bin/build -d . -r quay.io/test -p
-```
-
 ### Building RPMs locally
 
 If you want to build images containing your fork or different branches of ManageIQ source code, the `-b` option can be used, which will build RPMs locally before building the images. RPMs are built in `manageiq/rpm_build` container image but a different image can be used if needed.

--- a/bin/build
+++ b/bin/build
@@ -2,14 +2,7 @@
 
 TAG=latest
 
-BUILD_REF=${BUILD_REF:-master}
-BUILD_ORG=${BUILD_ORG:-ManageIQ}
-
 ARCH=`uname -m`
-CORE_REPO_NAME=${CORE_REPO_NAME:-manageiq}
-
-GIT_HOST=${GIT_HOST:-github.com}
-GIT_AUTH=${GIT_AUTH:-""}
 
 RPM_BUILD_OPTIONS=${RPM_BUILD_OPTIONS:-""}
 RPM_BUILD_IMAGE=${RPM_BUILD_IMAGE:-"manageiq/rpm_build:$TAG"}
@@ -68,11 +61,6 @@ pushd $IMAGE_DIR
 
   cmd+=" --tag $REPO/manageiq-base:$TAG \
          --pull \
-         --build-arg BUILD_REF=$BUILD_REF \
-         --build-arg BUILD_ORG=$BUILD_ORG \
-         --build-arg GIT_AUTH=$GIT_AUTH \
-         --build-arg GIT_HOST=$GIT_HOST \
-         --build-arg CORE_REPO_NAME=$CORE_REPO_NAME \
          --build-arg ARCH=$ARCH \
          --build-arg RPM_PREFIX=$RPM_PREFIX"
 

--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -1,16 +1,3 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest as appliance_build
-
-ARG BUILD_REF=master
-ARG BUILD_ORG=ManageIQ
-ARG CORE_REPO_NAME=manageiq
-ARG GIT_HOST=github.com
-ARG GIT_AUTH
-
-RUN mkdir build && \
-    if [[ -n "$GIT_AUTH" ]]; then GIT_HOST=${GIT_AUTH}@${GIT_HOST}; fi && curl -L https://${GIT_HOST}/${BUILD_ORG}/${CORE_REPO_NAME}-appliance-build/tarball/${BUILD_REF} | tar vxz -C build --strip 1
-
-################################################################################
-
 FROM registry.access.redhat.com/ubi8/ubi
 MAINTAINER ManageIQ https://manageiq.org
 
@@ -72,13 +59,6 @@ RUN dnf config-manager --setopt=tsflags=nodocs --setopt=install_weak_deps=False 
 
 # Add in the container_env file now that the APP_ROOT is created from the RPM
 ADD container-assets/container_env ${APP_ROOT}
-
-# Install python packages the same way the appliance does
-COPY --from=appliance_build build/kickstarts/partials/post/python_modules.ks.erb /tmp/python_modules
-RUN bash /tmp/python_modules && \
-    rm -f /tmp/python_modules && \
-    rm -rf /root/.cache/pip && \
-    clean_dnf_rpm
 
 # Build the RPM manifest
 RUN source /etc/default/evm && \


### PR DESCRIPTION
Updated/Rebased version of #636 

manageiq-appliance-build repo.

With this change, everything is built in manageiq-rpm_build, and no need for source customization in pods, which obsoletes CORE_REPO_NAME, GIT_AUTH and GIT_HOST.

<!-- 1. Describe what this PR does and why you think it is needed -->

<!--
2. If this issue fixes an existing issue, please specify in `Fixes #<id>` format
(See https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Tell the bot to mark this with an appropriate label (e.g. bug, enhancement, etc)
e.g. `@miq-bot add-label bug`
-->
