### PR TITLE
remove toolchain

### DIFF
--- a/manageiq-operator/go.mod
+++ b/manageiq-operator/go.mod
@@ -2,8 +2,6 @@ module github.com/ManageIQ/manageiq-pods/manageiq-operator
 
 go 1.23.0
 
-toolchain go1.23.4
-
 require (
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2


### PR DESCRIPTION
It's not necessary and we can just use the go version 
Closes #1199