### PR TITLE
Only return passwords that include letters.

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/generators.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/generators.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
+	"regexp"
 )
 
 func randomBytes(n int) []byte {
@@ -20,6 +21,13 @@ func generateEncryptionKey() string {
 }
 
 func generatePassword() string {
-	buf := randomBytes(8)
-	return hex.EncodeToString(buf)
+	for {
+		buf := randomBytes(8)
+		password := hex.EncodeToString(buf)
+		if match, err := regexp.MatchString(`\D+`, password); err == nil && match {
+			// Only return if a letter is included.
+			// Password decryption can fail if the database password is all numbers because ruby will read it as an integer instead of a string.
+			return password
+		}
+	}
 }


### PR DESCRIPTION
Password decryption can fail if the database password is all numbers because ruby will read it as an integer instead of a string.

```
== Checking deployment status ==
rake aborted!
NoMethodError: undefined method `empty?' for 8783875645714351:Integer 
.../gems/manageiq-password-1.2.0/lib/manageiq/password.rb:165:in `remove_erb' 
.../gems/manageiq-password-1.2.0/lib/manageiq/password.rb:90:in `try_decrypt' 
/var/www/miq/vmdb/lib/vmdb/settings_walker.rb:76:in `block in decrypt_passwords!'
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
