### PR TITLE
Deploy Kafka network policies only when needed

### DIFF
--- a/manageiq-operator/internal/controller/manageiq_controller.go
+++ b/manageiq-operator/internal/controller/manageiq_controller.go
@@ -677,18 +677,20 @@ func (r *ManageIQReconciler) generateNetworkPolicies(cr *miqv1alpha1.ManageIQ) e
 		logger.Info("NetworkPolicy allow postgres has been reconciled", "component", "network_policy", "result", result)
 	}
 
-	networkPolicyAllowKafka, mutateFunc := miqtool.NetworkPolicyAllowKafka(cr, r.Scheme, &r.Client)
-	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, networkPolicyAllowKafka, mutateFunc); err != nil {
-		return err
-	} else if result != controllerutil.OperationResultNone {
-		logger.Info("NetworkPolicy allow kafka has been reconciled", "component", "network_policy", "result", result)
-	}
+	if *cr.Spec.DeployMessagingService == true {
+		networkPolicyAllowKafka, mutateFunc := miqtool.NetworkPolicyAllowKafka(cr, r.Scheme, &r.Client)
+		if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, networkPolicyAllowKafka, mutateFunc); err != nil {
+			return err
+		} else if result != controllerutil.OperationResultNone {
+			logger.Info("NetworkPolicy allow kafka has been reconciled", "component", "network_policy", "result", result)
+		}
 
-	networkPolicyAllowZookeeper, mutateFunc := miqtool.NetworkPolicyAllowZookeeper(cr, r.Scheme, &r.Client)
-	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, networkPolicyAllowZookeeper, mutateFunc); err != nil {
-		return err
-	} else if result != controllerutil.OperationResultNone {
-		logger.Info("NetworkPolicy allow zookeeper has been reconciled", "component", "network_policy", "result", result)
+		networkPolicyAllowZookeeper, mutateFunc := miqtool.NetworkPolicyAllowZookeeper(cr, r.Scheme, &r.Client)
+		if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, networkPolicyAllowZookeeper, mutateFunc); err != nil {
+			return err
+		} else if result != controllerutil.OperationResultNone {
+			logger.Info("NetworkPolicy allow zookeeper has been reconciled", "component", "network_policy", "result", result)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
- Kafka and zookeeper network policies should only be deployed when `deployMessagingService: true`

@miq-bot add_label bug
@miq-bot assign @bdunne 