### PR TITLE
Log to stderr by turning off the log file collector

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/postgresql_conf.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/postgresql_conf.go
@@ -38,8 +38,10 @@ hot_standby = on
 # ERROR REPORTING AND LOGGING
 #------------------------------------------------------------------------------
 
-log_filename = 'postgresql.log'
-log_rotation_age = 0
+log_destination = 'stderr'
+# This is used when logging to stderr:
+logging_collector = off
+
 log_min_duration_statement = 5000
 log_connections = on
 log_disconnections = on


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/container-postgresql/issues/40

Drop the no longer used options for logging to a file.

Related: https://github.com/CrunchyData/postgres-operator/issues/1141#issuecomment-629235277

Technically, it's an enhancement, but you can't look at pg logs in podified without visiting the pg pod so users would probably say this is a bug.

EDIT:  We saw some possibly no longer used/wrong settings so I opened an issue to start that discussion: https://github.com/ManageIQ/manageiq-pods/issues/969