### PR TITLE
Fix failure if repodata already exists

### DIFF
--- a/images/manageiq-base/container-assets/create_local_yum_repo.sh
+++ b/images/manageiq-base/container-assets/create_local_yum_repo.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 yum -y install createrepo_c
+rm -rf /tmp/rpms/repodata
 createrepo /tmp/rpms
 yum -y remove createrepo_c
 


### PR DESCRIPTION
Example:
```
  Directory walk started
  Directory walk done - 22 packages
  Temporary output repo path: /tmp/rpms/.repodata/
  Preparing sqlite DBs
  Pool started (with 5 workers)
  Pool finished
  Critical: Cannot rename /tmp/rpms/.repodata/ -> /tmp/rpms/repodata/: Directory not empty
```