### PR TITLE
Improve httpd headers

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
@@ -43,6 +43,7 @@ Options SymLinksIfOwnerMatch
   Header always set X-Content-Type-Options "nosniff"
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   Header always set X-Frame-Options "SAMEORIGIN"
+  Header always set Reporting-Endpoints "csp-endpoint=\"https://%%{HTTP_HOST}e/dashboard/csp_report\""
 
   # Send API requests to the API pods
   ProxyPass /api %[2]s://web-service:3000/api
@@ -456,6 +457,7 @@ LimitRequestFieldSize 524288
   DocumentRoot /var/www/miq/vmdb/public
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   Header always set X-Frame-Options "SAMEORIGIN"
+  Header always set Reporting-Endpoints "csp-endpoint=\"https://%%{HTTP_HOST}e/dashboard/csp_report\""
 
   RewriteCond %%{REQUEST_URI}     ^/ws/notifications [NC]
   RewriteCond %%{HTTP:UPGRADE}    ^websocket$ [NC]

--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
@@ -475,8 +475,6 @@ LimitRequestFieldSize 524288
   ProxyPreserveHost on
   <Location /assets/>
     Header unset ETag
-    # Explicit HSTS needed: Location blocks using "Header set" don't inherit "Header always set" from VirtualHost
-    Header always set Strict-Transport-Security   "max-age=631138519"
     # CSP for static assets: strict policy since these are pre-compiled external files
     # No unsafe-inline needed - all scripts/styles are external resources
     Header always setifempty Content-Security-Policy "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; frame-src 'self'; worker-src 'self'; font-src 'self' fonts.gstatic.com fonts.googleapis.com; img-src 'self' data:; style-src 'self' fonts.googleapis.com fonts.gstatic.com; report-uri /dashboard/csp_report; report-to csp-endpoint"
@@ -492,8 +490,6 @@ LimitRequestFieldSize 524288
   </Location>
   <Location /packs/>
     Header unset ETag
-    # Explicit HSTS needed: Location blocks using "Header set" don't inherit "Header always set" from VirtualHost
-    Header always set Strict-Transport-Security   "max-age=631138519"
     # CSP for static assets: strict policy since these are pre-compiled external files
     # No unsafe-inline needed - all scripts/styles are external resources
     Header always setifempty Content-Security-Policy "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; frame-src 'self'; worker-src 'self'; font-src 'self' fonts.gstatic.com fonts.googleapis.com; img-src 'self' data:; style-src 'self' fonts.googleapis.com fonts.gstatic.com; report-uri /dashboard/csp_report; report-to csp-endpoint"

--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
@@ -42,6 +42,7 @@ Options SymLinksIfOwnerMatch
   Header always set Strict-Transport-Security "max-age=631138519"
   Header always set X-Content-Type-Options "nosniff"
   Header always set Referrer-Policy "no-referrer-when-downgrade"
+  Header always set X-Frame-Options "SAMEORIGIN"
 
   # Send API requests to the API pods
   ProxyPass /api %[2]s://web-service:3000/api
@@ -454,6 +455,7 @@ LimitRequestFieldSize 524288
   ServerName %s://ui
   DocumentRoot /var/www/miq/vmdb/public
   Header always set Referrer-Policy "no-referrer-when-downgrade"
+  Header always set X-Frame-Options "SAMEORIGIN"
 
   RewriteCond %%{REQUEST_URI}     ^/ws/notifications [NC]
   RewriteCond %%{HTTP:UPGRADE}    ^websocket$ [NC]

--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
@@ -41,6 +41,7 @@ Options SymLinksIfOwnerMatch
   RequestHeader set X-Forwarded-Host %[1]s
   Header always set Strict-Transport-Security "max-age=631138519"
   Header always set X-Content-Type-Options "nosniff"
+  Header always set Referrer-Policy "no-referrer-when-downgrade"
 
   # Send API requests to the API pods
   ProxyPass /api %[2]s://web-service:3000/api
@@ -452,6 +453,7 @@ LimitRequestFieldSize 524288
 
   ServerName %s://ui
   DocumentRoot /var/www/miq/vmdb/public
+  Header always set Referrer-Policy "no-referrer-when-downgrade"
 
   RewriteCond %%{REQUEST_URI}     ^/ws/notifications [NC]
   RewriteCond %%{HTTP:UPGRADE}    ^websocket$ [NC]

--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
@@ -455,6 +455,7 @@ LimitRequestFieldSize 524288
 
   ServerName %s://ui
   DocumentRoot /var/www/miq/vmdb/public
+  Header always set Strict-Transport-Security "max-age=631138519"
   Header always set Referrer-Policy "no-referrer-when-downgrade"
   Header always set X-Frame-Options "SAMEORIGIN"
   Header always set Reporting-Endpoints "csp-endpoint=\"https://%%{HTTP_HOST}e/dashboard/csp_report\""

--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
@@ -476,7 +476,7 @@ LimitRequestFieldSize 524288
     Header always set Strict-Transport-Security   "max-age=631138519"
     # CSP for static assets: strict policy since these are pre-compiled external files
     # No unsafe-inline needed - all scripts/styles are external resources
-    Header always setifempty Content-Security-Policy "default-src 'self'; base-uri 'self'; child-src 'self'; form-action 'self'; frame-ancestors 'self'; frame-src 'self'; worker-src 'self'; font-src 'self' fonts.gstatic.com fonts.googleapis.com; img-src 'self' data:; style-src 'self' fonts.googleapis.com fonts.gstatic.com; report-uri /dashboard/csp_report; report-to csp-endpoint"
+    Header always setifempty Content-Security-Policy "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; frame-src 'self'; worker-src 'self'; font-src 'self' fonts.gstatic.com fonts.googleapis.com; img-src 'self' data:; style-src 'self' fonts.googleapis.com fonts.gstatic.com; report-uri /dashboard/csp_report; report-to csp-endpoint"
     Header set Report-To                          "{\"group\":\"csp-endpoint\",\"max_age\":10886400,\"endpoints\":[{\"url\":\"/dashboard/csp_report\"}]}"
     Header set X-Content-Type-Options             "nosniff"
     Header set X-Frame-Options                    "SAMEORIGIN"
@@ -493,7 +493,7 @@ LimitRequestFieldSize 524288
     Header always set Strict-Transport-Security   "max-age=631138519"
     # CSP for static assets: strict policy since these are pre-compiled external files
     # No unsafe-inline needed - all scripts/styles are external resources
-    Header always setifempty Content-Security-Policy "default-src 'self'; base-uri 'self'; child-src 'self'; form-action 'self'; frame-ancestors 'self'; frame-src 'self'; worker-src 'self'; font-src 'self' fonts.gstatic.com fonts.googleapis.com; img-src 'self' data:; style-src 'self' fonts.googleapis.com fonts.gstatic.com; report-uri /dashboard/csp_report; report-to csp-endpoint"
+    Header always setifempty Content-Security-Policy "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; frame-src 'self'; worker-src 'self'; font-src 'self' fonts.gstatic.com fonts.googleapis.com; img-src 'self' data:; style-src 'self' fonts.googleapis.com fonts.gstatic.com; report-uri /dashboard/csp_report; report-to csp-endpoint"
     Header set Report-To                          "{\"group\":\"csp-endpoint\",\"max_age\":10886400,\"endpoints\":[{\"url\":\"/dashboard/csp_report\"}]}"
     Header set X-Content-Type-Options             "nosniff"
     Header set X-Frame-Options                    "SAMEORIGIN"


### PR DESCRIPTION
* Add Referrer-Policy to Apache VirtualHosts
* Add X-Frame-Options to Apache VirtualHost level
* Remove deprecated child-src from static-asset CSP
* Add Reporting-Endpoints header to Apache VirtualHosts (CP4AIOPS-31150)
* Add HSTS to UI pod VirtualHost (CP4AIOPS-447)
* Remove duplicate HSTS from assets/packs Location blocks (CP4AIOPS-25657)