### PR TITLE
Add missing evm:automate:reset on upgrade

### DIFF
--- a/images/manageiq-orchestrator/container-assets/entrypoint
+++ b/images/manageiq-orchestrator/container-assets/entrypoint
@@ -50,6 +50,9 @@ function check_deployment_status() {
         pushd ${APP_ROOT}
           bin/rake db:migrate
           [ "$?" -ne "0" ] && echo "ERROR: Failed to migrate database" && return 1
+
+          bin/rake evm:automate:reset
+          [ "$?" -ne "0" ] && echo "ERROR: Failed to reset automate database" && return 1
         popd
 
         return 0


### PR DESCRIPTION
When the builtin automate domain is updated the domain has to be reset by running `rake evm:automate:reset`
This was missing from the orchestrator upgrade process causing changes to the automate domain to not be applied when upgrading and existing deployment.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
