### PR TITLE
Lock down to UBI 8.8-1032

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi:8.8-1032
 MAINTAINER ManageIQ https://manageiq.org
 
 ARG ARCH=x86_64


### PR DESCRIPTION
/etc/yum.repos.d/ubi.repo is missing from
registry.redhat.io/ubi8:8.8-1032.1692772289(latest) for PPC64le

latest minimal, micro and s2i-core are fine

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=2233877

Related: https://github.com/ManageIQ/manageiq-rpm_build/pull/416