### PR TITLE
Revert back to UBI8 for now.

### DIFF
--- a/manageiq-operator/Dockerfile
+++ b/manageiq-operator/Dockerfile
@@ -17,7 +17,7 @@ COPY controllers/ controllers/
 # Build
 RUN CGO_ENABLED=0 go build -a -o manager main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 LABEL name="ManageIQ Operator" \
       summary="ManageIQ Operator manages the ManageIQ application on a Kubernetes cluster" \


### PR DESCRIPTION
UBI9 requires Power9 or above and Z14 or above.
I don't think we want to force users to upgrade hardware at this time.