### PR TITLE
Inspect the content of the local rpms directory to debug build issues

### DIFF
--- a/images/manageiq-base/container-assets/create_local_yum_repo.sh
+++ b/images/manageiq-base/container-assets/create_local_yum_repo.sh
@@ -4,6 +4,8 @@ yum -y install createrepo_c
 createrepo /tmp/rpms
 yum -y remove createrepo_c
 
+ls -al /tmp/rpms
+
 cat > /etc/yum.repos.d/local_rpm.repo << EOF
 [local-rpm]
 baseurl=file:///tmp/rpms/$basearch


### PR DESCRIPTION
Sometimes the build fails, but we don't know what is in the local RPM directory.