### PR TITLE
Allow Kafka communications

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/kafka.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/kafka.go
@@ -253,6 +253,10 @@ func KafkaDeployment(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*appsv1.
 				Name:  "ALLOW_PLAINTEXT_LISTENER",
 				Value: "yes",
 			},
+			corev1.EnvVar{
+				Name:  "KAFKA_CFG_ADVERTISED_LISTENERS",
+				Value: "PLAINTEXT://kafka:9092",
+			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			corev1.VolumeMount{Name: "kafka-data", MountPath: "/bitnami/kafka"},

--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/network_policies.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/network_policies.go
@@ -217,6 +217,44 @@ func NetworkPolicyAllowPostgres(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme
 	return networkPolicy, f
 }
 
+func NetworkPolicyAllowKafka(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, c *client.Client) (*networkingv1.NetworkPolicy, controllerutil.MutateFn) {
+	networkPolicy := newNetworkPolicy(cr, "allow-kafka")
+
+	f := func() error {
+		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
+			return err
+		}
+		addAppLabel(cr.Spec.AppName, &networkPolicy.ObjectMeta)
+		setIngressPolicyType(networkPolicy)
+
+		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"name": "kafka"}
+
+		pod := orchestratorPod(*c)
+		if pod == nil {
+			return nil
+		}
+
+		ensureIngressRule(networkPolicy)
+		setFirstIngressTCPPort(networkPolicy, 9092)
+		if len(networkPolicy.Spec.Ingress[0].From) != 2 {
+			networkPolicy.Spec.Ingress[0].From = []networkingv1.NetworkPolicyPeer{
+				networkingv1.NetworkPolicyPeer{},
+				networkingv1.NetworkPolicyPeer{},
+			}
+		}
+		orchestratedByLabelKey := cr.Spec.AppName + "-orchestrated-by"
+		orchestratedByLabelValue := pod.Name
+		networkPolicy.Spec.Ingress[0].From[0].PodSelector = &metav1.LabelSelector{}
+		networkPolicy.Spec.Ingress[0].From[0].PodSelector.MatchLabels = map[string]string{"name": "orchestrator"}
+		networkPolicy.Spec.Ingress[0].From[1].PodSelector = &metav1.LabelSelector{}
+		networkPolicy.Spec.Ingress[0].From[1].PodSelector.MatchLabels = map[string]string{orchestratedByLabelKey: orchestratedByLabelValue}
+
+		return nil
+	}
+
+	return networkPolicy, f
+}
+
 func NetworkPolicyAllowZookeeper(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, c *client.Client) (*networkingv1.NetworkPolicy, controllerutil.MutateFn) {
 	networkPolicy := newNetworkPolicy(cr, "allow-zookeeper")
 

--- a/manageiq-operator/controllers/manageiq_controller.go
+++ b/manageiq-operator/controllers/manageiq_controller.go
@@ -514,6 +514,13 @@ func (r *ManageIQReconciler) generateNetworkPolicies(cr *miqv1alpha1.ManageIQ) e
 		logger.Info("NetworkPolicy allow postgres has been reconciled", "component", "network_policy", "result", result)
 	}
 
+	networkPolicyAllowKafka, mutateFunc := miqtool.NetworkPolicyAllowKafka(cr, r.Scheme, &r.Client)
+	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, networkPolicyAllowKafka, mutateFunc); err != nil {
+		return err
+	} else if result != controllerutil.OperationResultNone {
+		logger.Info("NetworkPolicy allow kafka has been reconciled", "component", "network_policy", "result", result)
+	}
+
 	networkPolicyAllowZookeeper, mutateFunc := miqtool.NetworkPolicyAllowZookeeper(cr, r.Scheme, &r.Client)
 	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, networkPolicyAllowZookeeper, mutateFunc); err != nil {
 		return err


### PR DESCRIPTION
- added network policy to allow ingress to Kafka pod from orchestrator and worker pods
- set advertised listener in config, this will allow pods to communicate with the Kafka broker

Needed for:
- https://github.com/ManageIQ/manageiq-pods/pull/896

Ref:
- https://github.com/ManageIQ/manageiq/issues/22225

@miq-bot add_label enhancement
@miq-bot add_reviewer @Fryguy 
@miq-bot assign @bdunne 