### PR TITLE
Give the operator permission to give permission to pod/logs get

### DIFF
--- a/manageiq-operator/config/rbac/role.yaml
+++ b/manageiq-operator/config/rbac/role.yaml
@@ -25,6 +25,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods/logs
+  verbs:
+  - get
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/manageiq-operator/internal/controller/manageiq_controller.go
+++ b/manageiq-operator/internal/controller/manageiq_controller.go
@@ -47,6 +47,7 @@ type ManageIQReconciler struct {
 }
 
 //+kubebuilder:rbac:namespace=changeme,groups="",resources=configmaps;events;persistentvolumeclaims;pods;pods/finalizers;secrets;serviceaccounts;services;services/finalizers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:namespace=changeme,groups="",resources=pods/logs,verbs=get
 //+kubebuilder:rbac:namespace=changeme,groups=apps,resources=deployments;deployments/scale;replicasets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:namespace=changeme,groups=apps,resources=deployments/finalizers,resourceNames=manageiq-operator,verbs=update
 //+kubebuilder:rbac:namespace=changeme,groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update;delete


### PR DESCRIPTION
Followup to #999 

Fixes:
```
2023-10-10T16:16:02Z	ERROR	Reconciler error	{"controller": "manageiq", "controllerGroup": "manageiq.org", "controllerKind": "ManageIQ", "ManageIQ": {"name":"manageiq-sample","namespace":"miq"}, "namespace": "miq", "name": "manageiq-sample", "reconcileID": "8c9e0471-2231-4d18-ac75-7ef1530ccaed", "error": "roles.rbac.authorization.k8s.io \"manageiq-automation\" is forbidden: user \"system:serviceaccount:miq:manageiq-operator\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:miq\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"\"], Resources:[\"pods/logs\"], Verbs:[\"get\"]}"} sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.2/pkg/internal/controller/controller.go:329
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.2/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.2/pkg/internal/controller/controller.go:227
```
