### PR TITLE
When running Ingress, need https

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd.go
@@ -115,6 +115,11 @@ func Ingress(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*networkingv1.In
 		if err := controllerutil.SetControllerReference(cr, ingress, scheme); err != nil {
 			return err
 		}
+		if ingress.Annotations == nil {
+			ingress.Annotations = map[string]string{}
+		}
+		ingress.Annotations["nginx.ingress.kubernetes.io/ssl-redirect"] = "true"
+		ingress.Annotations["nginx.ingress.kubernetes.io/use-forwarded-headers"] = "true"
 		if len(ingress.Spec.TLS) == 0 {
 			ingress.Spec.TLS = append(ingress.Spec.TLS, networkingv1.IngressTLS{})
 		}

--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
@@ -39,6 +39,7 @@ Options SymLinksIfOwnerMatch
   ProxyPreserveHost on
   RequestHeader set Host %[1]s
   RequestHeader set X-Forwarded-Host %[1]s
+  RequestHeader set X_FORWARDED_PROTO 'https'
   Header always unset Strict-Transport-Security
   Header always set Strict-Transport-Security "max-age=631138519"
   Header always unset X-Content-Type-Options

--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd_conf.go
@@ -39,7 +39,7 @@ Options SymLinksIfOwnerMatch
   ProxyPreserveHost on
   RequestHeader set Host %[1]s
   RequestHeader set X-Forwarded-Host %[1]s
-  RequestHeader set X_FORWARDED_PROTO 'https'
+  RequestHeader set X-Forwarded-Proto 'https'
   Header always unset Strict-Transport-Security
   Header always set Strict-Transport-Security "max-age=631138519"
   Header always unset X-Content-Type-Options
@@ -606,7 +606,7 @@ func httpdSslConfig() string {
 SSLEngine on
 SSLCertificateFile "/root/server.crt"
 SSLCertificateKeyFile "/root/server.key"
-RequestHeader set X_FORWARDED_PROTO 'https'
+RequestHeader set X-Forwarded-Proto 'https'
 `
 }
 
@@ -615,7 +615,7 @@ func appHttpdSslConfig() string {
 SSLEngine on
 SSLCertificateFile "/etc/pki/tls/certs/server.crt"
 SSLCertificateKeyFile "/etc/pki/tls/private/server.key"
-RequestHeader set X_FORWARDED_PROTO 'https'
+RequestHeader set X-Forwarded-Proto 'https'
 `
 }
 


### PR DESCRIPTION
Root cause:
On k3s (non-OpenShift), the Ingress terminates TLS via the ingress controller, then forwards traffic as plain HTTP to 
the httpd service on port 8080. This is architecturally correct — but the httpd application.conf never sets RequestHeader 
set X_FORWARDED_PROTO 'https' unless the optional ssl_config snippet is loaded (which requires internal certificates). 
Without this header, ManageIQ's application layer sees HTTP, not HTTPS.

Additionally, the Ingress is missing the standard annotation to tell the ingress controller to redirect HTTP->HTTPS and forward the correct 
protocol header. Without nginx.ingress.kubernetes.io/force-ssl-redirect or equivalent Traefik annotations, visiting the plain 
HTTP URL won't redirect to HTTPS.

The fix:
Two files changed, two targeted additions:
httpd_conf.go — RequestHeader set X_FORWARDED_PROTO 'https' added unconditionally to application.conf so ManageIQ always knows the client came in 
               over HTTPS, regardless of environment. Safe on OpenShift because when internal certs exist the ssl_config include sets the exact 
               same value again.
httpd.go — Two nginx annotations added to the Ingress() function:
   ssl-redirect: "true" -> forces HTTP -> HTTPS redirect at the nginx level
   use-forwarded-headers: "true" ->  nginx passes X-Forwarded-Proto to the httpd backend
This function is never called on OpenShift (the controller deletes the Ingress there), so there is zero risk of affecting OpenShift.

