### PR TITLE
Read secrets from an ENV file if mounted

### DIFF
--- a/images/manageiq-base-worker/container-assets/entrypoint
+++ b/images/manageiq-base-worker/container-assets/entrypoint
@@ -2,12 +2,7 @@
 
 [[ -s ${APP_ROOT}/container_env ]] && source ${APP_ROOT}/container_env
 
-echo "== Writing encryption key =="
-cat > /var/www/miq/vmdb/certs/v2_key << KEY
----
-:algorithm: aes-256-cbc
-:key: ${ENCRYPTION_KEY}
-KEY
+[ ! -f /var/www/miq/vmdb/certs/v2_key ] && ln -s /var/run/secrets/manageiq/certs/v2_key /var/www/miq/vmdb/certs/
 
 echo "${GUID}" > ${APP_ROOT}/GUID
 

--- a/images/manageiq-base-worker/container-assets/entrypoint
+++ b/images/manageiq-base-worker/container-assets/entrypoint
@@ -2,10 +2,6 @@
 
 [[ -s ${APP_ROOT}/container_env ]] && source ${APP_ROOT}/container_env
 
-[ ! -f /var/www/miq/vmdb/certs/v2_key ] && ln -s /var/run/secrets/manageiq/certs/v2_key /var/www/miq/vmdb/certs/
-
-echo "${GUID}" > ${APP_ROOT}/GUID
-
 WORKER_OPTIONS=""
 [[ -n $EMS_IDS ]] && WORKER_OPTIONS="${WORKER_OPTIONS} --ems-id=${EMS_IDS} "
 [[ -n $HOSTNAME ]] && WORKER_OPTIONS="${WORKER_OPTIONS} --system-uid=$HOSTNAME "

--- a/images/manageiq-base/container-assets/container_env
+++ b/images/manageiq-base/container-assets/container_env
@@ -4,4 +4,45 @@
 
 [[ -s /etc/default/evm ]] && source /etc/default/evm
 
-[ ! -f /var/www/miq/vmdb/config/database.yml ] && ln -s /var/run/secrets/manageiq/config/database.yml /var/www/miq/vmdb/config/
+if [[ ! -f /var/www/miq/vmdb/config/database.yml ]]; then
+  [[ -f /run/secrets/postgresql/POSTGRESQL_HOSTNAME ]] && database_hostname_file=$(cat /run/secrets/postgresql/POSTGRESQL_HOSTNAME)
+  [[ -f /run/secrets/postgresql/POSTGRESQL_PASSWORD ]] && database_password_file=$(cat /run/secrets/postgresql/POSTGRESQL_PASSWORD)
+  [[ -f /run/secrets/postgresql/POSTGRESQL_PORT ]] && database_port_file=$(cat /run/secrets/postgresql/POSTGRESQL_PORT)
+  [[ -f /run/secrets/postgresql/POSTGRESQL_USER ]] && database_username_file=$(cat /run/secrets/postgresql/POSTGRESQL_USER)
+  database_hostname=${DATABASE_HOSTNAME:-$database_hostname_file}
+  database_password=${DATABASE_PASSWORD:-$database_password_file}
+  database_port=${DATABASE_PORT:-$database_port_file}
+  DATABASE_SSL_MODE=${DATABASE_SSL_MODE:-prefer}
+  database_username=${DATABASE_USERNAME:-$database_username_file}
+
+  echo "== Writing database config =="
+  cat > /var/www/miq/vmdb/config/database.yml << KEY
+---
+production:
+  adapter: postgresql
+  username: ${database_username}
+  password: ${database_password}
+  host: ${database_hostname}
+  database: vmdb_production
+  port: ${database_port}
+  encoding: utf8
+  pool: 5
+  wait_timeout: 5
+  ssl_mode: ${DATABASE_SSL_MODE}
+KEY
+
+  [[ -f /.postgresql/root.crt ]] && echo "  sslrootcert=/.postgresql/root.crt" >> /var/www/miq/vmdb/config/database.yml
+fi
+
+if [[ ! -f /var/www/miq/vmdb/certs/v2_key ]]; then
+  [[ -f /run/secrets/manageiq/application/encryption_key ]] && encryption_key_file=$(cat /run/secrets/manageiq/application/encryption_key)
+  encryption_key=${ENCRYPTION_KEY:-$encryption_key_file}
+  echo "== Writing encryption key =="
+  cat > /var/www/miq/vmdb/certs/v2_key << KEY
+---
+:algorithm: aes-256-cbc
+:key: ${encryption_key}
+KEY
+fi
+
+echo "${GUID}" > ${APP_ROOT}/GUID

--- a/images/manageiq-base/container-assets/container_env
+++ b/images/manageiq-base/container-assets/container_env
@@ -4,8 +4,4 @@
 
 [[ -s /etc/default/evm ]] && source /etc/default/evm
 
-DATABASE_USERINFO=""
-[[ -n "$DATABASE_USER" && -n "$DATABASE_PASSWORD" ]] && DATABASE_USERINFO="$(ruby --disable-gems -rcgi -e "puts \"#{CGI.escape(ENV['DATABASE_USER'])}:#{CGI.escape(ENV['DATABASE_PASSWORD'])}@\"")"
-DATABASE_QUERY="encoding=utf8&pool=5&wait_timeout=5&sslmode=${DATABASE_SSL_MODE:-prefer}"
-[[ -f /.postgresql/root.crt ]] && DATABASE_QUERY="${DATABASE_QUERY}&sslrootcert=/.postgresql/root.crt"
-export DATABASE_URL="postgresql://${DATABASE_USERINFO}${DATABASE_HOSTNAME:-localhost}:${DATABASE_PORT:-5432}/${DATABASE_NAME:-db_unknown}?${DATABASE_QUERY}"
+[ ! -f /var/www/miq/vmdb/config/database.yml ] && ln -s /var/run/secrets/manageiq/config/database.yml /var/www/miq/vmdb/config/

--- a/images/manageiq-orchestrator/container-assets/entrypoint
+++ b/images/manageiq-orchestrator/container-assets/entrypoint
@@ -115,16 +115,7 @@ EOS
 }
 
 check_svc_status ${MEMCACHED_SERVICE_HOST} ${MEMCACHED_SERVICE_PORT}
-check_svc_status ${DATABASE_HOSTNAME} ${DATABASE_PORT}
-
-echo "== Writing encryption key =="
-cat > /var/www/miq/vmdb/certs/v2_key << KEY
----
-:algorithm: aes-256-cbc
-:key: ${ENCRYPTION_KEY}
-KEY
-
-echo "${GUID}" > ${APP_ROOT}/GUID
+check_svc_status ${database_hostname} ${database_port}
 
 check_deployment_status || exit 1
 

--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/app-secret.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/app-secret.go
@@ -2,8 +2,6 @@ package miqtools
 
 import (
 	"context"
-	"fmt"
-	"net/url"
 
 	miqv1alpha1 "github.com/ManageIQ/manageiq-pods/manageiq-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -32,34 +30,6 @@ func ManageAppSecret(cr *miqv1alpha1.ManageIQ, client client.Client, scheme *run
 		addAppLabel(cr.Spec.AppName, &secret.ObjectMeta)
 		addBackupLabel(cr.Spec.BackupLabelName, &secret.ObjectMeta)
 
-		encryptionKey := string(secret.Data["encryption-key"])
-		d := map[string]string{
-			"encryption-key": encryptionKey,
-			"v2_key":         v2Key(encryptionKey),
-		}
-
-		// postgresql://root:98f43f0145d7e283@postgresql:5432/vmdb_production?encoding=utf8&pool=5&wait_timeout=5&sslmode=prefer
-		databaseUrl := "postgresql://"
-		postgresqlSecretKey := types.NamespacedName{Namespace: cr.ObjectMeta.Namespace, Name: cr.Spec.DatabaseSecret}
-		postgresqlSecret := &corev1.Secret{}
-		postgresqlSecretErr := client.Get(context.TODO(), postgresqlSecretKey, postgresqlSecret)
-		if postgresqlSecretErr == nil {
-			sslMode := "prefer"
-			if postgresqlSecret.Data["sslmode"] != nil {
-				sslMode = string(postgresqlSecret.Data["sslmode"])
-			}
-			databaseUrl += url.QueryEscape(string(postgresqlSecret.Data["username"])) + ":" + url.QueryEscape(string(postgresqlSecret.Data["password"]))
-			databaseUrl += "@" + string(postgresqlSecret.Data["hostname"]) + ":" + string(postgresqlSecret.Data["port"]) + "/" + string(postgresqlSecret.Data["dbname"])
-			databaseUrl += "?" + "encoding=utf8&pool=5&wait_timeout=5" + "&sslmode=" + sslMode
-			if postgresqlSecret.Data["rootcertificate"] != nil {
-				databaseUrl += "&" + "sslrootcert=" + "/.postgresql/root.crt"
-			}
-
-			d["database_yml"] = databaseYaml(databaseUrl)
-		}
-
-		secret.StringData = d
-
 		return nil
 	}
 
@@ -80,20 +50,4 @@ func defaultAppSecret(cr *miqv1alpha1.ManageIQ) *corev1.Secret {
 	}
 
 	return secret
-}
-
-func databaseYaml(databaseUrl string) string {
-	s := `---
-production:
-  url: %[1]s
-`
-	return fmt.Sprintf(s, databaseUrl)
-}
-
-func v2Key(encryptionKey string) string {
-	s := `---
-:algorithm: aes-256-cbc
-:key: %[1]s
-`
-	return fmt.Sprintf(s, encryptionKey)
 }

--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/app-secret.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/app-secret.go
@@ -12,8 +12,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+const appSecretName = "app-secrets"
+
 func ManageAppSecret(cr *miqv1alpha1.ManageIQ, client client.Client, scheme *runtime.Scheme) (*corev1.Secret, controllerutil.MutateFn) {
-	secretKey := types.NamespacedName{Namespace: cr.ObjectMeta.Namespace, Name: cr.Spec.DatabaseSecret}
+	secretKey := types.NamespacedName{Namespace: cr.ObjectMeta.Namespace, Name: appSecretName}
 	secret := &corev1.Secret{}
 	secretErr := client.Get(context.TODO(), secretKey, secret)
 	if secretErr != nil {
@@ -41,7 +43,7 @@ func defaultAppSecret(cr *miqv1alpha1.ManageIQ) *corev1.Secret {
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "app-secrets",
+			Name:      appSecretName,
 			Namespace: cr.ObjectMeta.Namespace,
 		},
 		StringData: secretData,

--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/orchestrator.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/orchestrator.go
@@ -330,6 +330,12 @@ func OrchestratorDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, cl
 			deployment.Spec.Template.Spec.Containers[0].Env = addOrUpdateEnvVar(deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "UI_SSL_SECRET_NAME", Value: cr.Spec.InternalCertificatesSecret})
 		}
 
+		volumeMount := corev1.VolumeMount{Name: "v2key", MountPath: "/run/secrets/manageiq/certs", ReadOnly: true}
+		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = addOrUpdateVolumeMount(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, volumeMount)
+
+		secretVolumeSource := corev1.SecretVolumeSource{SecretName: "app-secrets", Items: []corev1.KeyToPath{corev1.KeyToPath{Key: "v2_key", Path: "v2_key"}}}
+		deployment.Spec.Template.Spec.Volumes = addOrUpdateVolume(deployment.Spec.Template.Spec.Volumes, corev1.Volume{Name: "v2key", VolumeSource: corev1.VolumeSource{Secret: &secretVolumeSource}})
+
 		return nil
 	}
 


### PR DESCRIPTION
Having secrets in ENV vars may be less secure than having files on the filesystem.  Move sensitive information into files.
- [x] v2_key
- [x] database.yml
- [x] [postgres container](https://github.com/ManageIQ/container-postgresql/pull/49)

Depends on:
- [x] https://github.com/ManageIQ/manageiq-pods/pull/932
- [x] https://github.com/ManageIQ/container-postgresql/pull/49