### PR TITLE
Fix route permissions issues after #989

### DIFF
--- a/manageiq-operator/config/rbac/role.yaml
+++ b/manageiq-operator/config/rbac/role.yaml
@@ -132,7 +132,8 @@ rules:
 - apiGroups:
   - route.openshift.io
   resources:
-  - route
+  - routes
+  - routes/custom-host
   verbs:
   - create
   - delete

--- a/manageiq-operator/internal/controller/manageiq_controller.go
+++ b/manageiq-operator/internal/controller/manageiq_controller.go
@@ -57,7 +57,7 @@ type ManageIQReconciler struct {
 //+kubebuilder:rbac:namespace=changeme,groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create
 //+kubebuilder:rbac:namespace=changeme,groups=networking.k8s.io,resources=ingresses;networkpolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:namespace=changeme,groups=rbac.authorization.k8s.io,resources=rolebindings;roles,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:namespace=changeme,groups=route.openshift.io,resources=route,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:namespace=changeme,groups=route.openshift.io,resources=routes;routes/custom-host,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
routes:
E0928 15:56:00.508746       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.28.0-rc.0/tools/cache/reflector.go:229: Failed to watch *v1.Route: failed to list *v1.Route: routes.route.openshift.io is forbidden: User "system:serviceaccount:petrosian-1:manageiq-operator" cannot list resource "routes" in API group "route.openshift.io" in the namespace "petrosian-1"
W0928 15:56:44.778213       1 reflector.go:535] pkg/mod/k8s.io/client-go@v0.28.0-rc.0/tools/cache/reflector.go:229: failed to list *v1.Route: routes.route.openshift.io is forbidden: User "system:serviceaccount:petrosian-1:manageiq-operator" cannot list resource "routes" in API group "route.openshift.io" in the namespace "petrosian-1"

routes/custom-host:
2023-09-28T16:30:38Z	ERROR	Reconciler error	{"controller": "manageiq", "controllerGroup": "manageiq.org", "controllerKind": "ManageIQ", "ManageIQ": {"name":"manageiq-sample","namespace":"petrosian-1"}, "namespace": "petrosian-1", "name": "manageiq-sample", "reconcileID": "78aec8d7-f66d-4d63-8203-60f031384f19", "error": "Route.route.openshift.io \"httpd\" is invalid: spec.host: Forbidden: you do not have permission to set the host field of the route"}

<!-- 1. Describe what this PR does and why you think it is needed -->

<!--
2. If this issue fixes an existing issue, please specify in `Fixes #<id>` format
(See https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Tell the bot to mark this with an appropriate label (e.g. bug, enhancement, etc)
e.g. `@miq-bot add-label bug`
-->
