### PR TITLE
Install httpd after replacing the release RPM

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -34,9 +34,6 @@ COPY container-assets/create_local_yum_repo.sh /
 COPY container-assets/clean_dnf_rpm /usr/local/bin/
 
 RUN dnf config-manager --setopt=tsflags=nodocs --setopt=install_weak_deps=False --save && \
-    dnf -y --disableplugin=subscription-manager install \
-      httpd \
-      mod_ssl && \
     if [ ${ARCH} != "s390x" ] ; then \
       dnf -y --setopt=protected_packages= remove redhat-release && \
       dnf -y remove *subscription-manager* && \
@@ -47,6 +44,8 @@ RUN dnf config-manager --setopt=tsflags=nodocs --setopt=install_weak_deps=False 
       dnf config-manager --setopt=appstream*.exclude=*httpd*,mod_ssl --save \
     ; fi && \
     dnf -y install \
+      httpd \
+      mod_ssl \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
       https://rpm.manageiq.org/release/17-quinteros/el8/noarch/manageiq-release-17.0-1.el8.noarch.rpm && \
     dnf -y update && \


### PR DESCRIPTION
httpd will still come from the UBI appstream repo due to the exclusion set above.

When the release RPM is swapped, the RPM scripts from that and shadow-utils reset the contents of /etc/passwd causing the apache user to be removed and httpd fails to start due to the missing user.

Based on changes in https://github.com/ManageIQ/manageiq-pods/pull/956
Building with this change I see the package versions that we want:
```
[root@3f6ee3351684 /]# rpm -qa |grep httpd
httpd-2.4.37-51.module+el8.7.0+18499+2e106f0b.5.x86_64
redhat-logos-httpd-84.5-1.el8.noarch
httpd-tools-2.4.37-51.module+el8.7.0+18499+2e106f0b.5.x86_64
httpd-filesystem-2.4.37-51.module+el8.7.0+18499+2e106f0b.5.noarch

[root@3f6ee3351684 /]# rpm -qa |grep samba
samba-common-4.17.5-0.el8.noarch
samba-common-libs-4.17.5-0.el8.x86_64
samba-client-libs-4.17.5-0.el8.x86_64

[root@3f6ee3351684 /]# cat /etc/passwd|grep apache
apache:x:48:48:Apache:/usr/share/httpd:/sbin/nologin
```