### PR TITLE
Fix the path for `oc create -f` custom operator

### DIFF
--- a/manageiq-operator/README.md
+++ b/manageiq-operator/README.md
@@ -40,7 +40,7 @@ There are three different ways the operator can be run.
   3 - Run your custom image from the registry:
 
     ```bash
-    $ oc create -f deploy/operator.yaml
+    $ oc create -f config/manager/manager.yaml
     ```
 
 + #### Option 3: Run locally (on your local laptop/computer, outside of the cluster)


### PR DESCRIPTION
Trying to test out some miq_server changes and ran into this, believe it should be updated to match https://github.com/ManageIQ/manageiq-pods/pull/831/commits/b25cbb2f0eae71f23c38211d2c7eb204ca56127c#diff-6d4414c4f9d176009160c46934a42c9cc20803940e97af41e93fdd04509a6021L37-R37

I'm still having issues deploying a custom operator but I think that is unrelated to this
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
