### PR TITLE
Enable postgresql 13 module

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -47,7 +47,7 @@ RUN dnf config-manager --setopt=tsflags=nodocs --setopt=install_weak_deps=False 
     dnf -y install \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
       https://rpm.manageiq.org/release/16-petrosian/el8/noarch/manageiq-release-16.0-1.el8.noarch.rpm && \
-    dnf -y module enable ruby:3.0 && \
+    dnf -y module enable postgresql:13 ruby:3.0 && \
     if [[ "$RELEASE_BUILD" != "true" ]]; then dnf config-manager --enable manageiq-16-petrosian-nightly; fi && \
     dnf config-manager --setopt=ubi-8-*.exclude=dracut*,net-snmp*,perl-*,redhat-release* --save && \
     if [[ "$LOCAL_RPM" = "true" ]]; then /create_local_yum_repo.sh; fi && \


### PR DESCRIPTION
This is used in the monolithic image when it installs postgresql-server. I thought it was better to enable it here in case we need any dependencies.

This was causing the oparin-1 container build to fail since the monolithic image is built at the same time.

Part of: https://github.com/ManageIQ/manageiq-appliance-build/pull/532