### PR TITLE
Ensure we set user to manageiq

### DIFF
--- a/images/manageiq-base-worker/Dockerfile
+++ b/images/manageiq-base-worker/Dockerfile
@@ -3,6 +3,8 @@ ARG FROM_TAG=latest
 
 FROM ${FROM_REPO}/manageiq-base:${FROM_TAG} AS vddk
 
+USER 0
+
 COPY container-assets/ /vddk/
 
 RUN /vddk/extract-vmware-vddk
@@ -14,11 +16,15 @@ FROM ${FROM_REPO}/manageiq-base:${FROM_TAG}
 LABEL name="manageiq-base-worker" \
       summary="ManageIQ Worker Image"
 
+USER 0
+
 COPY container-assets/entrypoint /usr/local/bin
 COPY container-assets/manageiq_liveness_check /usr/local/bin
 
 COPY --from=vddk /vddk/vmware-vix-disklib-distrib/ /usr/lib/vmware-vix-disklib/
 COPY container-assets/install-vmware-vddk /tmp/
 RUN /tmp/install-vmware-vddk
+
+USER 903
 
 CMD ["entrypoint"]

--- a/images/manageiq-base/Dockerfile
+++ b/images/manageiq-base/Dockerfile
@@ -51,7 +51,8 @@ RUN --mount=type=bind,from=quay.io/manageiq/build_tools:v1,source=/tools,target=
     chown manageiq:root /home/manageiq && \
     chmod -R g=u /home/manageiq && \
     chgrp -R 0 $APP_ROOT && \
-    chmod -R g=u $APP_ROOT
+    chmod -R g=u $APP_ROOT && \
+    usermod -aG root manageiq
 
 # Add in the container_env file now that the APP_ROOT is created from the RPM
 ADD container-assets/container_env ${APP_ROOT}/
@@ -61,5 +62,7 @@ RUN --mount=type=bind,from=quay.io/manageiq/build_tools:v1,source=/tools,target=
     source /etc/default/evm && \
     /usr/bin/generate_rpm_manifest.sh && \
     miq_clean_dnf_rpm
+
+USER 903
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--single-child", "--"]

--- a/images/manageiq-webserver-worker/Dockerfile
+++ b/images/manageiq-webserver-worker/Dockerfile
@@ -14,6 +14,8 @@ LABEL name="manageiq-webserver-worker" \
 
 COPY container-assets/service-worker-entrypoint /usr/local/bin
 
+USER 0
+
 RUN --mount=type=bind,from=quay.io/manageiq/build_tools:v1,source=/tools,target=/usr/local/bin --mount=type=bind,from=rpms,source=/tmp/rpms,target=/tmp/rpms \
     dnf -y install \
       ${RPM_PREFIX}-ui && \
@@ -35,5 +37,7 @@ RUN --mount=type=bind,from=quay.io/manageiq/build_tools:v1,source=/tools,target=
 
 EXPOSE 3000
 EXPOSE 4000
+
+USER 903
 
 CMD ["service-worker-entrypoint"]


### PR DESCRIPTION
When running in OpenShift, this isn't completely necessary because it will run as the random userid assigned to the namespace. However, when run in other kubernetes like k3s, the container is launched with the default userid (0) which conflicts with the securityContext.runAsNonRoot=true that we set on the deployment.  So, we need to change the default userid to a non-root user.
