### PR TITLE
Only pick the major and minor go version to ensure the latest is pulled

### DIFF
--- a/manageiq-operator/Dockerfile
+++ b/manageiq-operator/Dockerfile
@@ -5,7 +5,7 @@ COPY go.mod /go.mod
 
 RUN microdnf -y install gzip jq tar && \
     arch=$(uname -m | sed 's/x86_64/amd64/') && \
-    goversion=$(sed -nr 's/^go\s+(.*)/go\1/p' /go.mod) && \
+    goversion=$(sed -nr 's/^go\s+([0-9]+\.[0-9]+)(\.[0-9]+)?/go\1/p' /go.mod) && \
     file=$(curl -s 'https://go.dev/dl/?mode=json&include=all' | jq -r --arg GOVERSION "${goversion}" --arg ARCH "${arch}" 'first(.[] | select(.version | startswith($GOVERSION))).files[] | select(.arch == $ARCH and .os == "linux").filename') && \
     curl -s -f -L https://go.dev/dl/${file} | tar -C / -xzf -
 


### PR DESCRIPTION
Handle cases where go.mod contains "go 1.24.0" or "go 1.24" and pick the latest patch version for that major.minor.

Previously this was picking up the whole of "go1.24.0" and locking us down to that minimum version