### PR TITLE
Fix bug in TLS secret detection

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd.go
@@ -605,7 +605,7 @@ func HttpdDbusAPIService(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*cor
 }
 
 func ManageTlsSecret(cr *miqv1alpha1.ManageIQ, client client.Client, scheme *runtime.Scheme) (*corev1.Secret, controllerutil.MutateFn, error) {
-	secretKey := types.NamespacedName{Namespace: cr.ObjectMeta.Namespace, Name: cr.Spec.DatabaseSecret}
+	secretKey := types.NamespacedName{Namespace: cr.ObjectMeta.Namespace, Name: tlsSecretName(cr)}
 	secret := &corev1.Secret{}
 	secretErr := client.Get(context.TODO(), secretKey, secret)
 	var err error


### PR DESCRIPTION
If someone were to successfully install the application then delete the TLSSecret, the operator would not recreate it because it detected that the Database Secret already existed.  This will cause errors during reconcile when the operator tries to update the CR status.  Instead, we should be checking the existence of the TLS Secret.