### PR TITLE
Fix nil pointer dereference error

### DIFF
--- a/manageiq-operator/internal/controller/manageiq_controller.go
+++ b/manageiq-operator/internal/controller/manageiq_controller.go
@@ -201,7 +201,7 @@ func (r *ManageIQReconciler) updateManageIQStatus(cr *miqv1alpha1.ManageIQ) erro
 					object.Spec.Rules != nil {
 					endpointInfo := &miqv1alpha1.Endpoint{}
 					if len(object.Spec.TLS[0].SecretName) != 0 {
-						if objectSecret := FindSecret(cr, r.Client, object.Spec.TLS[0].SecretName); object != nil {
+						if objectSecret := FindSecret(cr, r.Client, object.Spec.TLS[0].SecretName); objectSecret != nil {
 							endpointInfo.Name = ingressName
 							endpointInfo.Type = "UI"
 							endpointInfo.Scope = "External"


### PR DESCRIPTION
This should be checking whether we found objectSecret before continuing, we wouldn't be here if object was nil.

```
2024-05-17T17:14:52Z	INFO	controller_manageiq	Reconciling the CR status... 2024-05-17T17:14:52Z	INFO	Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference	{"controller": "manageiq", "controllerGroup": "manageiq.org", "controllerKind": "ManageIQ", "ManageIQ": {"name":"im-iminstall","namespace":"cp4aiops"}, "namespace": "cp4aiops", "name": "im-iminstall", "reconcileID": "9b4b34f7-5f38-4a68-aad7-858b417ce57e"} panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x15665c0]

goroutine 175 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:116 +0x2a8
panic({0x16e4600, 0x26e88f0})
	/usr/local/go/src/runtime/panic.go:914 +0x280
github.com/ManageIQ/manageiq-pods/manageiq-operator/internal/controller.(*ManageIQReconciler).updateManageIQStatus(0xc000506d20, 0xc000878e00)
	/workspace/internal/controller/manageiq_controller.go:208 +0x520
github.com/ManageIQ/manageiq-pods/manageiq-operator/internal/controller.(*ManageIQReconciler).Reconcile(0xc000506d20, {0x1b74a10, 0xc0008cd590}, {{{0xc0006be4c0, 0x8}, {0xc0006be4f0, 0xc}}})
	/workspace/internal/controller/manageiq_controller.go:152 +0x88c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0xc0002dedc0, {0x1b74a10, 0xc0008cd590}, {{{0xc0006be4c0, 0x8}, {0xc0006be4f0, 0xc}}})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:119 +0xce
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0002dedc0, {0x1b74a48, 0xc0002abb80}, {0x175e2a0, 0xc0000bea60})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:316 +0x42e
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0002dedc0, {0x1b74a48, 0xc0002abb80})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:266 +0x20a
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:227 +0xa2
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 90
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:223 +0x5f4
```
cc @sudhir-kelkar 