### PR TITLE
Revert "Merge pull request #1096 from bdunne/openssl_fix"

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -55,8 +55,6 @@ RUN --mount=type=bind,from=rpms,source=/tmp/rpms,target=/tmp/rpms \
       https://rpm.manageiq.org/release/19-spassky/el9/noarch/manageiq-release-19.0-1.el9.noarch.rpm && \
     if [[ "$RELEASE_BUILD" != "true" ]]; then dnf config-manager --enable manageiq-19-spassky-nightly; fi && \
     if [[ -n "$(ls /tmp/rpms)" ]]; then /usr/local/bin/prepare_local_yum_repo.sh; fi && \
-    dnf -y --disablerepo=ubi-9-baseos-rpms swap openssl-fips-provider openssl-libs && \
-    dnf -y update && \
     dnf -y module enable ruby:3.1 && \
     dnf -y install \
       httpd \


### PR DESCRIPTION
This reverts commit e93d917a529e5675908ad0228386e87849c059d5, reversing changes made to a4c927cf384542a9a483415a705f03a8d3a76b85.

Depends on: https://github.com/ManageIQ/manageiq-rpm_build/pull/458
It turns out that upgrading to openssl v3.2 did not fix our problems, instead we're going to lock down to <v3.2