### PR TITLE
Remove Zookeeper from operator

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/cr.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/cr.go
@@ -313,38 +313,6 @@ func serverGuid(cr *miqv1alpha1.ManageIQ, c *client.Client) string {
 	}
 }
 
-func zookeeperImage(cr *miqv1alpha1.ManageIQ) string {
-	if cr.Spec.ZookeeperImage == "" {
-		return zookeeperImageName(cr) + ":" + zookeeperImageTag(cr)
-	} else {
-		return cr.Spec.ZookeeperImage
-	}
-}
-
-func zookeeperImageName(cr *miqv1alpha1.ManageIQ) string {
-	if cr.Spec.ZookeeperImageName == "" {
-		return "docker.io/bitnami/zookeeper"
-	} else {
-		return cr.Spec.ZookeeperImageName
-	}
-}
-
-func zookeeperImageTag(cr *miqv1alpha1.ManageIQ) string {
-	if cr.Spec.ZookeeperImageTag == "" {
-		return "latest"
-	} else {
-		return cr.Spec.ZookeeperImageTag
-	}
-}
-
-func zookeeperVolumeCapacity(cr *miqv1alpha1.ManageIQ) string {
-	if cr.Spec.ZookeeperVolumeCapacity == "" {
-		return "1Gi"
-	} else {
-		return cr.Spec.ZookeeperVolumeCapacity
-	}
-}
-
 func ManageCR(cr *miqv1alpha1.ManageIQ, c *client.Client) (*miqv1alpha1.ManageIQ, controllerutil.MutateFn) {
 	f := func() error {
 		varDeployMessagingService := deployMessagingService(cr)
@@ -376,8 +344,6 @@ func ManageCR(cr *miqv1alpha1.ManageIQ, c *client.Client) (*miqv1alpha1.ManageIQ
 		cr.Spec.PostgresqlMaxConnections = postgresqlMaxConnections(cr)
 		cr.Spec.PostgresqlSharedBuffers = postgresqlSharedBuffers(cr)
 		cr.Spec.ServerGuid = serverGuid(cr, c)
-		cr.Spec.ZookeeperImage = zookeeperImage(cr)
-		cr.Spec.ZookeeperVolumeCapacity = zookeeperVolumeCapacity(cr)
 
 		addBackupLabel(backupLabelName(cr), &cr.ObjectMeta)
 

--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/network_policies.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/network_policies.go
@@ -255,35 +255,6 @@ func NetworkPolicyAllowKafka(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, c
 	return networkPolicy, f
 }
 
-func NetworkPolicyAllowZookeeper(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, c *client.Client) (*networkingv1.NetworkPolicy, controllerutil.MutateFn) {
-	networkPolicy := newNetworkPolicy(cr, "allow-zookeeper")
-
-	f := func() error {
-		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
-			return err
-		}
-		addAppLabel(cr.Spec.AppName, &networkPolicy.ObjectMeta)
-		setIngressPolicyType(networkPolicy)
-
-		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"name": "zookeeper"}
-
-		ensureIngressRule(networkPolicy)
-		setFirstIngressTCPPort(networkPolicy, 2181)
-		if len(networkPolicy.Spec.Ingress[0].From) != 1 {
-			networkPolicy.Spec.Ingress[0].From = []networkingv1.NetworkPolicyPeer{
-				networkingv1.NetworkPolicyPeer{},
-			}
-		}
-
-		networkPolicy.Spec.Ingress[0].From[0].PodSelector = &metav1.LabelSelector{}
-		networkPolicy.Spec.Ingress[0].From[0].PodSelector.MatchLabels = map[string]string{"name": "kafka"}
-
-		return nil
-	}
-
-	return networkPolicy, f
-}
-
 func newNetworkPolicy(cr *miqv1alpha1.ManageIQ, name string) *networkingv1.NetworkPolicy {
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/manageiq-operator/api/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/api/v1alpha1/manageiq_types.go
@@ -335,36 +335,36 @@ type ManageIQSpec struct {
 	// +optional
 	WebserverWorkerImage string `json:"webserverWorkerImage,omitempty"`
 
-	// Zookeeper deployment CPU limit (default: no limit)
+	// Deprecated: Zookeeper deployment CPU limit (default: no limit)
 	// +optional
 	ZookeeperCpuLimit string `json:"zookeeperCpulimit,omitempty"`
 
-	// Zookeeper deployment CPU request (default: no request)
+	// Deprecated: Zookeeper deployment CPU request (default: no request)
 	// +optional
 	ZookeeperCpuRequest string `json:"zookeeperCpuRequest,omitempty"`
 
-	// Image string used for the zookeeper deployment
+	// Deprecated: Image string used for the zookeeper deployment
 	// (default: <ZookeeperImageName>:<ZookeeperImageTag>)
 	// +optional
 	ZookeeperImage string `json:"zookeeperImage,omitempty"`
 
-	// Image used for the zookeeper deployment (default: docker.io/bitnami/zookeeper)
+	// Deprecated: Image used for the zookeeper deployment (default: docker.io/bitnami/zookeeper)
 	// +optional
 	ZookeeperImageName string `json:"zookeeperImageName,omitempty"`
 
-	// Image tag used for the zookeeper deployment (default: latest)
+	// Deprecated: Image tag used for the zookeeper deployment (default: latest)
 	// +optional
 	ZookeeperImageTag string `json:"zookeeperImageTag,omitempty"`
 
-	// Zookeeper deployment memory limit (default: no limit)
+	// Deprecated: Zookeeper deployment memory limit (default: no limit)
 	// +optional
 	ZookeeperMemoryLimit string `json:"zookeeperMemoryLimit,omitempty"`
 
-	// Zookeeper deployment memory request (default: no limit)
+	// Deprecated: Zookeeper deployment memory request (default: no limit)
 	// +optional
 	ZookeeperMemoryRequest string `json:"zookeeperMemoryRequest,omitempty"`
 
-	// Zookeeper volume size (default: 1Gi)
+	// Deprecated: Zookeeper volume size (default: 1Gi)
 	// +optional
 	ZookeeperVolumeCapacity string `json:"zookeeperVolumeCapacity,omitempty"`
 }

--- a/manageiq-operator/config/crd/bases/manageiq.org_manageiqs.yaml
+++ b/manageiq-operator/config/crd/bases/manageiq.org_manageiqs.yaml
@@ -298,30 +298,35 @@ spec:
                   By default this is determined by the orchestrator pod
                 type: string
               zookeeperCpuRequest:
-                description: 'Zookeeper deployment CPU request (default: no request)'
+                description: 'Deprecated: Zookeeper deployment CPU request (default:
+                  no request)'
                 type: string
               zookeeperCpulimit:
-                description: 'Zookeeper deployment CPU limit (default: no limit)'
+                description: 'Deprecated: Zookeeper deployment CPU limit (default:
+                  no limit)'
                 type: string
               zookeeperImage:
-                description: 'Image string used for the zookeeper deployment (default:
-                  <ZookeeperImageName>:<ZookeeperImageTag>)'
+                description: 'Deprecated: Image string used for the zookeeper deployment
+                  (default: <ZookeeperImageName>:<ZookeeperImageTag>)'
                 type: string
               zookeeperImageName:
-                description: 'Image used for the zookeeper deployment (default: docker.io/bitnami/zookeeper)'
+                description: 'Deprecated: Image used for the zookeeper deployment
+                  (default: docker.io/bitnami/zookeeper)'
                 type: string
               zookeeperImageTag:
-                description: 'Image tag used for the zookeeper deployment (default:
-                  latest)'
+                description: 'Deprecated: Image tag used for the zookeeper deployment
+                  (default: latest)'
                 type: string
               zookeeperMemoryLimit:
-                description: 'Zookeeper deployment memory limit (default: no limit)'
+                description: 'Deprecated: Zookeeper deployment memory limit (default:
+                  no limit)'
                 type: string
               zookeeperMemoryRequest:
-                description: 'Zookeeper deployment memory request (default: no limit)'
+                description: 'Deprecated: Zookeeper deployment memory request (default:
+                  no limit)'
                 type: string
               zookeeperVolumeCapacity:
-                description: 'Zookeeper volume size (default: 1Gi)'
+                description: 'Deprecated: Zookeeper volume size (default: 1Gi)'
                 type: string
             required:
             - applicationDomain

--- a/manageiq-operator/controllers/manageiq_controller.go
+++ b/manageiq-operator/controllers/manageiq_controller.go
@@ -371,7 +371,7 @@ func (r *ManageIQReconciler) generateKafkaResources(cr *miqv1alpha1.ManageIQ) er
 
 	hostName := getSecretKeyValue(r.Client, cr.Namespace, cr.Spec.KafkaSecret, "hostname")
 	if hostName != "" {
-		logger.Info("External Kafka Messaging Service selected, skipping kafka and zookeeper service reconciliation", "hostname", hostName)
+		logger.Info("External Kafka Messaging Service selected, skipping kafka service reconciliation", "hostname", hostName)
 		return nil
 	}
 
@@ -382,25 +382,11 @@ func (r *ManageIQReconciler) generateKafkaResources(cr *miqv1alpha1.ManageIQ) er
 		logger.Info("PVC has been reconciled", "component", "kafka", "result", result)
 	}
 
-	zookeeperPVC, mutateFunc := miqtool.ZookeeperPVC(cr, r.Scheme)
-	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, zookeeperPVC, mutateFunc); err != nil {
-		return err
-	} else if result != controllerutil.OperationResultNone {
-		logger.Info("PVC has been reconciled", "component", "zookeeper", "result", result)
-	}
-
 	kafkaService, mutateFunc := miqtool.KafkaService(cr, r.Scheme)
 	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, kafkaService, mutateFunc); err != nil {
 		return err
 	} else if result != controllerutil.OperationResultNone {
 		logger.Info("Service has been reconciled", "component", "kafka", "result", result)
-	}
-
-	zookeeperService, mutateFunc := miqtool.ZookeeperService(cr, r.Scheme)
-	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, zookeeperService, mutateFunc); err != nil {
-		return err
-	} else if result != controllerutil.OperationResultNone {
-		logger.Info("Service has been reconciled", "component", "zookeeper", "result", result)
 	}
 
 	kafkaDeployment, mutateFunc, err := miqtool.KafkaDeployment(cr, r.Scheme)
@@ -412,17 +398,6 @@ func (r *ManageIQReconciler) generateKafkaResources(cr *miqv1alpha1.ManageIQ) er
 		return err
 	} else if result != controllerutil.OperationResultNone {
 		logger.Info("Deployment has been reconciled", "component", "kafka", "result", result)
-	}
-
-	zookeeperDeployment, mutateFunc, err := miqtool.ZookeeperDeployment(cr, r.Scheme)
-	if err != nil {
-		return err
-	}
-
-	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, zookeeperDeployment, mutateFunc); err != nil {
-		return err
-	} else if result != controllerutil.OperationResultNone {
-		logger.Info("Deployment has been reconciled", "component", "zookeeper", "result", result)
 	}
 
 	return nil
@@ -519,13 +494,6 @@ func (r *ManageIQReconciler) generateNetworkPolicies(cr *miqv1alpha1.ManageIQ) e
 		return err
 	} else if result != controllerutil.OperationResultNone {
 		logger.Info("NetworkPolicy allow kafka has been reconciled", "component", "network_policy", "result", result)
-	}
-
-	networkPolicyAllowZookeeper, mutateFunc := miqtool.NetworkPolicyAllowZookeeper(cr, r.Scheme, &r.Client)
-	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, networkPolicyAllowZookeeper, mutateFunc); err != nil {
-		return err
-	} else if result != controllerutil.OperationResultNone {
-		logger.Info("NetworkPolicy allow zookeeper has been reconciled", "component", "network_policy", "result", result)
 	}
 
 	return nil


### PR DESCRIPTION
With the introduction of KRaft, Zookeeper is no longer needed and can be removed

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-pods/pull/951

Ref:
- [ ] https://github.com/ManageIQ/manageiq-pods/issues/789

@miq-bot assign @bdunne 
@miq-bot add_reviewer @Fryguy
@miq-bot add_label enhancement