### PR TITLE
WIP: Creating network policy for opentofu runner

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/network_policies.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/network_policies.go
@@ -284,6 +284,44 @@ func NetworkPolicyAllowZookeeper(cr *miqv1alpha1.ManageIQ, scheme *runtime.Schem
 	return networkPolicy, f
 }
 
+func NetworkPolicyAllowTfRunner(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme, c *client.Client) (*networkingv1.NetworkPolicy, controllerutil.MutateFn) {
+	networkPolicy := newNetworkPolicy(cr, "allow-tfrunner")
+
+	f := func() error {
+		if err := controllerutil.SetControllerReference(cr, networkPolicy, scheme); err != nil {
+			return err
+		}
+		addAppLabel(cr.Spec.AppName, &networkPolicy.ObjectMeta)
+		setIngressPolicyType(networkPolicy)
+
+		networkPolicy.Spec.PodSelector.MatchLabels = map[string]string{"name": "opentofu-runner"}
+
+		pod := orchestratorPod(*c)
+		if pod == nil {
+			return nil
+		}
+
+		ensureIngressRule(networkPolicy)
+		setFirstIngressTCPPort(networkPolicy, 6000)
+		if len(networkPolicy.Spec.Ingress[0].From) != 2 {
+			networkPolicy.Spec.Ingress[0].From = []networkingv1.NetworkPolicyPeer{
+				networkingv1.NetworkPolicyPeer{},
+				networkingv1.NetworkPolicyPeer{},
+			}
+		}
+		orchestratedByLabelKey := cr.Spec.AppName + "-orchestrated-by"
+		orchestratedByLabelValue := pod.Name
+		networkPolicy.Spec.Ingress[0].From[0].PodSelector = &metav1.LabelSelector{}
+		networkPolicy.Spec.Ingress[0].From[0].PodSelector.MatchLabels = map[string]string{"name": "orchestrator"}
+		networkPolicy.Spec.Ingress[0].From[1].PodSelector = &metav1.LabelSelector{}
+		networkPolicy.Spec.Ingress[0].From[1].PodSelector.MatchLabels = map[string]string{orchestratedByLabelKey: orchestratedByLabelValue}
+
+		return nil
+	}
+
+	return networkPolicy, f
+}
+
 func newNetworkPolicy(cr *miqv1alpha1.ManageIQ, name string) *networkingv1.NetworkPolicy {
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/manageiq-operator/internal/controller/manageiq_controller.go
+++ b/manageiq-operator/internal/controller/manageiq_controller.go
@@ -687,6 +687,13 @@ func (r *ManageIQReconciler) generateNetworkPolicies(cr *miqv1alpha1.ManageIQ) e
 		}
 	}
 
+	networkPolicyAllowTfRunner, mutateFunc := miqtool.NetworkPolicyAllowTfRunner(cr, r.Scheme, &r.Client)
+	if result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, networkPolicyAllowTfRunner, mutateFunc); err != nil {
+		return err
+	} else if result != controllerutil.OperationResultNone {
+		logger.Info("NetworkPolicy allow opentofu-runner has been reconciled", "component", "network_policy", "result", result)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR creates network policy for Opentofu runner.
- Network policy name will be `ibm-infra-management-application-allow-tfrunner`
- It will generate spec something like this
```
spec:
  podSelector:
    matchLabels:
      name: opentofu-runner
  ingress:
    - ports:
        - protocol: TCP
          port: 6000
      from:
        - podSelector:
            matchLabels:
              name: orchestrator
        - podSelector:
            matchLabels:
              ibm-infra-management-application-orchestrated-by: orchestrator-765bdbcdfc-kfrht
```

