### PR TITLE
Add or update unique volume mount

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/util.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/util.go
@@ -140,7 +140,7 @@ func addOrUpdateVolumeMount(volumeMounts []corev1.VolumeMount, volumeMount corev
 
 	index := -1
 	for i, v := range volumeMounts {
-		if v.Name == volumeMount.Name {
+		if v.Name == volumeMount.Name || v.MountPath == volumeMount.MountPath {
 			index = i
 		}
 	}


### PR DESCRIPTION
In kubernetes it is not possible to mount multiple volumes with the same mount path i.e. mount volume paths must be unique. Therefore added the edge case where if another volume is to be added that has the same mount path as an existing volume, the old volume is replaced

Needed for:
- https://github.com/ManageIQ/manageiq-pods/pull/1005

@miq-bot add_label enhancement
@miq-bot assign @bdunne 
