### PR TITLE
Switch to ubuntu-24.04

### DIFF
--- a/.github/workflows/build_pods.yaml
+++ b/.github/workflows/build_pods.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build_pods:
     if: github.repository_owner == 'ManageIQ'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Set up Go


### PR DESCRIPTION
`ubuntu-latest` still points to 22.04 which has podman 3.4.4 and run in that version does not support bind mounting volumes.  Upgrading to 24.04 gets us podman 4.9.3

Error:
```
error resolving mountpoints for container "4349440300a7f09982c00e0a8d5a010141b5eb912483ea6646bacaf54c080194": invalid mount type "bind"
```