### PR TITLE
Run seeds when upgrading a database

### DIFF
--- a/images/manageiq-orchestrator/container-assets/entrypoint
+++ b/images/manageiq-orchestrator/container-assets/entrypoint
@@ -51,6 +51,9 @@ function check_deployment_status() {
           bin/rake db:migrate
           [ "$?" -ne "0" ] && echo "ERROR: Failed to migrate database" && return 1
 
+          bin/rake db:seed
+          [ "$?" -ne "0" ] && echo "ERROR: Failed to seed database" && return 1
+
           bin/rake evm:automate:reset
           [ "$?" -ne "0" ] && echo "ERROR: Failed to reset automate database" && return 1
         popd


### PR DESCRIPTION
@Fryguy and I were on a call and he mentioned that this should be here.

This may not be the correct approach. But it matches my local development workflow.

When I upgrade a version of the product, I run `db:migrate` and `db:seed`. Not sure if this is standard practices. I also tend to turn off auto seeding in local dev.


ASIDE
=====

I'd like us to only seed on version upgrades, but not tackling that battle here.
Simple putting this in here because Jason said "That's strange."