### PR TITLE
Remove mounts due to overlay issue

### DIFF
--- a/images/manageiq-appliance/config.toml.azure
+++ b/images/manageiq-appliance/config.toml.azure
@@ -22,13 +22,7 @@ minsize = "20 GiB"
 name = "lv_os"
 mountpoint = "/"
 fs_type = "xfs"
-minsize = "10 GiB"
-
-[[customizations.disk.partitions.logical_volumes]]
-name = "lv_var_lib"
-mountpoint = "/var/lib"
-fs_type = "xfs"
-minsize = "10 GiB"
+minsize = "20 GiB"
 
 [[customizations.disk.partitions.logical_volumes]]
 name = "lv_var_log"
@@ -47,9 +41,3 @@ name = "lv_var_www_miq_tmp"
 mountpoint = "/var/www/miq_tmp"
 fs_type = "xfs"
 minsize = "10 GiB"
-
-[[customizations.disk.partitions.logical_volumes]]
-name = "lv_home"
-mountpoint = "/var/home"
-fs_type = "xfs"
-minsize = "1 GiB"

--- a/images/manageiq-appliance/config.toml.hyperv
+++ b/images/manageiq-appliance/config.toml.hyperv
@@ -22,13 +22,7 @@ minsize = "20 GiB"
 name = "lv_os"
 mountpoint = "/"
 fs_type = "xfs"
-minsize = "10 GiB"
-
-[[customizations.disk.partitions.logical_volumes]]
-name = "lv_var_lib"
-mountpoint = "/var/lib"
-fs_type = "xfs"
-minsize = "10 GiB"
+minsize = "20 GiB"
 
 [[customizations.disk.partitions.logical_volumes]]
 name = "lv_var_log"
@@ -47,12 +41,6 @@ name = "lv_var_www_miq_tmp"
 mountpoint = "/var/www/miq_tmp"
 fs_type = "xfs"
 minsize = "10 GiB"
-
-[[customizations.disk.partitions.logical_volumes]]
-name = "lv_home"
-mountpoint = "/var/home"
-fs_type = "xfs"
-minsize = "1 GiB"
 
 [[customizations.disk.partitions.logical_volumes]]
 name = "swaplv"

--- a/images/manageiq-appliance/config.toml.openstack
+++ b/images/manageiq-appliance/config.toml.openstack
@@ -22,13 +22,7 @@ minsize = "20 GiB"
 name = "lv_os"
 mountpoint = "/"
 fs_type = "xfs"
-minsize = "10 GiB"
-
-[[customizations.disk.partitions.logical_volumes]]
-name = "lv_var_lib"
-mountpoint = "/var/lib"
-fs_type = "xfs"
-minsize = "10 GiB"
+minsize = "20 GiB"
 
 [[customizations.disk.partitions.logical_volumes]]
 name = "lv_var_log"
@@ -47,12 +41,6 @@ name = "lv_var_www_miq_tmp"
 mountpoint = "/var/www/miq_tmp"
 fs_type = "xfs"
 minsize = "10 GiB"
-
-[[customizations.disk.partitions.logical_volumes]]
-name = "lv_home"
-mountpoint = "/var/home"
-fs_type = "xfs"
-minsize = "1 GiB"
 
 [[customizations.disk.partitions.logical_volumes]]
 name = "swaplv"

--- a/images/manageiq-appliance/config.toml.ovirt
+++ b/images/manageiq-appliance/config.toml.ovirt
@@ -22,13 +22,7 @@ minsize = "20 GiB"
 name = "lv_os"
 mountpoint = "/"
 fs_type = "xfs"
-minsize = "10 GiB"
-
-[[customizations.disk.partitions.logical_volumes]]
-name = "lv_var_lib"
-mountpoint = "/var/lib"
-fs_type = "xfs"
-minsize = "10 GiB"
+minsize = "20 GiB"
 
 [[customizations.disk.partitions.logical_volumes]]
 name = "lv_var_log"
@@ -47,12 +41,6 @@ name = "lv_var_www_miq_tmp"
 mountpoint = "/var/www/miq_tmp"
 fs_type = "xfs"
 minsize = "10 GiB"
-
-[[customizations.disk.partitions.logical_volumes]]
-name = "lv_home"
-mountpoint = "/var/home"
-fs_type = "xfs"
-minsize = "1 GiB"
 
 [[customizations.disk.partitions.logical_volumes]]
 name = "swaplv"

--- a/images/manageiq-appliance/config.toml.vagrant
+++ b/images/manageiq-appliance/config.toml.vagrant
@@ -22,13 +22,7 @@ minsize = "20 GiB"
 name = "lv_os"
 mountpoint = "/"
 fs_type = "xfs"
-minsize = "10 GiB"
-
-[[customizations.disk.partitions.logical_volumes]]
-name = "lv_var_lib"
-mountpoint = "/var/lib"
-fs_type = "xfs"
-minsize = "10 GiB"
+minsize = "20 GiB"
 
 [[customizations.disk.partitions.logical_volumes]]
 name = "lv_var_log"
@@ -47,12 +41,6 @@ name = "lv_var_www_miq_tmp"
 mountpoint = "/var/www/miq_tmp"
 fs_type = "xfs"
 minsize = "10 GiB"
-
-[[customizations.disk.partitions.logical_volumes]]
-name = "lv_home"
-mountpoint = "/var/home"
-fs_type = "xfs"
-minsize = "1 GiB"
 
 [[customizations.disk.partitions.logical_volumes]]
 name = "swaplv"

--- a/images/manageiq-appliance/config.toml.vsphere
+++ b/images/manageiq-appliance/config.toml.vsphere
@@ -22,13 +22,7 @@ minsize = "20 GiB"
 name = "lv_os"
 mountpoint = "/"
 fs_type = "xfs"
-minsize = "10 GiB"
-
-[[customizations.disk.partitions.logical_volumes]]
-name = "lv_var_lib"
-mountpoint = "/var/lib"
-fs_type = "xfs"
-minsize = "10 GiB"
+minsize = "20 GiB"
 
 [[customizations.disk.partitions.logical_volumes]]
 name = "lv_var_log"
@@ -47,12 +41,6 @@ name = "lv_var_www_miq_tmp"
 mountpoint = "/var/www/miq_tmp"
 fs_type = "xfs"
 minsize = "10 GiB"
-
-[[customizations.disk.partitions.logical_volumes]]
-name = "lv_home"
-mountpoint = "/var/home"
-fs_type = "xfs"
-minsize = "1 GiB"
 
 [[customizations.disk.partitions.logical_volumes]]
 name = "swaplv"


### PR DESCRIPTION
For now, we need to drop the mounts since they mount on top of required files and directories

https://github.com/osbuild/bootc-image-builder/issues/1222
https://jsw.ibm.com/browse/CP4AIOPS-29373
https://jsw.ibm.com/browse/CP4AIOPS-29363
