### PR TITLE
Drop MAINTAINER docker commands

### DIFF
--- a/images/manageiq-base-worker/Dockerfile
+++ b/images/manageiq-base-worker/Dockerfile
@@ -10,7 +10,6 @@ RUN /vddk/extract-vmware-vddk
 ################################################################################
 
 FROM ${FROM_REPO}/manageiq-base:${FROM_TAG}
-MAINTAINER ManageIQ https://manageiq.org
 
 LABEL name="manageiq-base-worker" \
       summary="ManageIQ Worker Image"

--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -16,11 +16,10 @@ ENV TERM=xterm \
     CONTAINER=true \
     APP_ROOT=/var/www/miq/vmdb
 
-MAINTAINER ManageIQ https://manageiq.org
 LABEL name="manageiq-base" \
+      summary="ManageIQ base application image" \
       vendor="ManageIQ" \
       url="https://manageiq.org/" \
-      summary="ManageIQ base application image" \
       description="ManageIQ is a management and automation platform for virtual, private, and hybrid cloud infrastructures." \
       io.k8s.display-name="ManageIQ" \
       io.k8s.description="ManageIQ is a management and automation platform for virtual, private, and hybrid cloud infrastructures." \

--- a/images/manageiq-orchestrator/Dockerfile
+++ b/images/manageiq-orchestrator/Dockerfile
@@ -2,7 +2,6 @@ ARG FROM_REPO=docker.io/manageiq
 ARG FROM_TAG=latest
 
 FROM ${FROM_REPO}/manageiq-base:${FROM_TAG}
-MAINTAINER ManageIQ https://manageiq.org
 
 LABEL name="manageiq-orchestrator" \
       summary="ManageIQ Orchestrator Image"

--- a/images/manageiq-ui-worker/Dockerfile
+++ b/images/manageiq-ui-worker/Dockerfile
@@ -2,7 +2,6 @@ ARG FROM_REPO=docker.io/manageiq
 ARG FROM_TAG=latest
 
 FROM ${FROM_REPO}/manageiq-webserver-worker:${FROM_TAG}
-MAINTAINER ManageIQ https://manageiq.org
 
 LABEL name="manageiq-ui-worker" \
       summary="ManageIQ user interface worker image"

--- a/images/manageiq-webserver-worker/Dockerfile
+++ b/images/manageiq-webserver-worker/Dockerfile
@@ -9,7 +9,6 @@ FROM ${FROM_REPO}/manageiq-rpms:${FROM_TAG} as rpms
 FROM ${FROM_REPO}/manageiq-base-worker:${FROM_TAG}
 ARG RPM_PREFIX=manageiq
 
-MAINTAINER ManageIQ https://manageiq.org
 LABEL name="manageiq-webserver-worker" \
       summary="ManageIQ web server worker image"
 


### PR DESCRIPTION
MAINTAINER is a deprecated command, and LABELs are preferred. We already have vendor and url labels with this same information.

@bdunne Please review.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
