### PR TITLE
Switch to CentOS Stream openssl packages

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -52,7 +52,8 @@ RUN --mount=type=bind,from=rpms,source=/tmp/rpms,target=/tmp/rpms \
       http://mirror.stream.centos.org/9-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-9.0-24.el9.noarch.rpm \
       http://mirror.stream.centos.org/9-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-9.0-24.el9.noarch.rpm && \
     dnf config-manager --enable crb && \
-    dnf config-manager --save --setopt=appstream.exclude=openssl* --setopt=baseos.exclude=openssl* && \
+    dnf -y --disablerepo=ubi-9-baseos-rpms swap openssl-fips-provider openssl-libs && \
+    dnf -y update && \
     dnf -y install \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
       https://rpm.manageiq.org/release/20-tal/el9/noarch/manageiq-release-20.0-1.el9.noarch.rpm && \


### PR DESCRIPTION
Fixes:
```
Error: 
 Problem: package python3-devel-3.9.23-1.el9.x86_64 from appstream requires python3-libs(x86-64) = 3.9.23-1.el9, but none of the providers can be installed
  - package python3-libs-3.9.23-1.el9.x86_64 from baseos requires libcrypto.so.3(OPENSSL_3.4.0)(64bit), but none of the providers can be installed
  - package python3-libs-3.9.23-1.el9.x86_64 from baseos requires libcrypto.so.3(OPENSSL_3.3.0)(64bit), but none of the providers can be installed
  - cannot install the best candidate for the job
  - package openssl-libs-1:3.5.0-1.el9.x86_64 from baseos is filtered out by exclude filtering
  - package openssl-libs-1:3.5.0-2.el9.x86_64 from baseos is filtered out by exclude filtering
  - package openssl-libs-1:3.5.0-3.el9.x86_64 from baseos is filtered out by exclude filtering
  - package openssl-libs-1:3.5.0-4.el9.x86_64 from baseos is filtered out by exclude filtering
  - package openssl-libs-1:3.5.1-1.el9.x86_64 from baseos is filtered out by exclude filtering
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```