### PR TITLE
Upsize default Kafka volume capacity

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/cr.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/cr.go
@@ -164,7 +164,7 @@ func kafkaImageTag(cr *miqv1alpha1.ManageIQ) string {
 
 func kafkaVolumeCapacity(cr *miqv1alpha1.ManageIQ) string {
 	if cr.Spec.KafkaVolumeCapacity == "" {
-		return "1Gi"
+		return "2Gi"
 	} else {
 		return cr.Spec.KafkaVolumeCapacity
 	}


### PR DESCRIPTION
Currently we allocate 1GB by default for our Kafka volume however, also by default Kafka creates 50 partitions for consumer offsets which are around 20MB each... which means that we don't have much disk space leftover for additional topics. 

For example on a fresh deployment of Kafka:
```
nasarkhan@Nasars-MacBook-Pro manageiq-operator %  oc exec kafka-584b6d69f6-x9bj2    -- df -ah
Filesystem                                                                                                                                               Size  Used Avail Use% Mounted on
172.30.143.197:6789,172.30.118.45:6789,172.30.81.85:6789:/volumes/csi/csi-vol-828e3e63-a8af-11ed-89ce-0a580afe1005/8a1f0cf2-2e69-47a8-bf8a-033b36665407  1.0G 1000M   24M  98% /bitnami/kafka
```
```
1000670000@kafka-584b6d69f6-x9bj2:/$ du -hs /bitnami/kafka/data/*
21M	/bitnami/kafka/data/__consumer_offsets-0
21M	/bitnami/kafka/data/__consumer_offsets-1
.
.
.
21M	/bitnami/kafka/data/__consumer_offsets-49
```

Error when >1 topic:
```
[2023-02-08 21:21:41,196] INFO [Broker id=1001] Stopped fetchers as part of LeaderAndIsr request correlationId 9 from controller 1001 epoch 1 as part of the become-leader transition for 1 partitions (state.change.logger)
[2023-02-08 21:21:41,215] ERROR [Broker id=1001] Error while processing LeaderAndIsr request correlationId 9 received from controller 1001 epoch 1 for partition lololol-0 (state.change.logger)
java.io.IOException: Disk quota exceeded
	at java.base/java.io.RandomAccessFile.setLength(Native Method)
	at kafka.log.AbstractIndex.<init>(AbstractIndex.scala:117)
	at kafka.log.OffsetIndex.<init>(OffsetIndex.scala:54)
	at kafka.log.LazyIndex$.$anonfun$forOffset$1(LazyIndex.scala:106)
	at kafka.log.LazyIndex.$anonfun$get$1(LazyIndex.scala:63)
	at kafka.log.LazyIndex.get(LazyIndex.scala:60)
	at kafka.log.LogSegment.offsetIndex(LogSegment.scala:64)
	at kafka.log.LogSegment.readNextOffset(LogSegment.scala:453)
	at kafka.log.LogLoader.$anonfun$recoverLog$6(LogLoader.scala:474)
	at scala.runtime.java8.JFunction0$mcJ$sp.apply(JFunction0$mcJ$sp.java:23)
	at scala.Option.getOrElse(Option.scala:189)
```

Upsizing to 2GB will give enough space for additional topics and their partitions to be created:
```
nasarkhan@Nasars-MacBook-Pro manageiq-operator % oc exec kafka-584b6d69f6-5vrd4  -- df -ah   
Filesystem                                                                                                                                               Size  Used Avail Use% Mounted on
172.30.143.197:6789,172.30.118.45:6789,172.30.81.85:6789:/volumes/csi/csi-vol-d5c3e7e3-a8b7-11ed-89ce-0a580afe1005/f3f92761-3a67-4920-8a75-f48b35ba39d9  2.0G 1020M  1.1G  50% /bitnami/kafka
```

Related:
- https://github.com/ManageIQ/manageiq-pods/pull/896
- https://github.com/ManageIQ/manageiq-pods/pull/935

Ref:
- https://github.com/ManageIQ/manageiq/issues/22225

@miq-bot add_label bug
@miq-bot assign @bdunne 
@miq-bot add_reviewer @Fryguy 