### PR TITLE
Update go to v1.23

### DIFF
--- a/manageiq-operator/Dockerfile
+++ b/manageiq-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/library/golang:1.22 as builder
+FROM docker.io/library/golang:1.23 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/manageiq-operator/go.mod
+++ b/manageiq-operator/go.mod
@@ -1,8 +1,6 @@
 module github.com/ManageIQ/manageiq-pods/manageiq-operator
 
-go 1.22.0
-
-toolchain go1.22.6
+go 1.23
 
 require (
 	github.com/onsi/ginkgo/v2 v2.20.0


### PR DESCRIPTION
Drop the toolchain and move minimum to 1.23

"If the toolchain line is omitted, the module or workspace is considered to have an implicit toolchain goV line, where V is the Go version from the go line." -https://go.dev/doc/toolchain
