### PR TITLE
[WIP] Kafka/Zookeeper SSL

### DIFF
--- a/manageiq-operator/controllers/manageiq_controller.go
+++ b/manageiq-operator/controllers/manageiq_controller.go
@@ -403,7 +403,7 @@ func (r *ManageIQReconciler) generateKafkaResources(cr *miqv1alpha1.ManageIQ) er
 		logger.Info("Service has been reconciled", "component", "zookeeper", "result", result)
 	}
 
-	kafkaDeployment, mutateFunc, err := miqtool.KafkaDeployment(cr, r.Scheme)
+	kafkaDeployment, mutateFunc, err := miqtool.KafkaDeployment(cr, r.Client, r.Scheme)
 	if err != nil {
 		return err
 	}
@@ -414,7 +414,7 @@ func (r *ManageIQReconciler) generateKafkaResources(cr *miqv1alpha1.ManageIQ) er
 		logger.Info("Deployment has been reconciled", "component", "kafka", "result", result)
 	}
 
-	zookeeperDeployment, mutateFunc, err := miqtool.ZookeeperDeployment(cr, r.Scheme)
+	zookeeperDeployment, mutateFunc, err := miqtool.ZookeeperDeployment(cr, r.Client, r.Scheme)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Opening a WIP PR to collaborate and get some more eyes on this for troubleshooting purposes. 

Notes:
- At the moment I am focusing on getting SSL working with only the Kafka client and will focus on Zookeeper afterwards
- I've left commented code to show the various configurations that I have attempted using
- `addKafkaStores` and `addZookeeperStores` will be integrated to `addInternalCertificate` method 
- I generated the truststore and keystores using the root CA generated by the `cert-generator` script

Resources/docs used:
- https://github.com/bitnami/containers/blob/main/bitnami/kafka/README.md#security
- https://github.com/bitnami/containers/tree/main/bitnami/zookeeper#configuration
- https://github.com/confluentinc/confluent-platform-security-tools/blob/master/single-trust-store-diagram.pdf

@miq-bot assign @bdunne 
@miq-bot add_reviewers @agrare