### PR TITLE
Add a new hotfix image build script

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -4,13 +4,10 @@ TAG=latest
 
 ARCH=`uname -m`
 
-RPM_BUILD_OPTIONS=${RPM_BUILD_OPTIONS:-""}
-RPM_BUILD_IMAGE=${RPM_BUILD_IMAGE:-"manageiq/rpm_build:$TAG"}
-RPM_PREFIX=${RPM_PREFIX:-"manageiq"}
-
-while getopts "t:d:r:hblnops" opt; do
+while getopts "t:c:d:r:hblnops" opt; do
   case $opt in
     b) REBUILD_RPM="true" ;;
+    c) CONTAINER_PREFIX=$OPTARG ;;
     d) BASE_DIR=$OPTARG ;;
     l) LOCAL_RPM="true" ;;
     n) NO_CACHE="true" ;;
@@ -19,7 +16,7 @@ while getopts "t:d:r:hblnops" opt; do
     r) REPO=$OPTARG ;;
     s) RELEASE_BUILD="true" ;;
     t) TAG=$OPTARG ;;
-    h) echo "Usage: $0 [-hblnops] [-d BASE_DIR] [-r IMAGE_REPOSITORY] [-t IMAGE_TAG]"; exit 1
+    h) echo "Usage: $0 [-hblnops] [-c CONTAINER_PREFIX] [-d BASE_DIR] [-r IMAGE_REPOSITORY] [-t IMAGE_TAG]"; exit 1
   esac
 done
 
@@ -28,10 +25,11 @@ if [ -n "$LOCAL_RPM" ] && [ -n "$REBUILD_RPM" ]; then
   exit 1
 fi
 
-REPO=${REPO:-docker.io/manageiq}
 BASE_DIR=${BASE_DIR:-$PWD}
+CONTAINER_PREFIX=${CONTAINER_PREFIX:-manageiq}
 IMAGE_DIR="$BASE_DIR/images"
 OPERATOR_DIR="$BASE_DIR/manageiq-operator"
+REPO=${REPO:-docker.io/manageiq}
 
 CONTAINER_COMMAND="$(which podman &>/dev/null && echo "podman" || echo "docker")"
 

--- a/bin/build_hotfix
+++ b/bin/build_hotfix
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+TAG=latest
+
+ARCH=`uname -m`
+
+while getopts "t:c:d:r:hblnops" opt; do
+  case $opt in
+    b) REBUILD_RPM="true" ;;
+    c) CONTAINER_PREFIX=$OPTARG ;;
+    d) BASE_DIR=$OPTARG ;;
+    l) LOCAL_RPM="true" ;;
+    n) NO_CACHE="true" ;;
+    o) NO_OPERATOR="true" ;;
+    p) PUSH="true" ;;
+    r) REPO=$OPTARG ;;
+    s) RELEASE_BUILD="true" ;;
+    t) TAG=$OPTARG ;;
+    h) echo "Usage: $0 [-hblnops] [-c CONTAINER_PREFIX] [-d BASE_DIR] [-r IMAGE_REPOSITORY] [-t IMAGE_TAG]"; exit 1
+  esac
+done
+
+BASE_DIR=${BASE_DIR:-$PWD}
+CONTAINER_PREFIX=${CONTAINER_PREFIX:-manageiq}
+IMAGE_DIR="$BASE_DIR/images"
+OPERATOR_DIR="$BASE_DIR/manageiq-operator"
+REPO=${REPO:-docker.io/manageiq}
+
+CONTAINER_COMMAND="$(which podman &>/dev/null && echo "podman" || echo "docker")"
+
+set -e
+
+pushd $IMAGE_DIR
+  cmd="$CONTAINER_COMMAND build"
+
+  hotfix_images="manageiq-base manageiq-base-worker manageiq-orchestrator manageiq-webserver-worker manageiq-ui-worker"
+  for image in $hotfix_images; do
+    cmd="$CONTAINER_COMMAND build"
+
+    if [ "$CONTAINER_COMMAND" == "podman" ]; then
+      cmd+=" --format docker"
+    fi
+
+    cmd+=" --tag $REPO/$image:$TAG \
+           --build-arg CONTAINER_PREFIX=$CONTAINER_PREFIX \
+           --build-arg FROM_REPO=$REPO \
+           --build-arg FROM_TAG=$TAG \
+           --pull \
+           manageiq-hotfix"
+
+    echo "Building hotfix for $image: $cmd"
+    $cmd
+  done
+popd
+
+if [ -n "$PUSH" ]; then
+  push_images="manageiq-base manageiq-base-worker manageiq-orchestrator manageiq-webserver-worker manageiq-ui-worker"
+
+  for image in $push_images; do
+    cmd="$CONTAINER_COMMAND push $REPO/$image:$TAG"
+
+    if [ "$CONTAINER_COMMAND" == "podman" ]; then
+      cmd+=" --format docker"
+    fi
+
+    echo "Pushing: $cmd"
+    $cmd
+  done
+fi

--- a/images/manageiq-hotfix/Dockerfile
+++ b/images/manageiq-hotfix/Dockerfile
@@ -1,0 +1,15 @@
+ARG CONTAINER_PREFIX=manageiq
+ARG FROM_REPO=manageiq
+ARG FROM_TAG=latest
+
+FROM ${FROM_REPO}/${CONTAINER_PREFIX}-base:${FROM_TAG}
+
+COPY rpms/* /tmp/rpms/
+
+RUN /create_local_yum_repo.sh && \
+    dnf -y --repo=local-rpm update && \
+    chgrp -R 0 $APP_ROOT && \
+    chmod -R g=u $APP_ROOT && \
+    source /etc/default/evm && \
+    /usr/bin/generate_rpm_manifest.sh && \
+    clean_dnf_rpm


### PR DESCRIPTION
- Build on top of existing images by copying over local RPMs and updating only those RPMs (as we would do in a hotfix situation between releases)
- Allow for productized source image names