### PR TITLE
Clean up unreferenced ostree objects (Experiment)

### DIFF
--- a/images/manageiq-appliance/Containerfile
+++ b/images/manageiq-appliance/Containerfile
@@ -54,6 +54,7 @@ RUN firewall-offline-cmd --new-zone=manageiq && \
     mkdir -p -m 700 ~/.ssh && \
     su manageiq -c "mkdir -m 700 ~/.ssh"
 
+RUN ostree prune --repo=/sysroot/ostree/repo --refs-only
 
 # Each provider-specific image...
 # FROM docker.io/manageiq/manageiq-appliance-base:latest


### PR DESCRIPTION
These likely came from original installation of packages, but if they have been updated since then we can remove the reference to the objects in the final image and scanners should find fewer vulnerabilities.
