### PR TITLE
Switch the service account to having the database backup label

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/rbac.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/rbac.go
@@ -46,7 +46,7 @@ func DefaultServiceAccount(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*c
 			addSAPullSecret(sa, cr.Spec.ImagePullSecret)
 		}
 
-		addBackupLabel(cr.Spec.BackupLabelName, &sa.ObjectMeta)
+		addBackupLabelDB(cr.Spec.BackupLabelName, &sa.ObjectMeta)
 
 		return nil
 	}


### PR DESCRIPTION
This allows the database to be restored on its own.
CP4AIOPS-16352
