### PR TITLE
Drop redundant HSTS from OIDC Location blocks

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
@@ -286,8 +286,6 @@ OIDCCookieSameSite                 On
   AuthType                   openid-connect
   Require                    valid-user
   FileETag                   None
-  # Explicit HSTS for redundancy
-  Header always set Strict-Transport-Security "max-age=631138519"
   Header always setifempty Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri /dashboard/csp_report; report-to csp-endpoint"
   Header set Report-To       "{\"group\":\"csp-endpoint\",\"max_age\":10886400,\"endpoints\":[{\"url\":\"/dashboard/csp_report\"}]}"
   Header Set Cache-Control   "max-age=0, no-store, no-cache, must-revalidate"
@@ -299,8 +297,6 @@ OIDCCookieSameSite                 On
   AuthType                   openid-connect
   Require                    valid-user
   FileETag                   None
-  # Explicit HSTS for redundancy
-  Header always set Strict-Transport-Security "max-age=631138519"
   Header always setifempty Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri /dashboard/csp_report; report-to csp-endpoint"
   Header set Report-To       "{\"group\":\"csp-endpoint\",\"max_age\":10886400,\"endpoints\":[{\"url\":\"/dashboard/csp_report\"}]}"
   Header Set Cache-Control   "max-age=0, no-store, no-cache, must-revalidate"


### PR DESCRIPTION
HSTS is already set at the VirtualHost *:8080 level in httpdApplicationConf, which covers all URLs including /oidc_login and /ui/service/oidc_login. The Location-block copies were duplicating the header on OIDC responses.

Partial fix for CP4AIOPS-25657; prior related work: 504f7a7

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
