### PR TITLE
Inherit renovate config from a central location

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
+  "inheritConfig": true,
+  "inheritConfigRepoName": "manageiq/renovate-config",
   "ignoreDeps": [
     "github.com/openshift/api"
   ],


### PR DESCRIPTION
The base config is located here: https://github.com/ManageIQ/renovate-config/blob/master/org-inherited-config.json

@bdunne Please review.