### PR TITLE
update content-security-policy to match apache

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
@@ -432,7 +432,7 @@ LimitRequestFieldSize 524288
   ProxyPreserveHost on
   <Location /assets/>
     Header unset ETag
-    Header set Content-Security-Policy            "default-src 'self'; child-src 'self'; connect-src 'self'; font-src 'self' fonts.gstatic.com; script-src 'self'; style-src 'self'; report-uri /dashboard/csp_report"
+    Header set Content-Security-Policy            "default-src 'self'; child-src 'self'; connect-src 'self' fonts.gstatic.com; font-src 'self' fonts.gstatic.com fonts.googleapis.com; img-src 'self' data:; object-src 'self'; script-src 'unsafe-eval' 'unsafe-inline' 'self'; style-src 'unsafe-inline' 'self' fonts.googleapis.com fonts.gstatic.com; report-uri /dashboard/csp_report"
     Header set X-Content-Type-Options             "nosniff"
     Header set X-Frame-Options                    "SAMEORIGIN"
     Header set X-Permitted-Cross-Domain-Policies  "none"
@@ -444,7 +444,7 @@ LimitRequestFieldSize 524288
   </Location>
   <Location /packs/>
     Header unset ETag
-    Header set Content-Security-Policy            "default-src 'self'; child-src 'self'; connect-src 'self'; font-src 'self' fonts.gstatic.com; script-src 'self'; style-src 'self'; report-uri /dashboard/csp_report"
+    Header set Content-Security-Policy            "default-src 'self'; child-src 'self'; connect-src 'self' fonts.gstatic.com; font-src 'self' fonts.gstatic.com fonts.googleapis.com; img-src 'self' data:; object-src 'self'; script-src 'unsafe-eval' 'unsafe-inline' 'self'; style-src 'unsafe-inline' 'self' fonts.googleapis.com fonts.gstatic.com; report-uri /dashboard/csp_report"
     Header set X-Content-Type-Options             "nosniff"
     Header set X-Frame-Options                    "SAMEORIGIN"
     Header set X-Permitted-Cross-Domain-Policies  "none"


### PR DESCRIPTION
see https://github.com/ManageIQ/manageiq-appliance/pull/383

This matches apache headers for rails, appliance, and pod