### PR TITLE
Fix bug where createrepo can't be installed because local repo is broken

### DIFF
--- a/images/manageiq-hotfix/Dockerfile
+++ b/images/manageiq-hotfix/Dockerfile
@@ -4,7 +4,8 @@ FROM ${FROM_IMAGE}
 
 COPY rpms/* /tmp/rpms/
 
-RUN rm -rf /tmp/rpms/repodata && \
+RUN dnf -y install createrepo_c && \
+    rm -rf /tmp/rpms/repodata && \
     /create_local_yum_repo.sh && \
     dnf -y --repo=local-rpm update && \
     chgrp -R 0 $APP_ROOT && \


### PR DESCRIPTION
```
Errors during downloading metadata for repository 'local-rpm':
  - Curl error (37): Couldn't read a file:// file for file:///tmp/rpms/repodata/repomd.xml [Couldn't open file /tmp/rpms/repodata/repomd.xml] Error: Failed to download metadata for repo 'local-rpm': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried /create_local_yum_repo.sh: line 4: createrepo: command not found
```