### PR TITLE
Default the system password_encryption to scram-sha-256

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/postgresql_conf.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/postgresql_conf.go
@@ -10,6 +10,8 @@ tcp_keepalives_count = 9
 tcp_keepalives_idle = 3
 tcp_keepalives_interval = 75
 
+password_encryption = scram-sha-256
+
 #------------------------------------------------------------------------------
 # RESOURCE USAGE (except WAL)
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Similar PR to https://github.com/ManageIQ/manageiq-appliance/pull/388, but for containerized.