### PR TITLE
Run with the latest go version

### DIFF
--- a/.github/workflows/build_pods.yaml
+++ b/.github/workflows/build_pods.yaml
@@ -15,7 +15,7 @@ jobs:
       with:
         cache-dependency-path: 'manageiq-operator/go.sum'
         check-latest: true
-        go-version-file: 'manageiq-operator/go.mod'
+        go-version: 'stable'
     - name: Docker login
       run: echo ${{ secrets.DOCKER_REGISTRY_PASSWORD }} | docker login docker.io --password-stdin --username ${{ secrets.DOCKER_REGISTRY_USERNAME }}
     - name: Build pods containers

--- a/.github/workflows/build_pods.yaml
+++ b/.github/workflows/build_pods.yaml
@@ -13,6 +13,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
+        cache-dependency-path: 'manageiq-operator/go.sum'
+        check-latest: true
         go-version-file: 'manageiq-operator/go.mod'
     - name: Docker login
       run: echo ${{ secrets.DOCKER_REGISTRY_PASSWORD }} | docker login docker.io --password-stdin --username ${{ secrets.DOCKER_REGISTRY_USERNAME }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       with:
         cache-dependency-path: 'manageiq-operator/go.sum'
         check-latest: true
-        go-version-file: manageiq-operator/go.mod
+        go-version: 'stable'
     - name: Run ruby tests
       run: bundle exec rake
     - name: Run golang tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
+        cache-dependency-path: 'manageiq-operator/go.sum'
+        check-latest: true
         go-version-file: manageiq-operator/go.mod
     - name: Run ruby tests
       run: bundle exec rake

--- a/.github/workflows/go_dependencies.yaml
+++ b/.github/workflows/go_dependencies.yaml
@@ -13,6 +13,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
+        cache-dependency-path: 'manageiq-operator/go.sum'
+        check-latest: true
         go-version-file: 'manageiq-operator/go.mod'
     - name: Update all dependencies
       run: |

--- a/.github/workflows/go_dependencies.yaml
+++ b/.github/workflows/go_dependencies.yaml
@@ -15,7 +15,7 @@ jobs:
       with:
         cache-dependency-path: 'manageiq-operator/go.sum'
         check-latest: true
-        go-version-file: 'manageiq-operator/go.mod'
+        go-version: 'stable'
     - name: Update all dependencies
       run: |
         go get -t -u ./...


### PR DESCRIPTION
Unfortunately it looks like we need to specify the z-version of go now... this will keep it up to date.
https://github.com/ManageIQ/manageiq-pods/actions/runs/15949770344/job/45082004161
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
