### PR TITLE
Fix `namespaces "system" not found` error

### DIFF
--- a/manageiq-operator/config/manager/manager.yaml
+++ b/manageiq-operator/config/manager/manager.yaml
@@ -2,9 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: manageiq-operator
-  namespace: system
   labels:
-    name: memcached-operator
+    name: manageiq-operator
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Fixes the following error when creating the manageiq-operator deployment
```
$ oc create -f config/manager/manager.yaml
Error from server (NotFound): error when creating "config/manager/manager.yaml": namespaces "system" not found
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
