### PR TITLE
Mark deprecated spec properties.

### DIFF
--- a/manageiq-operator/api/v1alpha1/manageiq_types.go
+++ b/manageiq-operator/api/v1alpha1/manageiq_types.go
@@ -104,12 +104,12 @@ type ManageIQSpec struct {
 	// +optional
 	HttpdImage string `json:"httpdImage,omitempty"`
 
-	// Image namespace used for the httpd deployment (default: manageiq)
+	// Deprecated: Image namespace used for the httpd deployment (default: manageiq)
 	// Note: the exact image will be determined by the authentication method selected
 	// +optional
 	HttpdImageNamespace string `json:"httpdImageNamespace,omitempty"`
 
-	// Image tag used for the httpd deployment (default: latest)
+	// Deprecated: Image tag used for the httpd deployment (default: latest)
 	// +optional
 	HttpdImageTag string `json:"httpdImageTag,omitempty"`
 
@@ -147,11 +147,11 @@ type ManageIQSpec struct {
 	// +optional
 	KafkaImage string `json:"kafkaImage,omitempty"`
 
-	// Image used for the kafka deployment (default: docker.io/bitnami/kafka)
+	// Deprecated: Image used for the kafka deployment (default: docker.io/bitnami/kafka)
 	// +optional
 	KafkaImageName string `json:"kafkaImageName,omitempty"`
 
-	// Image tag used for the kafka deployment (default: latest)
+	// Deprecated: Image tag used for the kafka deployment (default: latest)
 	// +optional
 	KafkaImageTag string `json:"kafkaImageTag,omitempty"`
 
@@ -184,11 +184,11 @@ type ManageIQSpec struct {
 	// +optional
 	MemcachedImage string `json:"memcachedImage,omitempty"`
 
-	// Image used for the memcached deployment (default: manageiq/memcached)
+	// Deprecated: Image used for the memcached deployment (default: manageiq/memcached)
 	// +optional
 	MemcachedImageName string `json:"memcachedImageName,omitempty"`
 
-	// Image tag used for the memcached deployment (default: 1.6)
+	// Deprecated: Image tag used for the memcached deployment (default: 1.6)
 	// +optional
 	MemcachedImageTag string `json:"memcachedImageTag,omitempty"`
 
@@ -252,15 +252,15 @@ type ManageIQSpec struct {
 	// +optional
 	OrchestratorImage string `json:"orchestratorImage,omitempty"`
 
-	// Image name used for the orchestrator deployment (default: manageiq-orchestrator)
+	// Deprecated: Image name used for the orchestrator deployment (default: manageiq-orchestrator)
 	// +optional
 	OrchestratorImageName string `json:"orchestratorImageName,omitempty"`
 
-	// Image namespace used for the orchestrator and worker deployments (default: manageiq)
+	// Deprecated: Image namespace used for the orchestrator and worker deployments (default: manageiq)
 	// +optional
 	OrchestratorImageNamespace string `json:"orchestratorImageNamespace,omitempty"`
 
-	// Image tag used for the orchestrator and worker deployments (default: latest)
+	// Deprecated: Image tag used for the orchestrator and worker deployments (default: latest)
 	// +optional
 	OrchestratorImageTag string `json:"orchestratorImageTag,omitempty"`
 
@@ -289,11 +289,11 @@ type ManageIQSpec struct {
 	// +optional
 	PostgresqlImage string `json:"postgresqlImage,omitempty"`
 
-	// Image used for the postgresql deployment (Default: docker.io/manageiq/postgresql)
+	// Deprecated: Image used for the postgresql deployment (Default: docker.io/manageiq/postgresql)
 	// +optional
 	PostgresqlImageName string `json:"postgresqlImageName,omitempty"`
 
-	// Image tag used for the postgresql deployment (Default: 13)
+	// Deprecated: Image tag used for the postgresql deployment (Default: 13)
 	// +optional
 	PostgresqlImageTag string `json:"postgresqlImageTag,omitempty"`
 
@@ -348,11 +348,11 @@ type ManageIQSpec struct {
 	// +optional
 	ZookeeperImage string `json:"zookeeperImage,omitempty"`
 
-	// Image used for the zookeeper deployment (default: docker.io/bitnami/zookeeper)
+	// Deprecated: Image used for the zookeeper deployment (default: docker.io/bitnami/zookeeper)
 	// +optional
 	ZookeeperImageName string `json:"zookeeperImageName,omitempty"`
 
-	// Image tag used for the zookeeper deployment (default: latest)
+	// Deprecated: Image tag used for the zookeeper deployment (default: latest)
 	// +optional
 	ZookeeperImageTag string `json:"zookeeperImageTag,omitempty"`
 

--- a/manageiq-operator/config/crd/bases/manageiq.org_manageiqs.yaml
+++ b/manageiq-operator/config/crd/bases/manageiq.org_manageiqs.yaml
@@ -105,12 +105,13 @@ spec:
                   <HttpdImageNamespace>/httpd[-init]:<HttpdImageTag>)'
                 type: string
               httpdImageNamespace:
-                description: 'Image namespace used for the httpd deployment (default:
-                  manageiq) Note: the exact image will be determined by the authentication
-                  method selected'
+                description: 'Deprecated: Image namespace used for the httpd deployment
+                  (default: manageiq) Note: the exact image will be determined by
+                  the authentication method selected'
                 type: string
               httpdImageTag:
-                description: 'Image tag used for the httpd deployment (default: latest)'
+                description: 'Deprecated: Image tag used for the httpd deployment
+                  (default: latest)'
                 type: string
               httpdMemoryLimit:
                 description: 'Httpd deployment memory limit (default: no limit)'
@@ -141,10 +142,12 @@ spec:
                   <KafkaImageName>:<KafkaImageTag>)'
                 type: string
               kafkaImageName:
-                description: 'Image used for the kafka deployment (default: docker.io/bitnami/kafka)'
+                description: 'Deprecated: Image used for the kafka deployment (default:
+                  docker.io/bitnami/kafka)'
                 type: string
               kafkaImageTag:
-                description: 'Image tag used for the kafka deployment (default: latest)'
+                description: 'Deprecated: Image tag used for the kafka deployment
+                  (default: latest)'
                 type: string
               kafkaMemoryLimit:
                 description: 'Kafka deployment memory limit (default: no limit)'
@@ -170,11 +173,12 @@ spec:
                   <MemcachedImageName>:<MemcachedImageTag>)'
                 type: string
               memcachedImageName:
-                description: 'Image used for the memcached deployment (default: manageiq/memcached)'
+                description: 'Deprecated: Image used for the memcached deployment
+                  (default: manageiq/memcached)'
                 type: string
               memcachedImageTag:
-                description: 'Image tag used for the memcached deployment (default:
-                  1.6)'
+                description: 'Deprecated: Image tag used for the memcached deployment
+                  (default: 1.6)'
                 type: string
               memcachedMaxConnection:
                 description: 'Memcached max simultaneous connections (default: 1024)'
@@ -227,16 +231,16 @@ spec:
                   <OrchestratorImageNamespace>/<OrchestratorImageName>:<OrchestratorImageTag>)'
                 type: string
               orchestratorImageName:
-                description: 'Image name used for the orchestrator deployment (default:
-                  manageiq-orchestrator)'
+                description: 'Deprecated: Image name used for the orchestrator deployment
+                  (default: manageiq-orchestrator)'
                 type: string
               orchestratorImageNamespace:
-                description: 'Image namespace used for the orchestrator and worker
-                  deployments (default: manageiq)'
+                description: 'Deprecated: Image namespace used for the orchestrator
+                  and worker deployments (default: manageiq)'
                 type: string
               orchestratorImageTag:
-                description: 'Image tag used for the orchestrator and worker deployments
-                  (default: latest)'
+                description: 'Deprecated: Image tag used for the orchestrator and
+                  worker deployments (default: latest)'
                 type: string
               orchestratorInitialDelay:
                 description: 'Number of seconds to wait before starting the orchestrator
@@ -260,11 +264,12 @@ spec:
                   <PostgresqlImageName>:<PostgresqlImageTag>)'
                 type: string
               postgresqlImageName:
-                description: 'Image used for the postgresql deployment (Default: docker.io/manageiq/postgresql)'
+                description: 'Deprecated: Image used for the postgresql deployment
+                  (Default: docker.io/manageiq/postgresql)'
                 type: string
               postgresqlImageTag:
-                description: 'Image tag used for the postgresql deployment (Default:
-                  13)'
+                description: 'Deprecated: Image tag used for the postgresql deployment
+                  (Default: 13)'
                 type: string
               postgresqlMaxConnections:
                 description: 'PostgreSQL maximum connection setting (default: 1000)'
@@ -308,11 +313,12 @@ spec:
                   <ZookeeperImageName>:<ZookeeperImageTag>)'
                 type: string
               zookeeperImageName:
-                description: 'Image used for the zookeeper deployment (default: docker.io/bitnami/zookeeper)'
+                description: 'Deprecated: Image used for the zookeeper deployment
+                  (default: docker.io/bitnami/zookeeper)'
                 type: string
               zookeeperImageTag:
-                description: 'Image tag used for the zookeeper deployment (default:
-                  latest)'
+                description: 'Deprecated: Image tag used for the zookeeper deployment
+                  (default: latest)'
                 type: string
               zookeeperMemoryLimit:
                 description: 'Zookeeper deployment memory limit (default: no limit)'


### PR DESCRIPTION
All of these should use XImage rather than the combination of: xImage
xImageName (sometimes)
xImageNamespace
xImageTag
