### PR TITLE
Revert "Lock down to UBI 8.8-1032"

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.8-1032
+FROM registry.access.redhat.com/ubi8/ubi
 MAINTAINER ManageIQ https://manageiq.org
 
 ARG ARCH=x86_64


### PR DESCRIPTION
This reverts commit d8a667c4d638b5eccfc5d199f140be80485350c2.

A new UBI8 image has been released. The yum repos are available on ppc64le now.
Related:
- https://github.com/ManageIQ/container-httpd/pull/84
- https://github.com/ManageIQ/container-memcached/pull/22
- https://github.com/ManageIQ/manageiq-rpm_build/pull/419
