### PR TITLE
Fix Reporting-Endpoints hostname in httpd Go configs

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/application.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/application.go
@@ -32,7 +32,7 @@ func ApplicationUiHttpdConfigMap(cr *miqv1alpha1.ManageIQ, scheme *runtime.Schem
 			configMap.Data["ssl_config"] = appHttpdSslConfig()
 		}
 
-		configMap.Data["manageiq-http.conf"] = uiHttpdConfig(protocol)
+		configMap.Data["manageiq-http.conf"] = uiHttpdConfig(protocol, cr.Spec.ApplicationDomain)
 
 		return nil
 	}

--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
@@ -48,7 +48,7 @@ Options SymLinksIfOwnerMatch
   Header always unset X-Frame-Options
   Header always set X-Frame-Options "SAMEORIGIN"
   Header always unset Reporting-Endpoints
-  Header always set Reporting-Endpoints "csp-endpoint=\"https://%%{HTTP_HOST}i/dashboard/csp_report\""
+  Header always set Reporting-Endpoints "csp-endpoint=\"https://%[1]s/dashboard/csp_report\""
 
   # Send API requests to the API pods
   ProxyPass /api %[2]s://web-service:3000/api
@@ -424,7 +424,7 @@ RequestHeader set X_REMOTE_USER_PRINCIPAL       %%{REMOTE_USER_PRINCIPAL}e env=R
 	return fmt.Sprintf(s, delimiter)
 }
 
-func uiHttpdConfig(protocol string) string {
+func uiHttpdConfig(protocol string, applicationDomain string) string {
 	s := `
 ## ManageIQ HTTP Virtual Host Context
 
@@ -463,7 +463,7 @@ LimitRequestFieldSize 524288
   Header always unset X-Frame-Options
   Header always set X-Frame-Options "SAMEORIGIN"
   Header always unset Reporting-Endpoints
-  Header always set Reporting-Endpoints "csp-endpoint=\"https://%%{HTTP_HOST}i/dashboard/csp_report\""
+  Header always set Reporting-Endpoints "csp-endpoint=\"https://%[2]s/dashboard/csp_report\""
 
   RewriteCond %%{REQUEST_URI}     ^/ws/notifications [NC]
   RewriteCond %%{HTTP:UPGRADE}    ^websocket$ [NC]
@@ -510,7 +510,7 @@ LimitRequestFieldSize 524288
   </Location>
 </VirtualHost>
 `
-	return fmt.Sprintf(s, protocol)
+	return fmt.Sprintf(s, protocol, applicationDomain)
 }
 
 func apiHttpdConfig(protocol string) string {


### PR DESCRIPTION
`%{HTTP_HOST}e` (ff1146a, CP4AIOPS-31150) and `%{HTTP_HOST}i` (0a4284a) both fail in Apache 2.4.63 on RHEL -- neither env-var nor incoming-header mod_headers specifiers are populated at `VirtualHost Header always set` level in this build. Tested in a running httpd pod: both produce (null).

Replace with Go fmt.Sprintf substitution so the hostname is baked into the generated Apache config string before Apache ever parses it:

  Before (broken at Apache runtime):
```
    Header always set Reporting-Endpoints "csp-endpoint=\"https://%%{HTTP_HOST}i/dashboard/csp_report\""
```
  After (hostname substituted at operator render time):
```
    Header always set Reporting-Endpoints "csp-endpoint=\"https://my.actual.host/dashboard/csp_report\""
```
This is the same approach already used for ServerName and OIDCRedirectURI in these same config strings -- the operator renders a static config with the real value; no Apache runtime substitution is needed or attempted.

- httpdApplicationConf: use %[1]s (applicationDomain, already arg 1)
- uiHttpdConfig: add applicationDomain parameter, use %[2]s; update caller in ApplicationUiHttpdConfigMap to pass cr.Spec.ApplicationDomain

Fixes CP4AIOPS-31150; prior related work: ff1146a, 0a4284a

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
