### PR TITLE
Replace EMS_IDS with EMS_ID in container entrypoint

### DIFF
--- a/images/manageiq-base-worker/container-assets/entrypoint
+++ b/images/manageiq-base-worker/container-assets/entrypoint
@@ -3,7 +3,7 @@
 [[ -s ${APP_ROOT}/container_env ]] && source ${APP_ROOT}/container_env
 
 WORKER_OPTIONS=""
-[[ -n $EMS_IDS ]] && WORKER_OPTIONS="${WORKER_OPTIONS} --ems-id=${EMS_IDS} "
+[[ -n $EMS_ID ]] && WORKER_OPTIONS="${WORKER_OPTIONS} --ems-id=${EMS_ID} "
 [[ -n $HOSTNAME ]] && WORKER_OPTIONS="${WORKER_OPTIONS} --system-uid=$HOSTNAME "
 
 exec ruby ${APP_ROOT}/lib/workers/bin/run_single_worker.rb --heartbeat ${WORKER_OPTIONS}${WORKER_CLASS_NAME}


### PR DESCRIPTION
Workers having a comma separated list of EMS IDs is no longer used and this can be simplified to a single EMS_ID.

Co-depends:
* https://github.com/ManageIQ/manageiq/pull/23195

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
