### PR TITLE
[morphy] upgrade go

### DIFF
--- a/manageiq-operator/go.mod
+++ b/manageiq-operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/ManageIQ/manageiq-pods/manageiq-operator
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/operator-framework/operator-sdk v0.18.2


### PR DESCRIPTION
Can't backport https://github.com/ManageIQ/manageiq-pods/pull/1244 because of the other dependencies included in it.