### PR TITLE
Prefer UBI and go download over library/golang

### DIFF
--- a/manageiq-operator/Dockerfile
+++ b/manageiq-operator/Dockerfile
@@ -4,12 +4,9 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
 COPY go.mod /go.mod
 
 RUN microdnf -y install gzip jq tar && \
-    arch=$(uname -m) && \
-    if [ ${arch} == "x86_64" ] ; then \
-      arch="amd64" \
-    ; fi && \
+    arch=$(uname -m | sed 's/x86_64/amd64/') && \
     goversion=$(sed -nr 's/^go\s+(.*)/go\1/p' /go.mod) && \
-    file=$(curl -s 'https://go.dev/dl/?mode=json&include=all' | jq -r --arg GOVERSION "${goversion}" --arg ARCH "${arch}" 'map(select(.version | startswith($GOVERSION)))[0].files[] | select(.arch == $ARCH and .os == "linux").filename') && \
+    file=$(curl -s 'https://go.dev/dl/?mode=json&include=all' | jq -r --arg GOVERSION "${goversion}" --arg ARCH "${arch}" 'first(.[] | select(.version | startswith($GOVERSION))).files[] | select(.arch == $ARCH and .os == "linux").filename') && \
     curl -s -f -L https://go.dev/dl/${file} | tar -C / -xzf -
 
 ENV PATH=/go/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/manageiq-operator/Dockerfile
+++ b/manageiq-operator/Dockerfile
@@ -1,8 +1,16 @@
 # Build the manager binary
 FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
 
-RUN microdnf -y install gzip tar && \
-    curl -f -L https://go.dev/dl/go1.23.1.linux-amd64.tar.gz | tar -C / -xzf -
+COPY go.mod /go.mod
+
+RUN microdnf -y install gzip jq tar && \
+    arch=$(uname -m) && \
+    if [ ${arch} == "x86_64" ] ; then \
+      arch="amd64" \
+    ; fi && \
+    goversion=$(sed -nr 's/^go\s+(.*)/go\1/p' /go.mod) && \
+    file=$(curl -s 'https://go.dev/dl/?mode=json&include=all' | jq -r --arg GOVERSION "${goversion}" --arg ARCH "${arch}" 'map(select(.version | startswith($GOVERSION)))[0].files[] | select(.arch == $ARCH and .os == "linux").filename') && \
+    curl -s -f -L https://go.dev/dl/${file} | tar -C / -xzf -
 
 ENV PATH=/go/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 

--- a/manageiq-operator/Dockerfile
+++ b/manageiq-operator/Dockerfile
@@ -1,5 +1,10 @@
 # Build the manager binary
-FROM docker.io/library/golang:1.23 as builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
+
+RUN microdnf -y install gzip tar && \
+    curl -f -L https://go.dev/dl/go1.23.1.linux-amd64.tar.gz | tar -C / -xzf -
+
+ENV PATH=/go/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -14,9 +19,11 @@ COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/controller/ internal/controller/
 
-# Build
+# Build go executable
 RUN CGO_ENABLED=0 go build -a -o manager cmd/main.go
 
+
+# Build operator image
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL name="ManageIQ Operator" \

--- a/spec/manageiq-operator/go_version_spec.rb
+++ b/spec/manageiq-operator/go_version_spec.rb
@@ -1,11 +1,9 @@
 describe "Go Version" do
   it "matches go.mod" do
     require 'awesome_spawn'
-    dockerfile_version = File.read(ROOT.join("manageiq-operator", "Dockerfile")).match(/^FROM.+golang:(\d+\.\d+).+/)[1]
-    mod_version        = File.read(ROOT.join("manageiq-operator", "go.mod")).match(/^go\s(\d+\.\d+)/)[1]
-    running_version    = AwesomeSpawn.run!("go version", :chdir => ROOT.join("manageiq-operator")).output.match(/.*\sgo(\d+\.\d+).*/)[1]
+    mod_version     = File.read(ROOT.join("manageiq-operator", "go.mod")).match(/^go\s(\d+\.\d+)/)[1]
+    running_version = AwesomeSpawn.run!("go version", :chdir => ROOT.join("manageiq-operator")).output.match(/.*\sgo(\d+\.\d+).*/)[1]
 
-    expect(dockerfile_version).to eq(mod_version)
-    expect(running_version).to    eq(mod_version)
+    expect(running_version).to eq(mod_version)
   end
 end


### PR DESCRIPTION
- speed up build since there is less to download
- reduce external dependencies
- build and run on the same base image

```
REPOSITORY                TAG  IMAGE ID     CREATED         SIZE
my                        test 422e3c099772 10 seconds ago  366 MB
docker.io/library/golang  1.23 361d8b5c9aa5 3 weeks ago     862 MB
```
