### PR TITLE
Fix go 1.20 build issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,4 +33,5 @@ jobs:
       run: |
         make test
         make build
+        make docker-build
       working-directory: "./manageiq-operator"

--- a/manageiq-operator/Dockerfile
+++ b/manageiq-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/library/golang:1.18 as builder
+FROM docker.io/library/golang:1.20 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
Followup to #914 

Error:
```
[1/2] STEP 9/9: RUN CGO_ENABLED=0 go build -a -o manager main.go # k8s.io/kube-openapi/pkg/cached
/go/pkg/mod/k8s.io/kube-openapi@v0.0.0-20230308215209-15aac26d736a/pkg/cached/cache.go:242:16: undefined: atomic.Pointer # go.uber.org/multierr
/go/pkg/mod/go.uber.org/multierr@v1.10.0/error.go:224:20: undefined: atomic.Bool note: module requires Go 1.19
Error: error building at STEP "RUN CGO_ENABLED=0 go build -a -o manager main.go": error while running runtime: exit status 2 make: *** [Makefile:142: docker-build] Error 2
```