### PR TITLE
[morphy] upgrade git

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -52,7 +52,7 @@ RUN dnf -y remove *subscription-manager* && \
     rm -f /etc/yum.repos.d/ovirt-4.4-dependencies.repo && \
     dnf -y module enable ruby:2.6 && \
     if [[ "$RELEASE_BUILD" != "true" ]]; then dnf config-manager --enable manageiq-13-morphy-nightly; fi && \
-    dnf config-manager --setopt=ubi-8-*.exclude=dracut*,net-snmp*,perl-*,redhat-release* --save && \
+    dnf config-manager --setopt=ubi-8-*.exclude=dracut*,net-snmp*,redhat-release* --save && \
     if [[ "$LOCAL_RPM" = "true" ]]; then /create_local_yum_repo.sh; fi && \
     dnf -y --setopt=tsflags=nodocs install \
       ${RPM_PREFIX}-pods          \


### PR DESCRIPTION
Previously we were stuck at 2.43.0-1.el8, with this change we can get 2.43.5-2.el8_10

This reverts https://github.com/ManageIQ/manageiq-pods/pull/722 now that CentOS 8 Stream has older packages than RHEL/UBI

CP4MCM-131

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
