### PR TITLE
Add Ingress annotations for HTTPS backend protocol

### DIFF
--- a/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd.go
+++ b/manageiq-operator/api/v1alpha1/helpers/miq-components/httpd.go
@@ -118,6 +118,7 @@ func Ingress(cr *miqv1alpha1.ManageIQ, scheme *runtime.Scheme) (*networkingv1.In
 		if ingress.Annotations == nil {
 			ingress.Annotations = map[string]string{}
 		}
+		ingress.Annotations["nginx.ingress.kubernetes.io/backend-protocol"] = "HTTPS"
 		ingress.Annotations["nginx.ingress.kubernetes.io/ssl-redirect"] = "true"
 		ingress.Annotations["nginx.ingress.kubernetes.io/use-forwarded-headers"] = "true"
 		if len(ingress.Spec.TLS) == 0 {


### PR DESCRIPTION
Without the annotations, Ingress will use HTTP for backend while we needs HTTPS. 