### PR TITLE
Kafka SSL with KRaft

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/util.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/util.go
@@ -116,6 +116,19 @@ func addInternalCertificate(cr *miqv1alpha1.ManageIQ, d *appsv1.Deployment, clie
 	}
 }
 
+func addKafkaStores(cr *miqv1alpha1.ManageIQ, d *appsv1.Deployment, client client.Client, mountPoint string) {
+	secret := InternalCertificatesSecret(cr, client)
+	if secret.Data["kafka_truststore"] != nil && secret.Data["kafka_keystore"] != nil && secret.Data["kafka_keystore_pass"] != nil {
+		volumeName := "kafka-certificate"
+
+		volumeMount := corev1.VolumeMount{Name: volumeName, MountPath: mountPoint, ReadOnly: true}
+		d.Spec.Template.Spec.Containers[0].VolumeMounts = addOrUpdateVolumeMount(d.Spec.Template.Spec.Containers[0].VolumeMounts, volumeMount)
+
+		secretVolumeSource := corev1.SecretVolumeSource{SecretName: secret.Name, Items: []corev1.KeyToPath{corev1.KeyToPath{Key: "kafka_truststore", Path: "kafka.truststore.jks"}, corev1.KeyToPath{Key: "kafka_keystore", Path: "kafka.keystore.jks"}}}
+		d.Spec.Template.Spec.Volumes = addOrUpdateVolume(d.Spec.Template.Spec.Volumes, corev1.Volume{Name: volumeName, VolumeSource: corev1.VolumeSource{Secret: &secretVolumeSource}})
+	}
+}
+
 func addOrUpdateEnvVar(environment []corev1.EnvVar, variable corev1.EnvVar) []corev1.EnvVar {
 	index := -1
 	for i, env := range environment {

--- a/manageiq-operator/controllers/manageiq_controller.go
+++ b/manageiq-operator/controllers/manageiq_controller.go
@@ -403,7 +403,7 @@ func (r *ManageIQReconciler) generateKafkaResources(cr *miqv1alpha1.ManageIQ) er
 		logger.Info("Service has been reconciled", "component", "zookeeper", "result", result)
 	}
 
-	kafkaDeployment, mutateFunc, err := miqtool.KafkaDeployment(cr, r.Scheme)
+	kafkaDeployment, mutateFunc, err := miqtool.KafkaDeployment(cr, r.Client, r.Scheme)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- SASL_SSL support for Kafka, running using KRaft
- Listeners will default to PLAINTEXT if SSL is not enabled

Depends on:
- [x] https://github.com/ManageIQ/manageiq-messaging/pull/77
- [x] https://github.com/ManageIQ/manageiq/pull/22437
- [ ] https://github.com/ManageIQ/manageiq-documentation/pull/1728
- [ ] https://github.com/ManageIQ/manageiq-pods/pull/952
- [ ] https://github.com/ManageIQ/manageiq-pods/pull/955

Ref:
- https://github.com/ManageIQ/manageiq-pods/issues/789

See https://github.com/bitnami/containers/blob/main/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh for justification of env vars
