### PR TITLE
Revert "Temporarily lock down to 10.2 due to signature issues on s390x latest"

### DIFF
--- a/manageiq-operator/Dockerfile
+++ b/manageiq-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2 as builder
+FROM registry.access.redhat.com/ubi10/ubi-minimal as builder
 
 COPY go.mod /go.mod
 
@@ -29,7 +29,7 @@ RUN CGO_ENABLED=0 go build -a -o manager cmd/main.go
 
 
 # Build operator image
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
 
 LABEL name="ManageIQ Operator" \
       summary="ManageIQ Operator manages the ManageIQ application on a Kubernetes cluster" \


### PR DESCRIPTION
This reverts commit 00f1f8b162ebaaeabf5b9382bee03293e40deb78.

A new UBI was published and the signatures are now valid.
https://github.com/ManageIQ/manageiq/issues/23855