### PR TITLE
Fix typo from #1378

### DIFF
--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -38,7 +38,7 @@ RUN --mount=type=bind,from=quay.io/manageiq/build_tools:v1,source=/tools,target=
     dnf config-manager --setopt=tsflags=nodocs --setopt=install_weak_deps=False --save && \
     dnf -y install https://rpm.manageiq.org/release/21-uhlmann/el10/noarch/manageiq-release-21.0-1.el10.noarch.rpm && \
     if [[ "$RELEASE_BUILD" != "true" ]]; then dnf config-manager --enable manageiq-21-uhlmann-nightly; fi && \
-    if [[ -n "$(ls /tmp/rpms)" ]]; then miq_prepare_local_yum_repo.sh; fi && \
+    if [[ -n "$(ls /tmp/rpms)" ]]; then miq_prepare_local_yum_repo; fi && \
     # Currently the minimum version of qpid-proton in EPEL is 0.40.0, but we're still on 0.37, so pull it from the ManageIQ RPM repo instead https://github.com/ManageIQ/manageiq/blob/b5bf7bee569991d3f1a182a4792fae8cb6265863/Gemfile#L220
     dnf config-manager --setopt=epel.exclude=*qpid-proton* --save && \
     dnf -y install \

--- a/images/manageiq-hotfix/Dockerfile
+++ b/images/manageiq-hotfix/Dockerfile
@@ -9,7 +9,7 @@ COPY rpms/* /tmp/rpms/
 RUN --mount=type=bind,from=quay.io/manageiq/build_tools:v1,source=/tools,target=/usr/local/bin \
     dnf -y install createrepo_c && \
     rm -rf /tmp/rpms/repodata && \
-    miq_prepare_local_yum_repo.sh && \
+    miq_prepare_local_yum_repo && \
     dnf -y --repo=local-rpm update && \
     chgrp -R 0 $APP_ROOT && \
     chmod -R g=u $APP_ROOT && \


### PR DESCRIPTION
/bin/sh: line 1: miq_prepare_local_yum_repo.sh: command not found