### PR TITLE
Switch from UBI openssl-libs to Stream openssl-libs

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -55,6 +55,8 @@ RUN --mount=type=bind,from=rpms,source=/tmp/rpms,target=/tmp/rpms \
       https://rpm.manageiq.org/release/19-spassky/el9/noarch/manageiq-release-19.0-1.el9.noarch.rpm && \
     if [[ "$RELEASE_BUILD" != "true" ]]; then dnf config-manager --enable manageiq-19-spassky-nightly; fi && \
     if [[ -n "$(ls /tmp/rpms)" ]]; then /usr/local/bin/prepare_local_yum_repo.sh; fi && \
+    dnf -y --disablerepo=ubi-9-baseos-rpms swap openssl-fips-provider openssl-libs && \
+    dnf -y update && \
     dnf -y module enable ruby:3.1 && \
     dnf -y install \
       httpd \


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq-rpm_build/pull/457

Disclaimer: I haven't tested this, but I'd be surprised if everything worked properly without it after merging https://github.com/ManageIQ/manageiq-rpm_build/pull/457