### PR TITLE
Specify OIDCPassClaimsAs with none for backwards compatibility

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
@@ -268,6 +268,7 @@ OIDCCryptoPassphrase         sp-secret
 OIDCOAuthRemoteUserClaim     username
 OIDCCacheShmEntrySizeMax     65536
 OIDCCacheShmMax              500
+OIDCPassClaimsAs             both none
 
 OIDCOAuthClientID                  ${HTTPD_AUTH_OIDC_CLIENT_ID}
 OIDCOAuthClientSecret              ${HTTPD_AUTH_OIDC_CLIENT_SECRET}


### PR DESCRIPTION
mod_auth_openidc 2.4.15+ encodes claim values as ISO-8859-1 when passing them in headers/env vars. Characters outside the Latin-1 range cause an invalid byte sequence error. Setting OIDCPassClaimsAs to none disables this encoding for backwards compatibility.

From: https://github.com/OpenIDC/mod_auth_openidc/commit/28e79bf76ab6b4aae286a89452c2c2ceeca36efb

Similar change as the one for appliances in https://github.com/ManageIQ/manageiq-appliance/pull/409
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
