### PR TITLE
Remove creation of manageiq.liveness-check topic

### DIFF
--- a/manageiq-operator/internal/controller/manageiq_controller.go
+++ b/manageiq-operator/internal/controller/manageiq_controller.go
@@ -572,7 +572,7 @@ func (r *ManageIQReconciler) generateKafkaResources(cr *miqv1alpha1.ManageIQ) er
 		logger.Info("Kafka User has been reconciled", "result", result)
 	}
 
-	topics := []string{"manageiq.liveness-check", "manageiq.ems", "manageiq.ems-events", "manageiq.ems-inventory", "manageiq.metrics"}
+	topics := []string{"manageiq.ems", "manageiq.ems-events", "manageiq.ems-inventory", "manageiq.metrics"}
 	for i := 0; i < len(topics); i++ {
 		kafkaTopicCR, mutateFunc := miqkafka.KafkaTopic(cr, r.Scheme, topics[i])
 		if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, kafkaTopicCR, mutateFunc); err != nil {


### PR DESCRIPTION
We no longer use a push/pop approach as health check for kafka via the orchestrator and so this topic no longer needs to be created

Ref: https://github.com/ManageIQ/manageiq/pull/23020

@miq-bot assign @bdunne 
@miq-bot add_reviewers @bdunne, @Fryguy 
@miq-bot add_labels bug, radjabov/yes?