### PR TITLE
Move messaging configuration to file and deprecate deployMessagingService flag

### DIFF
--- a/images/manageiq-base/container-assets/container_env
+++ b/images/manageiq-base/container-assets/container_env
@@ -46,4 +46,35 @@ cat > ${APP_ROOT}/certs/v2_key << KEY
 :key: ${encryption_key}
 KEY
 
+
+[[ -f /run/secrets/messaging/MESSAGING_HOSTNAME ]] && messaging_hostname_file=$(cat /run/secrets/messaging/MESSAGING_HOSTNAME)
+[[ -f /run/secrets/messaging/MESSAGING_USERNAME ]] && messaging_username_file=$(cat /run/secrets/messaging/MESSAGING_USERNAME)
+[[ -f /run/secrets/messaging/MESSAGING_PASSWORD ]] && messaging_password_file=$(cat /run/secrets/messaging/MESSAGING_PASSWORD)
+[[ -f /run/secrets/messaging/MESSAGING_PORT ]] && messaging_port_file=$(cat /run/secrets/messaging/MESSAGING_PORT)
+[[ -f /run/secrets/messaging/MESSAGING_SASL_MECHANISM ]] && messaging_sasl_mechanism_file=$(cat /run/secrets/messaging/MESSAGING_SASL_MECHANISM)
+[[ -f /etc/pki/ca-trust/source/anchors/root.crt ]] && messaging_ca_path=/etc/pki/ca-trust/source/anchors/root.crt
+messaging_hostname=${MESSAGING_HOSTNAME:-$messaging_hostname_file}
+messaging_hostname=${messaging_hostname:-localhost}
+messaging_username=${MESSAGING_USERNAME:-$messaging_username_file}
+messaging_password=${MESSAGING_PASSWORD:-$messaging_password_file}
+messaging_port=${MESSAGING_PORT:-$messaging_port_file}
+messaging_port=${messaging_port:-9093}
+messaging_sasl_mechanism=${MESSAGING_SASL_MECHANISM:-$messaging_sasl_mechanism_file}
+messaging_ca_path=${messaging_ca_path:-/etc/pki/ca-trust/source/anchors/ca.crt}
+
+echo "== Writing messaging config =="
+cat > ${APP_ROOT}/config/messaging.yml << KEY
+---
+production:
+  host: ${messaging_hostname}
+  port: ${messaging_port}
+  protocol: Kafka
+  encoding: json
+  username: ${messaging_username}
+  password: ${messaging_password}
+  sasl_mechanism: ${messaging_sasl_mechanism}
+  ssl: true
+  ca_file: ${messaging_ca_path}
+KEY
+
 echo "${GUID}" > ${APP_ROOT}/GUID

--- a/images/manageiq-orchestrator/container-assets/entrypoint
+++ b/images/manageiq-orchestrator/container-assets/entrypoint
@@ -116,10 +116,7 @@ EOS
 
 check_svc_status ${MEMCACHED_SERVICE_HOST} ${MEMCACHED_SERVICE_PORT}
 check_svc_status ${database_hostname} ${database_port}
-
-if [ -n "$MESSAGING_HOSTNAME" ] && [ -n "$MESSAGING_PORT" ]; then
-  check_svc_status ${MESSAGING_HOSTNAME} ${MESSAGING_PORT}
-fi
+check_svc_status ${messaging_hostname} ${messaging_port}
 
 check_deployment_status || exit 1
 

--- a/manageiq-operator/internal/controller/manageiq_controller.go
+++ b/manageiq-operator/internal/controller/manageiq_controller.go
@@ -134,11 +134,9 @@ func (r *ManageIQReconciler) Reconcile(ctx context.Context, request ctrl.Request
 	if e := r.generateMemcachedResources(miqInstance); e != nil {
 		return reconcile.Result{}, e
 	}
-	if *miqInstance.Spec.DeployMessagingService {
-		logger.Info("Reconciling the Kafka resources...")
-		if e := r.generateKafkaResources(miqInstance); e != nil {
-			return reconcile.Result{}, e
-		}
+	logger.Info("Reconciling the Kafka resources...")
+	if e := r.generateKafkaResources(miqInstance); e != nil {
+		return reconcile.Result{}, e
 	}
 	logger.Info("Reconciling the Orchestrator resources...")
 	if e := r.generateOrchestratorResources(miqInstance); e != nil {
@@ -526,6 +524,19 @@ func (r *ManageIQReconciler) generatePostgresqlResources(cr *miqv1alpha1.ManageI
 }
 
 func (r *ManageIQReconciler) generateKafkaResources(cr *miqv1alpha1.ManageIQ) error {
+	secret, mutateFunc := miqkafka.MessagingEnvSecret(cr, r.Client, r.Scheme)
+	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, secret, mutateFunc); err != nil {
+		return err
+	} else if result != controllerutil.OperationResultNone {
+		logger.Info("Secret has been reconciled", "component", "kafka", "result", result)
+	}
+
+	hostName := string(secret.Data["hostname"])
+	if hostName != "manageiq-kafka-bootstrap" {
+		logger.Info("External Kafka selected, skipping Kafka service reconciliation", "hostname", hostName)
+		return nil
+	}
+
 	if miqutilsv1alpha1.FindCatalogSourceByName(r.Client, "openshift-marketplace", "community-operators") != nil {
 		kafkaOperatorGroup, mutateFunc := miqkafka.KafkaOperatorGroup(cr, r.Scheme)
 		if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, kafkaOperatorGroup, mutateFunc); err != nil {
@@ -580,13 +591,6 @@ func (r *ManageIQReconciler) generateKafkaResources(cr *miqv1alpha1.ManageIQ) er
 		} else if result != controllerutil.OperationResultNone {
 			logger.Info(fmt.Sprintf("Kafka topic %s has been reconciled", topics[i]))
 		}
-	}
-
-	secret, mutateFunc := miqkafka.MessagingEnvSecret(cr, r.Client, r.Scheme)
-	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, secret, mutateFunc); err != nil {
-		return err
-	} else if result != controllerutil.OperationResultNone {
-		logger.Info("Secret has been reconciled", "component", "kafka", "result", result)
 	}
 
 	return nil
@@ -678,7 +682,7 @@ func (r *ManageIQReconciler) generateNetworkPolicies(cr *miqv1alpha1.ManageIQ) e
 		logger.Info("NetworkPolicy allow postgres has been reconciled", "component", "network_policy", "result", result)
 	}
 
-	if *cr.Spec.DeployMessagingService == true {
+	if cr.Spec.AppName == "manageiq" {
 		networkPolicyAllowKafka, mutateFunc := miqtool.NetworkPolicyAllowKafka(cr, r.Scheme, &r.Client)
 		if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, networkPolicyAllowKafka, mutateFunc); err != nil {
 			return err

--- a/manageiq-operator/internal/controller/manageiq_controller.go
+++ b/manageiq-operator/internal/controller/manageiq_controller.go
@@ -582,6 +582,13 @@ func (r *ManageIQReconciler) generateKafkaResources(cr *miqv1alpha1.ManageIQ) er
 		}
 	}
 
+	secret, mutateFunc := miqkafka.MessagingEnvSecret(cr, r.Client, r.Scheme)
+	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, secret, mutateFunc); err != nil {
+		return err
+	} else if result != controllerutil.OperationResultNone {
+		logger.Info("Secret has been reconciled", "component", "kafka", "result", result)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
- move messaging config from env vars to file
- the configs will be stored in secrets and mounted as a projected volume since the kafka user password is located in another secret created by strimzi
- kafka user secret naming convention normalized to match downstream `cr.Spec.AppName-user` -> `cr.Spec.AppName-kafka-admin` so that upstream and downstream can both use `func MessagingEnvSecret`
- moving the config to secrets allows us to check the hostname to see whether kafka resources should be deployed or not in the case of an external kafka. This allows us to fully deprecate `cr.Spec.DeployMessagingService`

Depends on:
- [ ] https://github.com/ManageIQ/manageiq/pull/22859

@miq-bot assign @bdunne
@miq-bot add_reviewer @Fryguy 